### PR TITLE
🧬feat(connectivity): add snapshot mechanism for datatype subscription

### DIFF
--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -39,7 +39,7 @@ impl LocalConnectivity {
         let local_datatype_server = datatypes
             .get(resource_id)
             .cloned()
-            .ok_or(ConnectivityError::ResourceNotFound)?;
+            .ok_or(ConnectivityError::ResourceNotFound(resource_id.to_string()))?;
         Ok(local_datatype_server)
     }
 

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -134,4 +134,11 @@ impl MutableDatatype {
         }
         result
     }
+
+    pub fn new_snapshot_operation(&self) -> Operation {
+        let data = self.crdt.serialize();
+        let mut snap_op = Operation::new_snapshot(data);
+        snap_op.lamport = self.op_id.lamport;
+        snap_op
+    }
 }

--- a/src/errors/connectivity.rs
+++ b/src/errors/connectivity.rs
@@ -2,6 +2,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ConnectivityError {
-    #[error("[ConnectivityError] the demanded resource is not found")]
-    ResourceNotFound,
+    #[error("[ConnectivityError] the demanded resource is not found: {_0}")]
+    ResourceNotFound(String),
 }

--- a/src/operations/body.rs
+++ b/src/operations/body.rs
@@ -11,6 +11,8 @@ pub enum OperationBody {
     Delay4Test(Delay4TestBody),
     #[display("CounterIncrease{_0}")]
     CounterIncrease(CounterIncreaseBody),
+    #[display("Snapshot{_0}")]
+    Snapshot(SnapshotBody),
 }
 
 impl Debug for OperationBody {
@@ -25,6 +27,7 @@ impl MemoryMeasurable for OperationBody {
             #[cfg(test)]
             OperationBody::Delay4Test(body) => body.size(),
             OperationBody::CounterIncrease(body) => body.size(),
+            OperationBody::Snapshot(body) => body.size(),
         }
     }
 }
@@ -75,6 +78,24 @@ impl CounterIncreaseBody {
 impl MemoryMeasurable for CounterIncreaseBody {
     fn size(&self) -> u64 {
         size_of::<i64>() as u64
+    }
+}
+
+#[derive(Debug, Clone, Display, PartialEq, Eq)]
+#[display("(size:{})", data.len())]
+pub struct SnapshotBody {
+    pub data: Box<[u8]>,
+}
+
+impl SnapshotBody {
+    pub fn new(data: Box<[u8]>) -> Self {
+        Self { data }
+    }
+}
+
+impl MemoryMeasurable for SnapshotBody {
+    fn size(&self) -> u64 {
+        self.data.len() as u64
     }
 }
 

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -7,7 +7,7 @@ use chrono::Local;
 
 #[cfg(test)]
 use crate::operations::body::Delay4TestBody;
-use crate::operations::body::{CounterIncreaseBody, OperationBody};
+use crate::operations::body::{CounterIncreaseBody, OperationBody, SnapshotBody};
 
 pub mod body;
 pub mod transaction;
@@ -36,6 +36,11 @@ impl Operation {
         Self::new(OperationBody::CounterIncrease(CounterIncreaseBody::new(
             delta,
         )))
+    }
+
+    pub fn new_snapshot(body: Box<[u8]>) -> Self {
+        let op_body = SnapshotBody::new(body);
+        Self::new(OperationBody::Snapshot(op_body))
     }
 
     #[cfg(test)]
@@ -88,6 +93,12 @@ mod tests_operations {
         info!("{op} vs. {op:?}");
         let s = op.to_string();
         assert_eq!(s, format!("{op:?}"));
+
+        let hello = String::from("hello");
+        let hello_bytes: Box<[u8]> = hello.into_bytes().into_boxed_slice();
+        let snap_op = Operation::new_snapshot(hello_bytes);
+        assert_eq!(format!("{snap_op}"), format!("{snap_op:?}"));
+        info!("{snap_op} vs. {snap_op:?}");
     }
 
     #[test]


### PR DESCRIPTION
- close #7 
Implement snapshot-based state synchronization for subscribing clients. When a client subscribes to an existing datatype, the creator's current CRDT state is captured as a snapshot and delivered to the subscriber.

Changes:
- Add SnapshotBody operation type and serialization support
- Track creator CUID in LocalDatatypeServer for snapshot generation
- Add get_subscribe_snapshot() method to WiredDatatype
- Validate that subscribers cannot push transactions during subscription
- Improve ConnectivityError with resource identification
- Optimize write lock scope in WiredDatatype.push_pull()
- Add test case for DueToSubscribe state handling

Note: PullHandler.execute_transactions() implementation is pending to complete the snapshot application on subscriber side.