### PR TITLE
🧬feat(client): add collection name and datatype key validation

### DIFF
--- a/.github/ISSUE_TEMPLATE/📜-doc-request.md
+++ b/.github/ISSUE_TEMPLATE/📜-doc-request.md
@@ -29,13 +29,6 @@ assignees: ''
 
 <!-- If you have ideas about what should be included, list them here -->
 
--
--
-
-### 📎 Additional context
-
-<!-- Add any other context, examples, or references -->
-
 ### ✅ Checklist
 
 - [ ] I have searched existing documentation to avoid duplicates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1004,6 +1004,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
+ "regex",
  "rstest",
  "strum_macros",
  "thiserror",
@@ -1100,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1112,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1231,18 +1232,28 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1399,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
  "itoa",
@@ -1409,22 +1420,22 @@ dependencies = [
  "num-conv",
  "num_threads",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1640,16 +1651,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
  "opentelemetry",
- "opentelemetry_sdk",
- "rustversion",
  "smallvec",
- "thiserror",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,22 +35,23 @@ tracing = "^0.1.44"
 nanoid = "^0.4.0"
 tokio = { version = "^1.49.0", features = ["full"] }
 parking_lot = "^0.12.5"
-time = { version = "^0.3.44", features = [
+time = { version = "^0.3.45", features = [
     "formatting",
     "local-offset",
     "macros",
 ] }
 itoa = "^1.0.17"
 derive_more = { version = "^2.1.1", features = ["display", "debug"] }
-chrono = "^0.4.42"
+chrono = "^0.4.43"
 thiserror = "^2.0.17"
 opentelemetry = { version = "^0.31.0" }
-tracing-opentelemetry = { version = "^0.32.0" }
+tracing-opentelemetry = { version = "^0.32.1" }
 ubyte = "^0.10.4"
 crossbeam-channel = "^0.5.15"
 futures = "^0.3.28"
 btparse = "^0.2.0"
 strum_macros = "^0.27.2"
+regex = "^1.12.2"
 
 [dev-dependencies]
 rstest = "^0.26.1"

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -112,7 +112,7 @@ mod tests_local_connectivity {
 
     use crate::{
         Client, Datatype, DatatypeState, connectivity::local_connectivity::LocalConnectivity,
-        utils::path::get_test_func_name,
+        utils::path::get_test_collection_name,
     };
 
     #[test]
@@ -120,18 +120,20 @@ mod tests_local_connectivity {
     fn can_compare_manual_and_realtime_local_connectivity() {
         let lc_manual = LocalConnectivity::new_arc();
         lc_manual.set_realtime(false);
-        let client_manual = Client::builder(get_test_func_name!(), "local_connectivity_test")
+        let client_manual = Client::builder(get_test_collection_name!(), "manual client")
             .with_connectivity(lc_manual)
-            .build();
+            .build()
+            .unwrap();
         let counter_manual = client_manual
             .create_datatype("manual")
             .build_counter()
             .unwrap();
 
         let lc_realtime = LocalConnectivity::new_arc();
-        let client_realtime = Client::builder(get_test_func_name!(), "local_connectivity_test")
+        let client_realtime = Client::builder(get_test_collection_name!(), "realtime client")
             .with_connectivity(lc_realtime)
-            .build();
+            .build()
+            .unwrap();
         let counter_realtime = client_realtime
             .create_datatype("realtime")
             .build_counter()

--- a/src/datatypes/counter.rs
+++ b/src/datatypes/counter.rs
@@ -45,7 +45,7 @@ impl Counter {
     ///
     /// ```
     /// # use qortoo::{Client, Counter, DatatypeState};
-    /// let client = Client::builder("doc-example", "increase_by-test").build();
+    /// let client = Client::builder("doc-example", "increase_by-test").build().unwrap();
     /// let counter = client.create_datatype("test-counter").build_counter().unwrap();
     /// assert_eq!(counter.increase_by(5).unwrap(), 5);
     /// assert_eq!(counter.increase_by(-2).unwrap(), 3);
@@ -74,7 +74,7 @@ impl Counter {
     ///
     /// ```
     /// # use qortoo::{Client, Counter, DatatypeState};
-    /// let client = Client::builder("doc-example", "increase-test").build();
+    /// let client = Client::builder("doc-example", "increase-test").build().unwrap();
     /// let counter = client.create_datatype("test-counter").build_counter().unwrap();
     /// assert_eq!(counter.increase().unwrap(), 1);
     /// assert_eq!(counter.increase().unwrap(), 2);
@@ -93,7 +93,7 @@ impl Counter {
     ///
     /// ```
     /// # use qortoo::{Client, Counter, DatatypeState};
-    /// let client = Client::builder("doc-example", "get_value-test").build();
+    /// let client = Client::builder("doc-example", "get_value-test").build().unwrap();
     /// let counter = client.create_datatype("test-counter").build_counter().unwrap();
     /// assert_eq!(counter.get_value(), 0);
     /// counter.increase();
@@ -124,7 +124,7 @@ impl Counter {
     ///
     /// ```
     /// # use qortoo::{Client, Counter, DatatypeState};
-    /// let client = Client::builder("doc-example", "transaction-test").build();
+    /// let client = Client::builder("doc-example", "transaction-test").build().unwrap();
     /// let counter = client.create_datatype("test-counter").build_counter().unwrap();
     ///
     /// // Successful transaction

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -16,7 +16,7 @@ use crate::{
 /// use qortoo::Client;
 /// use qortoo::{Counter, Datatype};
 /// use qortoo::{DatatypeState, DataType};
-/// let client = Client::builder("doc-example", "Datatype-trait").build();
+/// let client = Client::builder("doc-example", "Datatype-trait").build().unwrap();
 /// let counter = client.create_datatype("test-counter".to_string()).build_counter().unwrap();
 /// assert_eq!(counter.get_key(), "test-counter");
 /// assert_eq!(counter.get_type(), DataType::Counter);
@@ -83,7 +83,7 @@ mod tests_datatype_trait {
             common::new_attribute, datatype::Datatype, transactional::TransactionalDatatype,
         },
         errors::push_pull::ClientPushPullError,
-        utils::path::get_test_func_name,
+        utils::path::{get_test_collection_name, get_test_func_name},
     };
 
     #[test]
@@ -105,10 +105,11 @@ mod tests_datatype_trait {
     fn can_use_sync_method() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
-        let resource_id = format!("{}/{}", module_path!(), get_test_func_name!());
-        let client1 = Client::builder(module_path!(), module_path!())
+        let resource_id = format!("{}/{}", get_test_collection_name!(), get_test_func_name!());
+        let client1 = Client::builder(get_test_collection_name!(), get_test_collection_name!())
             .with_connectivity(connectivity.clone())
-            .build();
+            .build()
+            .unwrap();
         let counter1 = client1
             .create_datatype(get_test_func_name!())
             .build_counter()

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -138,12 +138,17 @@ mod tests_push_handlers {
 
     use tracing::{info, instrument};
 
-    use crate::{Client, Datatype, DatatypeState, utils::path::get_test_func_name};
+    use crate::{
+        Client, Datatype, DatatypeState,
+        utils::path::{get_test_collection_name, get_test_func_name},
+    };
 
     #[test]
     #[instrument]
     fn can_check_versions() {
-        let client = Client::builder(module_path!(), get_test_func_name!()).build();
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .build()
+            .unwrap();
         let counter = client
             .create_datatype(get_test_func_name!())
             .build_counter()

--- a/src/errors/clients.rs
+++ b/src/errors/clients.rs
@@ -6,9 +6,17 @@ use thiserror::Error;
 /// Two `ClientError` values are considered equal if they are the **same variant**,
 /// regardless of their message payload. See the custom `PartialEq` implementation.
 ///
+#[non_exhaustive]
 #[repr(i32)]
 #[derive(Debug, Error)]
 pub enum ClientError {
+    /// Invalid collection name provided.
+    ///
+    /// Returned when attempting to create a client with a collection name
+    /// that does not meet validation requirements.
+    #[error("[ClientError] invalid collection name: {0}")]
+    InvalidCollectionName(String) = 100,
+
     /// Subscribe or Create Datatype failed.
     ///
     /// Returned when a request to subscribe or create a datatype is
@@ -23,3 +31,7 @@ impl PartialEq for ClientError {
         std::mem::discriminant(self) == std::mem::discriminant(other)
     }
 }
+
+pub(crate) const CLIENT_ERROR_MSG_COLLECTION_NAME: &str = "invalid collection name. Collection name must be 1-47 characters, start with a letter or underscore, contain only alphanumeric characters and '.', '_', '~', '-', and must not start with 'system.' or contain '.system.'.";
+
+pub(crate) const CLIENT_ERROR_MSG_DATATYPE_KEY: &str = "invalid datatype key. Key must not be empty, must not contain null characters (\\0), must not exceed 255 bytes in length, and must not start with '$'.";

--- a/src/errors/connectivity.rs
+++ b/src/errors/connectivity.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+#[non_exhaustive]
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ConnectivityError {
     #[error("[ConnectivityError] the demanded resource is not found: {_0}")]

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -12,6 +12,7 @@ use crate::errors::{BoxedError, push_pull::ClientPushPullError};
 /// Two `DatatypeError` values are considered equal if they are the **same variant**,
 /// regardless of their message payload. See the custom `PartialEq` implementation.
 ///
+#[non_exhaustive]
 #[repr(i32)]
 #[derive(Debug, Error)]
 pub enum DatatypeError {

--- a/src/errors/push_pull.rs
+++ b/src/errors/push_pull.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 
 use crate::ConnectivityError;
 
+#[non_exhaustive]
 #[repr(i32)]
 #[derive(Debug, Error, Eq)]
 pub enum ServerPushPullError {
@@ -29,6 +30,7 @@ pub enum CaseAfterPushPullError {
     Abort,
 }
 
+#[non_exhaustive]
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ClientPushPullError {
     #[error("[ClientPushPullError] pushBuffer exceeded max size of memory")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! use qortoo::Client;
 //!
 //! // Create a client
-//! let client = Client::builder("my-collection", "my-client").build();
+//! let client = Client::builder("my-collection", "my-client").build().unwrap();
 //!
 //! // Create and use a counter
 //! let counter = client

--- a/src/types/datatype.rs
+++ b/src/types/datatype.rs
@@ -10,7 +10,7 @@ use derive_more::Display;
 /// ```
 /// use qortoo::{Client, DataType, Datatype};
 ///
-/// let client = Client::builder("doc-example", "datatype-test").build();
+/// let client = Client::builder("doc-example", "datatype-test").build().unwrap();
 /// let counter = client.create_datatype("my-counter").build_counter().unwrap();
 /// assert_eq!(counter.get_type(), DataType::Counter);
 /// ```
@@ -44,7 +44,7 @@ pub enum DataType {
 /// ```
 /// use qortoo::{Client, DatatypeState, Datatype};
 ///
-/// let client = Client::builder("doc-example", "state-test").build();
+/// let client = Client::builder("doc-example", "state-test").build().unwrap();
 ///
 /// // DueToCreate state allows writing
 /// let counter1 = client.create_datatype("c1").build_counter().unwrap();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod defer_guard;
+pub mod name_validator;
 pub mod no_guard_mutex;
 pub mod path;
 pub mod runtime;

--- a/src/utils/name_validator.rs
+++ b/src/utils/name_validator.rs
@@ -1,0 +1,81 @@
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+static COLLECTION_NAME_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-zA-Z_][a-zA-Z0-9._~-]*$").unwrap());
+
+pub fn is_valid_collection_name(name: &str) -> bool {
+    // Check length: 1-47 characters
+    if name.is_empty() || name.len() > 47 {
+        return false;
+    }
+
+    // Check pattern: must start with underscore or letter, followed by alphanumeric, '.', '_', '~', '-'
+    if !COLLECTION_NAME_PATTERN.is_match(name) {
+        return false;
+    }
+
+    // Check forbidden patterns: cannot start with "system." or contain ".system."
+    if name.starts_with("system.") || name.contains(".system.") {
+        return false;
+    }
+
+    true
+}
+
+pub fn is_valid_datatype_key(key: &str) -> bool {
+    if key.is_empty() || key.contains('\0') || key.len() > 255 || key.starts_with('$') {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests_name_validator {
+    use rstest::rstest;
+
+    use crate::utils::name_validator::{is_valid_collection_name, is_valid_datatype_key};
+
+    #[rstest]
+    #[case::allowed_name1("hello_world", true)]
+    #[case::allowed_name2("a", true)]
+    #[case::allowed_name3("my-collection", true)]
+    #[case::allowed_name4("my.collection", true)]
+    #[case::allowed_name5("my~collection", true)]
+    #[case::allowed_name6("_private", true)]
+    #[case::allowed_name7("Collection123", true)]
+    #[case::allowed_name8("a-b.c~d_e", true)]
+    #[case::allowed_name9(&"a".repeat(47), true)]
+    #[case::disallowed_empty("", false)]
+    #[case::disallowed_too_long(&"a".repeat(48), false)]
+    #[case::disallowed_start_digit("1hello", false)]
+    #[case::disallowed_start_dash("-hello", false)]
+    #[case::disallowed_start_dot(".hello", false)]
+    #[case::disallowed_system_prefix("system.hello", false)]
+    #[case::disallowed_system_infix("my.system.hello", false)]
+    #[case::disallowed_special_char("hello@world", false)]
+    #[case::disallowed_space("hello world", false)]
+    #[case::allowed_system_suffix("hello.system", true)]
+    #[case::allowed_system_word("system", true)]
+    #[case::allowed_system_no_dot("system123", true)]
+    fn can_valid_collection_names(#[case] name: &str, #[case] expected: bool) {
+        assert_eq!(expected, is_valid_collection_name(name));
+    }
+
+    #[rstest]
+    #[case::allow_key1("hello_world", true)]
+    #[case::allow_key2("simple", true)]
+    #[case::allow_key3("user:123:profile", true)]
+    #[case::allow_key4("a", true)]
+    #[case::allow_key5("with-dash-and.dot", true)]
+    #[case::allow_key6("한글키", true)]
+    #[case::allow_key7(&"a".repeat(255), true)]
+    #[case::disallow_empty("", false)]
+    #[case::disallow_null("hello\0world", false)]
+    #[case::disallow_dollar("$hello", false)]
+    #[case::disallow_too_long(&"a".repeat(256), false)]
+    fn can_valid_datatype_key(#[case] key: &str, #[case] expected: bool) {
+        assert_eq!(expected, is_valid_datatype_key(key))
+    }
+}

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -30,7 +30,29 @@ macro_rules! get_test_func_name {
 }
 
 #[cfg(test)]
+macro_rules! get_test_collection_name {
+    () => {{
+        let thread_name = std::thread::current()
+            .name()
+            .unwrap_or("unknown")
+            .to_string();
+        let parts: Vec<&str> = thread_name.split("::").collect();
+        let mut collection_name = if parts.len() > 1 {
+            parts[..parts.len() - 1].join("-")
+        } else {
+            "unknown".to_owned()
+        };
+        if collection_name.len() > 47 {
+            collection_name.truncate(47);
+        }
+        collection_name
+    }};
+}
+
+#[cfg(test)]
 pub(crate) use caller_path;
+#[cfg(test)]
+pub(crate) use get_test_collection_name;
 #[cfg(test)]
 pub(crate) use get_test_func_name;
 
@@ -42,12 +64,10 @@ mod tests_path {
 
     #[test]
     fn can_use_path_macros() {
-        let path_parts = split_module_path(module_path!());
-        assert_eq!(path_parts, vec!["qortoo", "utils", "path", "tests_path"]);
-        let caller = caller_path!();
-        info!("{caller:?}");
-        let func_name = get_test_func_name!();
-        info!("func_name: {func_name}");
-        assert_eq!(func_name, "can_use_path_macros");
+        let collection_name = get_test_collection_name!();
+        let document_key = get_test_func_name!();
+        info!("{collection_name} AND {document_key}");
+        assert_eq!(collection_name, "utils-path-tests_path");
+        assert_eq!(document_key, "can_use_path_macros")
     }
 }

--- a/tests/datatype_builder.rs
+++ b/tests/datatype_builder.rs
@@ -5,7 +5,9 @@ mod tests_datatype_builder {
     #[test]
     #[instrument]
     fn can_build_counter() {
-        let client = Client::builder(module_path!(), "can_build_counter").build();
+        let client = Client::builder("test-collection", "can_build_counter")
+            .build()
+            .unwrap();
         let counter = client
             .create_datatype("counter-1")
             .with_max_memory_size_of_push_buffer(10_000_000)


### PR DESCRIPTION
- close #12 
- Add name_validator module with is_valid_collection_name() and is_valid_datatype_key()
- Collection names: 1-47 chars, alphanumeric with ._~-, no system. prefix
- Datatype keys: non-empty, no null chars, max 255 bytes, no $ prefix
- Add #[non_exhaustive] to all error enums for future extensibility
- Update dependencies: regex 1.12.2, chrono 0.4.43, serde 1.0.228

BREAKING CHANGE: ClientBuilder::build() now returns Result<Client, ClientError>