### PR TITLE
🧬feat(datatypes): make sync() return Result and improve error handling

### DIFF
--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -134,6 +134,11 @@ impl Client {
     pub fn subscribe_or_create_datatype(&self, key: impl IntoString) -> DatatypeBuilder<'_> {
         DatatypeBuilder::new(self, key.into(), DatatypeState::DueToSubscribeOrCreate)
     }
+
+    #[cfg(test)]
+    pub fn get_cuid(&self) -> crate::types::uid::Cuid {
+        self.common.cuid.clone()
+    }
 }
 
 #[cfg(test)]

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -86,7 +86,8 @@ impl LocalDatatypeServer {
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
         let mut pulled = pushed.get_pulled_stub();
-        // 이미 생성 되었다면 에러가 발생해야 하지만, 같은 DUID인 경우는 중복 전송 케이스로 간주하여 허용한다.
+        // If already created, an error should occur,
+        // but if the DUID is the same, it is considered a duplicate transmission case and is allowed.
         if self.created && self.duid != pushed.duid {
             pulled.error = Some(ServerPushPullError::FailedToCreate(
                 "already exist".to_string(),
@@ -155,6 +156,11 @@ impl LocalDatatypeServer {
     }
 
     pub fn pull_transactions(&self) {}
+
+    #[cfg(test)]
+    pub fn get_wired_datatype(&self, cuid: &Cuid) -> Option<Arc<WiredDatatype>> {
+        self.wired_map.get(cuid).cloned()
+    }
 }
 
 #[cfg(test)]

--- a/src/datatypes/common.rs
+++ b/src/datatypes/common.rs
@@ -97,7 +97,6 @@ impl Attribute {
         r#type: DataType,
         connectivity: Arc<dyn crate::connectivity::Connectivity>,
     ) -> Arc<Self> {
-
         let key = paths.pop_back().unwrap_or(format!("{type}")).into();
         let client_alias = paths.pop_back().unwrap_or("client".into()).into();
         let collection = paths.pop_back().unwrap_or("collection".to_owned()).into();
@@ -172,7 +171,7 @@ mod tests_attribute {
 
     use tracing::info;
 
-    use crate::{types::uid::Duid, utils::path::caller_path, DataType};
+    use crate::{DataType, types::uid::Duid, utils::path::caller_path};
 
     #[test]
     fn can_new_attribute_for_test() {

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -106,8 +106,8 @@ impl Datatype for TransactionalDatatype {
         self.mutable.read().op_id.cseq
     }
 
-    fn sync(&self) {
-        self.event_loop.send_push_transaction_with_guarantee();
+    fn sync(&self) -> Result<(), DatatypeError> {
+        self.event_loop.send_push_transaction_with_guarantee()
     }
 }
 

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -48,6 +48,11 @@ impl WiredDatatype {
         })
     }
 
+    #[cfg(test)]
+    pub fn get_wired_interceptor(&self) -> Arc<WiredInterceptor> {
+        self.interceptor.clone()
+    }
+
     pub fn push_if_needed(&self) {
         if !self.attr.client_common.connectivity.is_realtime() || !self.mutable.read().need_push() {
             return;

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::errors::{BoxedError, connectivity::ConnectivityError};
+use crate::errors::{BoxedError, push_pull::ClientPushPullError};
 
 /// Errors that can occur while working with Qortoo datatypes.
 ///
@@ -39,11 +39,11 @@ pub enum DatatypeError {
     #[error("[DatatypeError] failed to execute operation: {0}")]
     FailedToExecuteOperation(String) = 204,
     #[error("[DatatypeError] failure in EventLoop")]
-    FailureInEventLoop(BoxedError) = 205,
+    FailedInEventLoop(BoxedError) = 205,
     #[error("[DatatypeError] not allowed to write")]
     FailedToWrite(String) = 206,
-    #[error("[DatatypeError] failed to push and pull: {0}")]
-    FailedToPushPull(ConnectivityError) = 207,
+    #[error("[DatatypeError] failed to sync: {0}")]
+    FailedToSync(ClientPushPullError) = 207,
 }
 
 impl PartialEq for DatatypeError {

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -91,7 +91,7 @@ mod tests_datatype_errors {
     }
 
     fn into_next_stack() {
-        let err = Box::new(TrySendError::Full(Event::PushTransaction));
-        let _d3 = with_err_out!(DatatypeError::FailureInEventLoop(err));
+        let err = Box::new(TrySendError::Full(Event::PushTransaction(None)));
+        let _d3 = with_err_out!(DatatypeError::FailedInEventLoop(err));
     }
 }


### PR DESCRIPTION
- close #17 

BREAKING CHANGE: Datatype::sync() now returns Result<(), DatatypeError>

Changes:
- Change sync() signature from `fn sync(&self)` to `fn sync(&self) -> Result<(), DatatypeError>`
- Add response channel to Event::PushTransaction for error propagation
- Improve send_push_transaction_with_guarantee() to properly handle errors
- Rename error variants for consistency:
  - FailureInEventLoop -> FailedInEventLoop
  - FailedToPushPull -> FailedToSync
- Move connectivity.register() before spawning event loop to ensure proper initialization
- Add test helper methods for better testability
- Add comprehensive test case for sync() error handling

Impact:
- Users must now handle Result from sync() calls
- Provides better error propagation from event loop to caller
- Fixes silent error swallowing in synchronization path