### PR TITLE
🧬feat(datatypes): implement snapshot-based subscription and enhance validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dtor"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +225,15 @@ name = "dtor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
+name = "dyn-fmt"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c992f591dfce792a9bc2d1880ab67ffd4acc04551f8e551ca3b6233efb322f00"
+dependencies = [
+ "document-features",
+]
 
 [[package]]
 name = "either"
@@ -697,6 +715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1019,7 @@ dependencies = [
  "crossbeam-channel",
  "ctor",
  "derive_more",
+ "dyn-fmt",
  "futures",
  "itoa",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ futures = "^0.3.28"
 btparse = "^0.2.0"
 strum_macros = "^0.27.2"
 regex = "^1.12.2"
+dyn-fmt = "^0.4.3"
 
 [dev-dependencies]
 rstest = "^0.26.1"

--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use dyn_fmt::AsStrFormatExt;
 use parking_lot::RwLock;
 
 use crate::{
@@ -38,10 +39,9 @@ impl ClientBuilder {
     /// Returns [`ClientError::InvalidCollectionName`] if the collection name is invalid.
     pub fn build(self) -> Result<Client, ClientError> {
         if !is_valid_collection_name(&self.collection) {
-            return Err(ClientError::InvalidCollectionName(format!(
-                "'{}' - {}",
-                self.collection, CLIENT_ERROR_MSG_COLLECTION_NAME,
-            )));
+            return Err(ClientError::InvalidCollectionName(
+                CLIENT_ERROR_MSG_COLLECTION_NAME.format(&[self.collection]),
+            ));
         }
 
         let common =

--- a/src/datatypes/builder.rs
+++ b/src/datatypes/builder.rs
@@ -1,3 +1,5 @@
+use dyn_fmt::AsStrFormatExt;
+
 use crate::{
     Client, ClientError, Counter, DataType, DatatypeState,
     datatypes::{datatype_set::DatatypeSet, option::DatatypeOption},
@@ -81,10 +83,9 @@ impl<'c> DatatypeBuilder<'c> {
     pub fn build_counter(self) -> Result<Counter, ClientError> {
         if !is_valid_datatype_key(&self.key) {
             return Err(with_err_out!(
-                ClientError::FailedToSubscribeOrCreateDatatype(format!(
-                    "'{}' - {}",
-                    self.key, CLIENT_ERROR_MSG_DATATYPE_KEY
-                ),)
+                ClientError::FailedToSubscribeOrCreateDatatype(
+                    CLIENT_ERROR_MSG_DATATYPE_KEY.format(&[self.key])
+                )
             ));
         }
         let ds = self.client.do_subscribe_or_create_datatype(

--- a/src/datatypes/common.rs
+++ b/src/datatypes/common.rs
@@ -3,8 +3,11 @@ use std::{
     sync::Arc,
 };
 
+use parking_lot::RwLock;
+
 use crate::{
     DataType,
+    clients::common::ClientCommon,
     datatypes::option::DatatypeOption,
     types::{
         common::{ArcStr, ResourceID},
@@ -120,7 +123,7 @@ impl Attribute {
         )
     }
 
-    pub fn cuid(&self) -> Cuid {
+    pub fn get_cuid(&self) -> Cuid {
         self.client_common.cuid.clone()
     }
 
@@ -142,24 +145,7 @@ macro_rules! new_attribute {
 }
 
 #[cfg(test)]
-macro_rules! new_attribute_with_connectivity {
-    ($enum_variant:path, $connectivity:expr) => {{
-        let paths = crate::utils::path::caller_path!();
-        crate::datatypes::common::Attribute::new_for_test_with_connectivity(
-            paths,
-            $enum_variant,
-            $connectivity,
-        )
-    }};
-}
-
-#[cfg(test)]
 pub(crate) use new_attribute;
-#[cfg(test)]
-pub(crate) use new_attribute_with_connectivity;
-use parking_lot::RwLock;
-
-use crate::clients::common::ClientCommon;
 
 pub enum ReturnType {
     None,

--- a/src/datatypes/crdts/counter_crdt.rs
+++ b/src/datatypes/crdts/counter_crdt.rs
@@ -1,10 +1,12 @@
+use derive_more::Display;
+
 use crate::{
     DatatypeError,
     datatypes::common::ReturnType,
     operations::{Operation, body::OperationBody},
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, Display)]
 pub struct CounterCrdt {
     value: i64,
 }

--- a/src/datatypes/crdts/mod.rs
+++ b/src/datatypes/crdts/mod.rs
@@ -1,3 +1,5 @@
+use derive_more::Display;
+
 #[cfg(test)]
 use crate::operations::body::OperationBody;
 use crate::{
@@ -9,7 +11,7 @@ use crate::{
 
 pub mod counter_crdt;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Display)]
 pub enum Crdt {
     Counter(CounterCrdt),
 }

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -33,6 +33,8 @@ pub trait Datatype {
     fn get_client_version(&self) -> u64;
     fn get_synced_client_version(&self) -> u64;
     fn sync(&self) -> Result<(), DatatypeError>;
+    #[cfg(test)]
+    fn get_attr(&self) -> std::sync::Arc<crate::datatypes::common::Attribute>;
 }
 
 pub trait DatatypeBlanket {
@@ -69,6 +71,11 @@ where
 
     fn sync(&self) -> Result<(), DatatypeError> {
         self.get_core().sync()
+    }
+
+    #[cfg(test)]
+    fn get_attr(&self) -> std::sync::Arc<crate::datatypes::common::Attribute> {
+        self.get_core().attr.clone()
     }
 }
 

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -72,6 +72,10 @@ impl<'a> PullHandler<'a> {
             DatatypeState::DueToSubscribe => {
                 if self.pulled_ppp.state == DatatypeState::DueToSubscribe {
                     self.new_state = DatatypeState::Subscribed;
+                    if let Some(snapshot_tx) = self.pulled_ppp.snapshot_transaction.take() {
+                        self.mutable.apply_snapshot_transaction(snapshot_tx)?;
+                    }
+                    self.mutable.attr.set_duid(self.pulled_ppp.duid.clone());
                 } else {
                     // TODO: handle error
                 }
@@ -171,6 +175,7 @@ mod tests_push_handlers {
 
         counter.increase_by(2).unwrap();
         counter.increase_by(3).unwrap();
+        counter.sync().unwrap();
 
         awaitility::at_most(Duration::from_secs(1))
             .poll_interval(Duration::from_micros(100))

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -109,6 +109,11 @@ impl Datatype for TransactionalDatatype {
     fn sync(&self) -> Result<(), DatatypeError> {
         self.event_loop.send_push_transaction_with_guarantee()
     }
+
+    #[cfg(test)]
+    fn get_attr(&self) -> std::sync::Arc<Attribute> {
+        self.attr.clone()
+    }
 }
 
 impl TransactionalDatatype {

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -90,7 +90,7 @@ impl WiredDatatype {
     }
 
     pub fn cuid(&self) -> Cuid {
-        self.attr.cuid()
+        self.attr.get_cuid()
     }
 
     pub fn get_subscribe_snapshot(&self) -> Transaction {

--- a/src/errors/clients.rs
+++ b/src/errors/clients.rs
@@ -32,6 +32,21 @@ impl PartialEq for ClientError {
     }
 }
 
-pub(crate) const CLIENT_ERROR_MSG_COLLECTION_NAME: &str = "invalid collection name. Collection name must be 1-47 characters, start with a letter or underscore, contain only alphanumeric characters and '.', '_', '~', '-', and must not start with 'system.' or contain '.system.'.";
+pub(crate) const CLIENT_ERROR_MSG_COLLECTION_NAME: &str = "invalid collection name: '{}' - Collection name must be 1-47 characters, start with a letter or underscore, contain only alphanumeric characters and '.', '_', '~', '-', and must not start with 'system.' or contain '.system.'";
+pub(crate) const CLIENT_ERROR_MSG_DATATYPE_KEY: &str = "invalid datatype key: '{}' - Key must not be empty, must not contain null characters (\\0), must not exceed 255 bytes in length, and must not start with '$'.";
 
-pub(crate) const CLIENT_ERROR_MSG_DATATYPE_KEY: &str = "invalid datatype key. Key must not be empty, must not contain null characters (\\0), must not exceed 255 bytes in length, and must not start with '$'.";
+#[cfg(test)]
+mod tests_client_error {
+    use dyn_fmt::AsStrFormatExt;
+    use tracing::info;
+
+    use crate::errors::clients::CLIENT_ERROR_MSG_COLLECTION_NAME;
+
+    #[test]
+    fn can_use_error_msg_format() {
+        let invalid_collection_name = "invalid::collection::name";
+        let err_msg = CLIENT_ERROR_MSG_COLLECTION_NAME.format(&[invalid_collection_name]);
+        info!("{err_msg}");
+        assert!(err_msg.contains(invalid_collection_name));
+    }
+}

--- a/src/errors/push_pull.rs
+++ b/src/errors/push_pull.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 use crate::ConnectivityError;
 
+pub(crate) const CLIENT_PUSHPULL_ERR_MSG_NO_SNAPSHOT: &str = "no snapshot operation";
+
 #[non_exhaustive]
 #[repr(i32)]
 #[derive(Debug, Error, Eq)]
@@ -43,6 +45,8 @@ pub enum ClientPushPullError {
     FailedInConnectivity(ConnectivityError),
     #[error("[ClientPushPullError] failed and abort datatype: {0}")]
     FailedAndAbort(String),
+    #[error("[ClientPushPullError] failed with protocol violation: {0}")]
+    FailedWithProtocolViolation(String),
 }
 
 impl ClientPushPullError {
@@ -56,6 +60,7 @@ impl ClientPushPullError {
                 todo!();
             }
             ClientPushPullError::FailedAndAbort(_) => todo!(),
+            ClientPushPullError::FailedWithProtocolViolation(_) => todo!(),
         }
     }
 }

--- a/src/operations/transaction.rs
+++ b/src/operations/transaction.rs
@@ -21,7 +21,7 @@ pub struct Transaction {
     pub sseq: u64,
     pub tag: Option<String>,
     pub event: bool,
-    operations: Vec<Operation>,
+    pub operations: Vec<Operation>,
 }
 
 impl Transaction {

--- a/src/types/push_pull_pack.rs
+++ b/src/types/push_pull_pack.rs
@@ -26,8 +26,8 @@ pub struct PushPullPack {
     pub checkpoint: CheckPoint,
     pub safe_sseq: u64,
     pub transactions: Vec<Arc<Transaction>>,
+    pub snapshot_transaction: Option<Arc<Transaction>>,
     pub is_readonly: bool,
-    pub has_snapshot: bool,
     pub error: Option<ServerPushPullError>,
 }
 
@@ -43,8 +43,8 @@ impl PushPullPack {
             checkpoint: CheckPoint::default(),
             safe_sseq: 0,
             transactions: Vec::new(),
+            snapshot_transaction: None,
             is_readonly: attr.is_readonly,
-            has_snapshot: false,
             error: None,
         }
     }
@@ -74,8 +74,8 @@ impl PushPullPack {
             checkpoint: CheckPoint::default(),
             safe_sseq: self.safe_sseq,
             transactions: Vec::new(),
+            snapshot_transaction: None,
             is_readonly: self.is_readonly,
-            has_snapshot: false,
             error: None,
         }
     }
@@ -99,7 +99,7 @@ impl Display for PushPullPack {
             attr.push_str("rw");
         }
 
-        if self.has_snapshot {
+        if self.snapshot_transaction.is_some() {
             attr.push_str("|sn");
         }
 
@@ -157,7 +157,8 @@ mod tests_push_pull_pack {
         ));
         assert_eq!(format!("{ppp}"), format!("{ppp:?}"));
         info!("{ppp}");
-        ppp.has_snapshot = true;
+        ppp.snapshot_transaction =
+            Some(crate::operations::transaction::Transaction::new_arc_for_test(&ppp.cuid, 0));
         assert_eq!(format!("{ppp}"), format!("{ppp:?}"));
         info!("{ppp:?}");
     }


### PR DESCRIPTION
- close #8 
- Add snapshot mechanism for efficient datatype subscription synchronization, allowing new subscribers to receive current state without full history replay. Improve error messages with dynamic formatting using dyn-fmt crate.

  - Add apply_snapshot_transaction() for snapshot-based state sync
  - Change PushPullPack.has_snapshot to snapshot_transaction Option
  - Add Display trait to CounterCrdt and Crdt enum
  - Add FailedWithProtocolViolation error variant
  - Refactor tests to use Client/Counter API instead of low-level WiredDatatype
  - Rename cuid() to get_cuid() for naming consistency