### PR TITLE
[#13] 📜docs: revise documents for the 1st iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Qortoo is a Rust SDK for conflict-free datatypes with distributed synchronizatio
 use qortoo::Client;
 
 // Create a client
-let client = Client::builder("my-collection", "my-client").build();
+let client = Client::builder("my-collection", "my-client").build().unwrap();
 
 // Create a writable counter
 let counter = client
@@ -48,43 +48,31 @@ let readonly_counter = client
 assert!(readonly_counter.increase().is_err());
 ```
 
-## For development
-
-### Getting started
+## Build and Development Commands
 
 ```shell
-# install 
-$ make install
-# 
-$ make enable-jeager 
-```
+# Install dependencies (cargo-tarpaulin)
+make install
 
-> [!NOTE]
-> To enable log output in the tests, you should run test with '--all-features' after running the follows:
+# Run all tests
+cargo test
 
-```shell
-$ make enable-jaeger
-$ cargo test --all-features 
-```
+# Run tests with tracing/observability (requires Jaeger)
+make enable-jaeger
+cargo test --all-features
 
-You can find the traces in the jaeger UI: http://localhost:16686/
+# Run a single test
+cargo test test_name
 
-### Code Coverage
+# Run tests in a specific module
+cargo test module_name::
 
-Code coverage is measured using cargo-tarpaulin:
+# Lint (run before PR)
+make lint
 
-```shell
-# run tarpaulin
-$ make tarpaulin
+# Code coverage (requires 90% minimum)
+make tarpaulin
 
-# local update coverage badge
-$ make update-coverage-badge
-```
-
-### Before pull request
-
-Run the full lint suite before submitting:
-
-```shell
-$ make lint
+# Generate documentation
+make doc
 ```

--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -52,6 +52,27 @@ impl ClientBuilder {
         })
     }
 
+    /// Sets a custom connectivity backend for synchronization.
+    ///
+    /// By default, [`Client`] uses [`NullConnectivity`](crate::connectivity::null_connectivity::NullConnectivity),
+    /// which is a no-op implementation. Use this method to provide a real
+    /// connectivity backend for distributed synchronization.
+    ///
+    /// # Arguments
+    ///
+    /// * `connectivity` - An `Arc`-wrapped implementation of the [`Connectivity`] trait
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use qortoo::{Client, LocalConnectivity};
+    ///
+    /// let connectivity = LocalConnectivity::new_arc();
+    /// let client = Client::builder("collection", "alias")
+    ///     .with_connectivity(connectivity)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
     pub fn with_connectivity(mut self, connectivity: Arc<dyn Connectivity>) -> Self {
         self.connectivity = connectivity;
         self

--- a/src/errors/connectivity.rs
+++ b/src/errors/connectivity.rs
@@ -1,8 +1,20 @@
 use thiserror::Error;
 
+/// Errors related to connectivity operations.
+///
+/// These errors occur when interacting with the underlying synchronization
+/// backend or when resources cannot be found.
+///
+/// # Equality
+/// Two `ConnectivityError` values are considered equal if they have the same
+/// variant and message content.
 #[non_exhaustive]
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ConnectivityError {
+    /// The requested resource was not found.
+    ///
+    /// Returned when attempting to access a datatype or resource that
+    /// does not exist in the connectivity backend.
     #[error("[ConnectivityError] the demanded resource is not found: {_0}")]
     ResourceNotFound(String),
 }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -3,6 +3,21 @@ pub mod connectivity;
 pub mod datatypes;
 pub mod push_pull;
 
+/// A type alias for a boxed error that is thread-safe.
+///
+/// This is used throughout Qortoo to represent errors that can be passed
+/// across thread boundaries. It wraps any error implementing the standard
+/// `Error` trait along with `Send` and `Sync`.
+///
+/// # Examples
+///
+/// ```
+/// use qortoo::BoxedError;
+///
+/// fn may_fail() -> Result<(), BoxedError> {
+///     Err("something went wrong".into())
+/// }
+/// ```
 pub type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 
 pub fn with_stack_trace(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub use datatypes::datatype_set::DatatypeSet;
 
 pub use crate::{
     clients::client::Client,
+    connectivity::local_connectivity::LocalConnectivity,
     datatypes::{builder::DatatypeBuilder, counter::Counter, datatype::Datatype},
     errors::{
         BoxedError, clients::ClientError, connectivity::ConnectivityError, datatypes::DatatypeError,


### PR DESCRIPTION
- close #13 
- Add doc comments to LocalConnectivity with usage examples
- Document Datatype trait methods including sync()
- Add documentation to ConnectivityError and BoxedError
- Export LocalConnectivity in public API
- Update README with cleaner build commands section