### PR TITLE
[🧬FEAT] implement handling errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "libc",
+ "libc 0.2.180",
 ]
 
 [[package]]
@@ -54,6 +54,16 @@ name = "awaitility"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01a30fe9eeb37d815ce4dbb49702dc715305379ea72365a7cd468e463179648"
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "tokio",
+]
 
 [[package]]
 name = "base64"
@@ -248,6 +258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,7 +379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.180",
  "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
@@ -374,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.180",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
 ]
@@ -504,7 +520,7 @@ dependencies = [
  "http-body",
  "hyper",
  "ipnet",
- "libc",
+ "libc 0.2.180",
  "percent-encoding",
  "pin-project-lite",
  "socket2",
@@ -708,6 +724,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libc"
+version = "1.0.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e136bfa874086c78f34d6eba98c423fefe464ce57f38164d16893ba8ed358e70"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,7 +777,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
- "libc",
+ "libc 0.2.180",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -780,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -799,14 +821,14 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
- "libc",
+ "libc 0.2.180",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opentelemetry"
@@ -899,7 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.180",
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.0",
@@ -1007,6 +1029,7 @@ name = "qortoo"
 version = "0.1.0"
 dependencies = [
  "awaitility",
+ "backon",
  "btparse",
  "chrono",
  "crossbeam-channel",
@@ -1015,7 +1038,7 @@ dependencies = [
  "dyn-fmt",
  "futures",
  "itoa",
- "libc",
+ "libc 1.0.0-alpha.3",
  "nanoid",
  "once_cell",
  "opentelemetry",
@@ -1055,7 +1078,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
+ "libc 0.2.180",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -1323,7 +1346,7 @@ version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
- "libc",
+ "libc 0.2.180",
 ]
 
 [[package]]
@@ -1344,7 +1367,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
- "libc",
+ "libc 0.2.180",
  "windows-sys 0.59.0",
 ]
 
@@ -1428,13 +1451,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
+ "libc 0.2.180",
  "num-conv",
  "num_threads",
  "powerfmt",
@@ -1445,15 +1468,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1471,12 +1494,12 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
- "libc",
+ "libc 0.2.180",
  "mio",
  "parking_lot",
  "pin-project-lite",
@@ -1695,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ tracing = [
 
 [dependencies]
 # optional
-libc = { version = "^0.2.180", optional = true }
-once_cell = { version = "^1.21.3", optional = true }
-tracing-subscriber = { version = "^0.3.22", features = [
+libc = { version = "^1.0.0-alpha.3", optional = true }
+once_cell = { version = "^1.21.4", optional = true }
+tracing-subscriber = { version = "^0.3.23", features = [
     "json",
     "fmt",
     "env-filter",
@@ -33,9 +33,9 @@ ctor = { version = "^0.6.3", optional = true }
 
 tracing = "^0.1.44"
 nanoid = "^0.4.0"
-tokio = { version = "^1.49.0", features = ["full"] }
+tokio = { version = "^1.50.0", features = ["full"] }
 parking_lot = "^0.12.5"
-time = { version = "^0.3.45", features = [
+time = { version = "^0.3.47", features = [
     "formatting",
     "local-offset",
     "macros",
@@ -53,8 +53,9 @@ btparse = "^0.2.0"
 strum_macros = "^0.28.0"
 regex = "^1.12.3"
 dyn-fmt = "^0.4.3"
+backon = { version = "^1.6.0", default-features = false, features = ["tokio-sleep"] }
 
 [dev-dependencies]
 rstest = "^0.26.1"
 awaitility = "^0.4.1"
-tokio = { version = "^1.49.0", features = ["full", "test-util"] }
+tokio = { version = "^1.50.0", features = ["full", "test-util"] }

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -172,7 +172,7 @@ impl Connectivity for LocalConnectivity {
             DatatypeState::DueToSubscribe => {
                 local_datatype_server.process_due_to_subscribe(pushed)?
             }
-            _ => todo!(),
+            _ => todo!("TODO: {}", pushed.state),
         };
         Ok(pulled)
     }

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -168,9 +168,12 @@ mod tests_local_datatype_server {
     use tracing::{info, instrument};
 
     use crate::{
-        Client, Datatype, DatatypeState,
+        Client, Datatype, DatatypeError, DatatypeState,
         connectivity::local_connectivity::LocalConnectivity,
-        errors::push_pull::{ClientPushPullError, ServerPushPullError},
+        errors::{
+            datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
+            push_pull::{ClientPushPullError, ServerPushPullError},
+        },
         types::{checkpoint::CheckPoint, push_pull_pack::PushPullPack, uid::Duid},
         utils::path::{get_test_collection_name, get_test_func_name},
     };
@@ -229,7 +232,12 @@ mod tests_local_datatype_server {
                     DatatypeState::DueToCreate,
                     Some(ServerPushPullError::FailedToCreate("".to_string())),
                 );
-                Err(ClientPushPullError::FailToGetAfter)
+
+                Err(DatatypeErrorWithActions::new(
+                    DatatypeError::FailedToCreate("".to_owned()),
+                    EventLoopAction::Normal,
+                    DatatypeAction::Normal,
+                ))
             });
         assert!(counter1.sync().is_err());
         assert!(!server.read().created);
@@ -248,7 +256,11 @@ mod tests_local_datatype_server {
                     DatatypeState::DueToCreate,
                     None,
                 );
-                Err(ClientPushPullError::FailToGetAfter)
+                Err(DatatypeErrorWithActions::new(
+                    DatatypeError::FailedToCreate("".to_owned()),
+                    EventLoopAction::Normal,
+                    DatatypeAction::Normal,
+                ))
             });
         assert!(counter1.sync().is_err());
         assert!(server.read().created);
@@ -269,7 +281,7 @@ mod tests_local_datatype_server {
                     DatatypeState::DueToCreate,
                     None,
                 );
-                Err(ClientPushPullError::FailToGetAfter)
+                Err(ClientPushPullError::FailToGetPushingTransactions.mapping())
             });
 
         assert!(counter1.sync().is_err());
@@ -293,7 +305,7 @@ mod tests_local_datatype_server {
                         "already exist".to_string(),
                     )),
                 );
-                Err(ClientPushPullError::FailToGetAfter)
+                Err(ClientPushPullError::FailToGetPushingTransactions.mapping())
             });
         assert!(counter1.sync().is_err());
         assert!(server.read().created);

--- a/src/datatypes/builder.rs
+++ b/src/datatypes/builder.rs
@@ -219,7 +219,7 @@ mod tests_datatype_builder {
         // Write operations should fail
         assert_eq!(
             counter.increase().unwrap_err(),
-            DatatypeError::FailedToWrite("".into())
+            DatatypeError::Disallowed("".into())
         );
 
         // Transaction should fail
@@ -227,10 +227,7 @@ mod tests_datatype_builder {
             c.increase().unwrap();
             Ok(())
         });
-        assert_eq!(
-            tx_result.unwrap_err(),
-            DatatypeError::FailedToWrite("".into())
-        );
+        assert_eq!(tx_result.unwrap_err(), DatatypeError::Disallowed("".into()));
         assert_eq!(counter.get_value(), 0);
     }
 
@@ -252,7 +249,7 @@ mod tests_datatype_builder {
         assert_eq!(counter.get_state(), DatatypeState::DueToSubscribe);
         assert_eq!(
             counter.increase().unwrap_err(),
-            DatatypeError::FailedToWrite("".into())
+            DatatypeError::Disallowed("".into())
         );
 
         let counter = client

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -54,7 +54,7 @@ pub trait Datatype {
     ///
     /// # Errors
     ///
-    /// Returns [`DatatypeError::FailedToSync`] if the synchronization fails.
+    /// Returns [`DatatypeError::FailedToPushPull`] if the synchronization fails.
     ///
     /// # Examples
     ///
@@ -140,7 +140,10 @@ mod tests_datatype_trait {
         datatypes::{
             common::new_attribute, datatype::Datatype, transactional::TransactionalDatatype,
         },
-        errors::push_pull::ClientPushPullError,
+        errors::{
+            datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
+            push_pull::ClientPushPullError,
+        },
         utils::path::{get_test_collection_name, get_test_func_name},
     };
 
@@ -182,11 +185,17 @@ mod tests_datatype_trait {
             .unwrap();
 
         // produce push_pull error
-        interceptor1.set_after_pull(|_pull| Err(ClientPushPullError::ExceedMaxMemSize));
+        interceptor1.set_after_pull(|_pull| {
+            Err(DatatypeErrorWithActions::new(
+                DatatypeError::FailedToPushPull(ClientPushPullError::ExceedMaxMemSize),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Recovery,
+            ))
+        });
 
         assert_eq!(
             counter1.sync().unwrap_err(),
-            DatatypeError::FailedToSync(ClientPushPullError::ExceedMaxMemSize)
+            DatatypeError::FailedToPushPull(ClientPushPullError::ExceedMaxMemSize)
         );
         assert_eq!(counter1.get_state(), DatatypeState::DueToCreate);
 

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -188,7 +188,7 @@ mod tests_datatype_trait {
         interceptor1.set_after_pull(|_pull| {
             Err(DatatypeErrorWithActions::new(
                 DatatypeError::FailedToPushPull(ClientPushPullError::ExceedMaxMemSize),
-                EventLoopAction::PauseSync,
+                EventLoopAction::BackOff,
                 DatatypeAction::Recovery,
             ))
         });

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -1,21 +1,35 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crossbeam_channel::{Receiver, Sender};
 use derive_more::Display;
 use tokio::sync::oneshot;
 use tracing::{Span, error, instrument};
 
+use backon::{BackoffBuilder, ExponentialBackoff, ExponentialBuilder};
+
 use crate::{
-    DatatypeError, connectivity::Connectivity, datatypes::wired::WiredDatatype,
-    errors::with_err_out, observability::macros::add_span_event,
+    DatatypeError,
+    connectivity::Connectivity,
+    datatypes::wired::WiredDatatype,
+    defaults::DEFAULT_EVENT_LOOP_TIMEOUT_MS,
+    errors::{
+        datatypes::{DatatypeAction, EventLoopAction},
+        with_err_out,
+    },
+    observability::macros::add_span_event,
 };
+
+const BACKOFF_MIN_DELAY: Duration = Duration::from_millis(500);
+const BACKOFF_MAX_DELAY: Duration = Duration::from_secs(30);
 
 #[derive(Display)]
 pub enum Event {
     #[display("Stop")]
-    Stop(oneshot::Sender<()>),
+    Stop(Sender<()>),
     #[display("PushTransaction")]
     PushTransaction(Option<oneshot::Sender<Option<DatatypeError>>>),
+    #[display("BackOff")]
+    BackOff
 }
 
 #[derive(Debug)]
@@ -28,6 +42,14 @@ pub struct EventLoop {
 }
 
 impl EventLoop {
+    fn build_backoff() -> ExponentialBackoff {
+        ExponentialBuilder::new()
+            .with_min_delay(BACKOFF_MIN_DELAY)
+            .with_max_delay(BACKOFF_MAX_DELAY)
+            .without_max_times()
+            .build()
+    }
+
     pub fn new_arc(connectivity: Arc<dyn Connectivity>) -> Arc<Self> {
         let (unbounded_tx, unbounded_rx) = crossbeam_channel::unbounded::<Event>();
         let (bounded_tx, bounded_rx) = crossbeam_channel::bounded::<Event>(0);
@@ -60,48 +82,49 @@ impl EventLoop {
         rt_handle.spawn_blocking(move || {
             span.in_scope(|| {
                 add_span_event!("start event_loop");
+                let mut event_loop_action = EventLoopAction::Normal;
+                let mut backoff = None;
                 loop {
-                    wired.push_if_needed();
-                    let event = crossbeam_channel::select! {
-                        recv(unbounded_rx) -> msg => {
-                            match msg {
-                                Ok(event) => event,
-                                Err(e) => {
-                                    error!("unbounded channel error {e:?}; stopping event loop");
-                                    break;
+                    match Self::receive_event(
+                        &wired,
+                        &bounded_rx,
+                        &unbounded_rx,
+                        &mut event_loop_action,
+                        &mut backoff,
+                    ) {
+                        Ok(event) => match event {
+                            Event::Stop(tx) => {
+                                add_span_event!("receive STOP");
+                                if tx.send(()).is_err() {
+                                    error!("failed to respond STOP event");
+                                }
+                                break;
+                            }
+                            Event::PushTransaction(blocking_resp_tx) => {
+                                let response = match wired.push_pull() {
+                                    Ok(_) => {
+                                        event_loop_action = EventLoopAction::Normal;
+                                        None
+                                    }
+                                    Err(dewa) => {
+                                        event_loop_action = dewa.event_loop_action;
+                                        wired.handle_error(&dewa.error, dewa.datatype_action);
+                                        Some(dewa.error)
+                                    }
+                                };
+                                if !matches!(event_loop_action, EventLoopAction::BackOff) {
+                                    backoff = None;
+                                }
+                                if let Some(sender) = blocking_resp_tx {
+                                    if sender.send(response).is_err() {
+                                        error!("failed to respond PushTransaction event");
+                                    }
                                 }
                             }
-                        }
-                        recv(bounded_rx) -> msg => {
-                            match msg {
-                                Ok(event) => event,
-                                Err(e) => {
-                                    error!("bounded channel error {e:?}; stopping event loop");
-                                    break;
-                                }
-                            }
-                        }
-                    };
-                    match event {
-                        Event::Stop(tx) => {
-                            add_span_event!("receive STOP");
-                            if tx.send(()).is_err() {
-                                error!("failed to respond STOP event");
-                            }
-                            break;
-                        }
-                        Event::PushTransaction(tx_opt) => {
-                            add_span_event!("receive PushTransaction");
-                            let mut err_opt = None;
-                            if let Err(e) = wired.push_pull() {
-                                error!("push_pull failed: {e}");
-                                err_opt = Some(DatatypeError::FailedToSync(e));
-                            }
-                            if let Some(tx) = tx_opt {
-                                if tx.send(err_opt).is_err() {
-                                    error!("failed to respond PushTransaction event");
-                                }
-                            }
+                            Event::BackOff => {}
+                        },
+                        Err(err) => {
+                            wired.handle_error(&err, DatatypeAction::Disable);
                         }
                     }
                 }
@@ -110,15 +133,60 @@ impl EventLoop {
         });
     }
 
+    #[instrument(skip_all)]
+    fn receive_event(
+        wired: &WiredDatatype,
+        bounded_rx: &Receiver<Event>,
+        unbounded_rx: &Receiver<Event>,
+        event_loop_action: &mut EventLoopAction,
+        backoff: &mut Option<ExponentialBackoff>,
+    ) -> Result<Event, DatatypeError> {
+        let (push_if_needed, backoff_duration) = match event_loop_action {
+            EventLoopAction::Normal => (true, None),
+            EventLoopAction::PauseSync => (false, None),
+            EventLoopAction::BackOff => {
+                let backoff_iter = backoff.get_or_insert_with(Self::build_backoff);
+                let d = backoff_iter.next().unwrap_or(BACKOFF_MAX_DELAY);
+                (false, Some(d))
+            }
+        };
+
+        if push_if_needed && wired.push_if_needed() {
+            return Ok(Event::PushTransaction(None));
+        }
+
+        let map_err = |e, ch: &str| {
+            error!("{ch} channel error {e:?}; stopping event loop");
+            DatatypeError::FailedInEventLoop(Box::new(e))
+        };
+
+        if let Some(duration) = backoff_duration {
+            add_span_event!(format!("enter backOff during {duration:?}"));
+            crossbeam_channel::select! {
+                // only unbounded_rx is allowed to receive events during backoff for STOP or explicit sync event
+                recv(unbounded_rx) -> event => event.map_err(|e| map_err(e, "unbounded")),
+                default(duration) => {
+                    *event_loop_action = EventLoopAction::Normal;
+                    Ok(Event::BackOff)
+                }
+            }
+        } else {
+            crossbeam_channel::select! {
+                recv(unbounded_rx) -> event => event.map_err(|e| map_err(e, "unbounded")),
+                recv(bounded_rx) -> event => event.map_err(|e| map_err(e, "bounded")),
+            }
+        }
+    }
+
     pub fn send_stop(&self) {
-        let (tx, rx) = oneshot::channel();
+        let (tx, rx) = crossbeam_channel::bounded::<()>(1);
         match self.send_to_unbounded(Event::Stop(tx)) {
             Ok(_) => {
-                futures::executor::block_on(async {
-                    if rx.await.is_err() {
-                        error!("failed to receive stop confirmation")
-                    }
-                });
+                if let Err(e) =
+                    rx.recv_timeout(Duration::from_millis(DEFAULT_EVENT_LOOP_TIMEOUT_MS))
+                {
+                    error!("fail to stop event loop: {e}");
+                }
             }
             Err(e) => {
                 error!("failed to send stop event to event loop: {}", e);
@@ -162,5 +230,194 @@ impl EventLoop {
                 )),
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests_event_loop {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
+    use tracing::instrument;
+
+    use crate::{
+        Client, ConnectivityError, DatatypeError, DatatypeState,
+        connectivity::local_connectivity::LocalConnectivity,
+        datatypes::datatype::Datatype,
+        errors::{
+            datatypes::DatatypeErrorWithActions,
+            push_pull::ClientPushPullError,
+        },
+        utils::path::{get_test_collection_name, get_test_func_name},
+    };
+
+    fn make_backoff_error() -> DatatypeErrorWithActions {
+        ClientPushPullError::FailedInConnectivity(ConnectivityError::ResourceNotFound(
+            "injected".to_string(),
+        ))
+        .mapping()
+    }
+
+    fn make_pause_sync_error() -> DatatypeErrorWithActions {
+        ClientPushPullError::FailedWithProtocolViolation("injected".to_string()).mapping()
+    }
+
+    /// Test that an explicit sync() call bypasses the BackOff wait via the unbounded channel.
+    /// After a FailedInConnectivity error sets BackOff on the event loop, the next sync()
+    /// is still processed immediately (not after the 500ms delay).
+    #[test]
+    #[instrument]
+    fn can_manually_retry_after_backoff_error() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let collection = get_test_collection_name!();
+        let key = get_test_func_name!();
+        let resource_id = format!("{collection}/{key}");
+        let client = Client::builder(collection, "client")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype(key).build_counter().unwrap();
+
+        let interceptor = connectivity
+            .get_wired_interceptor(&resource_id, &client.get_cuid())
+            .unwrap();
+
+        // inject FailedInConnectivity → maps to EventLoopAction::BackOff, DatatypeAction::Normal
+        interceptor.set_after_pull(|_| Err(make_backoff_error()));
+
+        let err = counter.sync().unwrap_err();
+        assert!(matches!(err, DatatypeError::FailedToPushPull(_)));
+        // DatatypeAction::Normal → no state change
+        assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
+
+        // explicit sync() sends to unbounded channel → bypasses 500ms BackOff wait
+        interceptor.set_after_pull(|_| Ok(()));
+        assert!(counter.sync().is_ok());
+        assert_eq!(counter.get_state(), DatatypeState::Subscribed);
+    }
+
+    /// Test that the event loop auto-retries after the BackOff timeout expires (~500ms).
+    /// Without any manual sync() call, the event loop's select! default(500ms) fires
+    /// and triggers a retry push_pull().
+    #[test]
+    #[instrument]
+    fn can_auto_retry_after_backoff_timeout() {
+        let connectivity = LocalConnectivity::new_arc();
+        let collection = get_test_collection_name!();
+        let key = get_test_func_name!();
+        let resource_id = format!("{collection}/{key}");
+
+        let client = Client::builder(collection, "client")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype(key).build_counter().unwrap();
+
+        let interceptor = connectivity
+            .get_wired_interceptor(&resource_id, &client.get_cuid())
+            .unwrap();
+
+        let pull_count = Arc::new(AtomicUsize::new(0));
+        let pull_count_for_after_pull = pull_count.clone();
+        interceptor.set_after_pull(move |_| {
+            let count = pull_count_for_after_pull.fetch_add(1, Ordering::SeqCst) + 1;
+            if count >= 3 {
+                Ok(())
+            } else {
+                Err(make_backoff_error())
+            }
+        });
+
+        assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
+
+        awaitility::at_most(Duration::from_secs(50))
+            .poll_interval(Duration::from_millis(100))
+            .until(|| counter.get_state() == DatatypeState::Subscribed);
+    }
+
+    /// Test that a successful manual retry exits BackOff immediately.
+    /// If BackOff is not cleared on success, the loop can fire one more timed retry.
+    #[test]
+    #[instrument]
+    fn does_not_trigger_extra_retry_after_successful_manual_retry() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let collection = get_test_collection_name!();
+        let key = get_test_func_name!();
+        let resource_id = format!("{collection}/{key}");
+        let client = Client::builder(collection, "client")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype(key).build_counter().unwrap();
+
+        let interceptor = connectivity
+            .get_wired_interceptor(&resource_id, &client.get_cuid())
+            .unwrap();
+
+        let should_fail = Arc::new(AtomicBool::new(true));
+        let should_fail_for_after_pull = should_fail.clone();
+        let pull_count = Arc::new(AtomicUsize::new(0));
+        let pull_count_for_after_pull = pull_count.clone();
+        interceptor.set_after_pull(move |_| {
+            pull_count_for_after_pull.fetch_add(1, Ordering::SeqCst);
+            if should_fail_for_after_pull.load(Ordering::SeqCst) {
+                Err(make_backoff_error())
+            } else {
+                Ok(())
+            }
+        });
+
+        assert!(counter.sync().is_err());
+        assert_eq!(pull_count.load(Ordering::SeqCst), 1);
+
+        should_fail.store(false, Ordering::SeqCst);
+        assert!(counter.sync().is_ok());
+        assert_eq!(pull_count.load(Ordering::SeqCst), 2);
+
+        std::thread::sleep(Duration::from_millis(800));
+        assert_eq!(pull_count.load(Ordering::SeqCst), 2);
+    }
+
+    /// Test that PauseSync + Disable transitions datatype to Disabled and
+    /// does not keep retrying automatically afterwards.
+    #[test]
+    #[instrument]
+    fn can_handle_pause_sync_error_without_auto_retry_loop() {
+        let connectivity = LocalConnectivity::new_arc();
+        // connectivity.set_realtime(false);
+        let collection = get_test_collection_name!();
+        let key = get_test_func_name!();
+        let resource_id = format!("{collection}/{key}");
+        let client = Client::builder(collection, "client")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype(key).build_counter().unwrap();
+
+        let interceptor = connectivity
+            .get_wired_interceptor(&resource_id, &client.get_cuid())
+            .unwrap();
+
+        let pull_count = Arc::new(AtomicUsize::new(0));
+        let pull_count_for_after_pull = pull_count.clone();
+        interceptor.set_after_pull(move |_| {
+            pull_count_for_after_pull.fetch_add(1, Ordering::SeqCst);
+            Err(make_pause_sync_error())
+        });
+
+        assert!(counter.sync().is_err());
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+        assert_eq!(pull_count.load(Ordering::SeqCst), 1);
+
+        std::thread::sleep(Duration::from_millis(800));
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+        assert_eq!(pull_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -1,11 +1,10 @@
 use std::{sync::Arc, time::Duration};
 
+use backon::{BackoffBuilder, ExponentialBackoff, ExponentialBuilder};
 use crossbeam_channel::{Receiver, Sender};
 use derive_more::Display;
 use tokio::sync::oneshot;
 use tracing::{Span, error, instrument};
-
-use backon::{BackoffBuilder, ExponentialBackoff, ExponentialBuilder};
 
 use crate::{
     DatatypeError,
@@ -29,7 +28,7 @@ pub enum Event {
     #[display("PushTransaction")]
     PushTransaction(Option<oneshot::Sender<Option<DatatypeError>>>),
     #[display("BackOff")]
-    BackOff
+    BackOff,
 }
 
 #[derive(Debug)]
@@ -101,6 +100,9 @@ impl EventLoop {
                                 break;
                             }
                             Event::PushTransaction(blocking_resp_tx) => {
+                                if matches!(event_loop_action, EventLoopAction::PauseSync) {
+                                    continue;
+                                }
                                 let response = match wired.push_pull() {
                                     Ok(_) => {
                                         event_loop_action = EventLoopAction::Normal;
@@ -249,10 +251,7 @@ mod tests_event_loop {
         Client, ConnectivityError, DatatypeError, DatatypeState,
         connectivity::local_connectivity::LocalConnectivity,
         datatypes::datatype::Datatype,
-        errors::{
-            datatypes::DatatypeErrorWithActions,
-            push_pull::ClientPushPullError,
-        },
+        errors::{datatypes::DatatypeErrorWithActions, push_pull::ClientPushPullError},
         utils::path::{get_test_collection_name, get_test_func_name},
     };
 
@@ -336,7 +335,7 @@ mod tests_event_loop {
 
         assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
 
-        awaitility::at_most(Duration::from_secs(50))
+        awaitility::at_most(Duration::from_secs(10))
             .poll_interval(Duration::from_millis(100))
             .until(|| counter.get_state() == DatatypeState::Subscribed);
     }
@@ -345,7 +344,7 @@ mod tests_event_loop {
     /// If BackOff is not cleared on success, the loop can fire one more timed retry.
     #[test]
     #[instrument]
-    fn does_not_trigger_extra_retry_after_successful_manual_retry() {
+    fn can_block_extra_retry_after_successful_manual_retry() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
         let collection = get_test_collection_name!();
@@ -374,13 +373,17 @@ mod tests_event_loop {
             }
         });
 
+        // First, sync fails
         assert!(counter.sync().is_err());
         assert_eq!(pull_count.load(Ordering::SeqCst), 1);
 
+        // Then, make sync not fail
         should_fail.store(false, Ordering::SeqCst);
+
         assert!(counter.sync().is_ok());
         assert_eq!(pull_count.load(Ordering::SeqCst), 2);
 
+        // Check if no sync happens
         std::thread::sleep(Duration::from_millis(800));
         assert_eq!(pull_count.load(Ordering::SeqCst), 2);
     }
@@ -391,7 +394,6 @@ mod tests_event_loop {
     #[instrument]
     fn can_handle_pause_sync_error_without_auto_retry_loop() {
         let connectivity = LocalConnectivity::new_arc();
-        // connectivity.set_realtime(false);
         let collection = get_test_collection_name!();
         let key = get_test_func_name!();
         let resource_id = format!("{collection}/{key}");
@@ -413,8 +415,8 @@ mod tests_event_loop {
         });
 
         assert!(counter.sync().is_err());
-        assert_eq!(counter.get_state(), DatatypeState::Disabled);
         assert_eq!(pull_count.load(Ordering::SeqCst), 1);
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
 
         std::thread::sleep(Duration::from_millis(800));
         assert_eq!(counter.get_state(), DatatypeState::Disabled);

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -55,10 +55,15 @@ impl MutableDatatype {
         }
     }
 
-    fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.push_buffer = MemoryPushBuffer::new(self.attr.option.clone());
         self.rollback = Rollback::new(self.crdt.clone(), self.state, self.op_id.clone());
         self.transaction = Default::default();
+    }
+
+    pub fn disable(&mut self) {
+        self.reset();
+        self.set_state(DatatypeState::Disabled);
     }
 
     pub fn apply_snapshot_transaction(
@@ -98,7 +103,7 @@ impl MutableDatatype {
                 tx.set_tag(tag);
                 let tx = Arc::new(tx);
                 if tx.cuid == self.op_id.cuid {
-                    if let Err(err) = self.push_buffer.enque(tx.clone()) {
+                    if let Err(err) = self.push_buffer.enqueue(tx.clone()) {
                         if err == ClientPushPullError::ExceedMaxMemSize {
                             todo!("should reduce the push buffer size");
                         }

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -1,20 +1,10 @@
 use tracing::instrument;
 
 use crate::{
-    DatatypeState,
-    datatypes::mutable::MutableDatatype,
-    errors::push_pull::{ClientPushPullError, ServerPushPullError},
-    observability::macros::add_span_event,
+    DatatypeState, datatypes::mutable::MutableDatatype,
+    errors::datatypes::DatatypeErrorWithActions, observability::macros::add_span_event,
     types::push_pull_pack::PushPullPack,
 };
-
-#[allow(dead_code)]
-pub enum CaseAfterSync {
-    Normal,
-    BackOff,
-    Reset,
-    Halt,
-}
 
 pub struct PullHandler<'a> {
     pulled_ppp: &'a mut PushPullPack,
@@ -37,7 +27,7 @@ impl<'a> PullHandler<'a> {
     }
 
     #[instrument(skip_all, name = "applyPull")]
-    pub fn apply(&mut self) -> Result<(), ClientPushPullError> {
+    pub fn apply(&mut self) -> Result<(), DatatypeErrorWithActions> {
         self.handle_error_and_datatype_state()?;
         self.skip_duplicated_transactions()?;
         self.execute_transactions()?;
@@ -46,18 +36,9 @@ impl<'a> PullHandler<'a> {
         Ok(())
     }
 
-    fn handle_error_and_datatype_state(&mut self) -> Result<(), ClientPushPullError> {
+    fn handle_error_and_datatype_state(&mut self) -> Result<(), DatatypeErrorWithActions> {
         if let Some(sppe) = self.pulled_ppp.error.as_ref() {
-            match sppe {
-                ServerPushPullError::IllegalPushRequest(reason) => {
-                    // IllegalPushRequest indicates an unrecoverable state
-                    return Err(ClientPushPullError::FailedAndAbort(reason.to_owned()));
-                }
-                ServerPushPullError::FailedToCreate(_err_msg) => {
-                    // TODO: handle FailedToCreate
-                }
-                ServerPushPullError::FailedToSubscribe(_) => todo!(),
-            }
+            return Err(sppe.mapping());
         }
 
         match self.old_state {
@@ -73,7 +54,9 @@ impl<'a> PullHandler<'a> {
                 if self.pulled_ppp.state == DatatypeState::DueToSubscribe {
                     self.new_state = DatatypeState::Subscribed;
                     if let Some(snapshot_tx) = self.pulled_ppp.snapshot_transaction.take() {
-                        self.mutable.apply_snapshot_transaction(snapshot_tx)?;
+                        self.mutable
+                            .apply_snapshot_transaction(snapshot_tx)
+                            .map_err(|e| e.mapping())?;
                     }
                     self.mutable.attr.set_duid(self.pulled_ppp.duid.clone());
                 } else {
@@ -110,24 +93,24 @@ impl<'a> PullHandler<'a> {
         Ok(())
     }
 
-    fn skip_duplicated_transactions(&mut self) -> Result<(), ClientPushPullError> {
+    fn skip_duplicated_transactions(&mut self) -> Result<(), DatatypeErrorWithActions> {
         // TODO: skip duplicated transactions
         Ok(())
     }
 
-    fn execute_transactions(&mut self) -> Result<(), ClientPushPullError> {
+    fn execute_transactions(&mut self) -> Result<(), DatatypeErrorWithActions> {
         // TODO: execute transactions
         Ok(())
     }
 
-    fn sync_checkpoint(&mut self) -> Result<(), ClientPushPullError> {
+    fn sync_checkpoint(&mut self) -> Result<(), DatatypeErrorWithActions> {
         self.mutable
             .checkpoint
             .check_with(&self.pulled_ppp.checkpoint);
         Ok(())
     }
 
-    fn wrap_up(&mut self) -> Result<(), ClientPushPullError> {
+    fn wrap_up(&mut self) -> Result<(), DatatypeErrorWithActions> {
         self.mutable.set_state(self.new_state);
         Ok(())
     }

--- a/src/datatypes/push_buffer.rs
+++ b/src/datatypes/push_buffer.rs
@@ -8,8 +8,8 @@ use crate::{
 
 #[allow(dead_code)]
 pub trait PushBuffer {
-    fn enque(&mut self, tx: Arc<Transaction>) -> Result<(), ClientPushPullError>;
-    fn get_after(
+    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), ClientPushPullError>;
+    fn get_pushing_transactions(
         &mut self,
         cseq: u64,
         max_mem_size: u64,
@@ -54,7 +54,7 @@ impl MemoryPushBuffer {
 }
 
 impl PushBuffer for MemoryPushBuffer {
-    fn enque(&mut self, tx: Arc<Transaction>) -> Result<(), ClientPushPullError> {
+    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), ClientPushPullError> {
         if self.last_cseq != 0 && self.last_cseq + 1 != tx.cseq {
             return Err(ClientPushPullError::NonSequentialCseq);
         }
@@ -70,14 +70,14 @@ impl PushBuffer for MemoryPushBuffer {
         Ok(())
     }
 
-    fn get_after(
+    fn get_pushing_transactions(
         &mut self,
         cseq: u64,
         max_mem_size: u64,
     ) -> Result<(Vec<Arc<Transaction>>, u64), ClientPushPullError> {
         let mut popped = vec![];
         if cseq == 0 || cseq < self.first_cseq {
-            return Err(ClientPushPullError::FailToGetAfter);
+            return Err(ClientPushPullError::FailToGetPushingTransactions);
         }
 
         let mut total_size: u64 = 0;
@@ -169,14 +169,14 @@ mod tests_push_buffer {
         let mut op_id = OperationId::new();
         let tx = Arc::new(Transaction::new(&mut op_id));
         let tx_size = tx.size();
-        assert!(push_buffer.enque(tx).is_ok());
+        assert!(push_buffer.enqueue(tx).is_ok());
         assert_eq!(push_buffer.mem_size, tx_size);
         assert_eq!(push_buffer.first_cseq, 1);
         assert_eq!(push_buffer.last_cseq, 1);
 
         for _ in 0..9 {
             let tx = Arc::new(Transaction::new(&mut op_id));
-            assert!(push_buffer.enque(tx).is_ok());
+            assert!(push_buffer.enqueue(tx).is_ok());
         }
         assert_eq!(push_buffer.mem_size, tx_size * 10);
         assert_eq!(push_buffer.first_cseq, 1);
@@ -184,19 +184,19 @@ mod tests_push_buffer {
 
         let mut op_id2 = OperationId::new();
         let tx_not_sequential = Arc::new(Transaction::new(&mut op_id2));
-        let result = push_buffer.enque(tx_not_sequential);
+        let result = push_buffer.enqueue(tx_not_sequential);
         assert_eq!(result.unwrap_err(), ClientPushPullError::NonSequentialCseq);
 
         loop {
             let tx = Arc::new(Transaction::new(&mut op_id));
             if push_buffer.mem_size + tx.size() > MAX_SIZE {
                 assert_eq!(
-                    push_buffer.enque(tx).unwrap_err(),
+                    push_buffer.enqueue(tx).unwrap_err(),
                     ClientPushPullError::ExceedMaxMemSize
                 );
                 break;
             }
-            assert!(push_buffer.enque(tx).is_ok());
+            assert!(push_buffer.enqueue(tx).is_ok());
         }
     }
 
@@ -210,27 +210,33 @@ mod tests_push_buffer {
         let mut op_id = OperationId::new();
         let tx = Arc::new(Transaction::new(&mut op_id));
         let tx_size = tx.size();
-        assert!(push_buffer.enque(tx).is_ok());
+        assert!(push_buffer.enqueue(tx).is_ok());
         for _ in 1..100 {
             let tx = Arc::new(Transaction::new(&mut op_id));
-            assert!(push_buffer.enque(tx).is_ok());
+            assert!(push_buffer.enqueue(tx).is_ok());
         }
         assert_eq!(push_buffer.mem_size, tx_size * 100);
         assert_eq!(push_buffer.first_cseq, 1);
         assert_eq!(push_buffer.last_cseq, 100);
 
-        let (push_transactions, push_tx_size) = push_buffer.get_after(50, MAX_PUSH_SIZE).unwrap();
+        let (push_transactions, push_tx_size) = push_buffer
+            .get_pushing_transactions(50, MAX_PUSH_SIZE)
+            .unwrap();
         info!("push_buffer: {push_buffer} {push_tx_size}");
         assert_eq!(push_transactions.len(), 51);
         assert_eq!(push_tx_size, tx_size * 51);
         assert_eq!(push_transactions.first().unwrap().cseq, 50);
 
-        let (push_transactions, push_tx_size) = push_buffer.get_after(50, tx_size * 10).unwrap();
+        let (push_transactions, push_tx_size) = push_buffer
+            .get_pushing_transactions(50, tx_size * 10)
+            .unwrap();
         assert_eq!(push_transactions.len(), 10);
         assert_eq!(push_tx_size, tx_size * 10);
         assert_eq!(push_transactions.first().unwrap().cseq, 50);
 
-        let (push_transactions, push_tx_size) = push_buffer.get_after(101, MAX_PUSH_SIZE).unwrap();
+        let (push_transactions, push_tx_size) = push_buffer
+            .get_pushing_transactions(101, MAX_PUSH_SIZE)
+            .unwrap();
         assert_eq!(push_transactions.len(), 0);
         assert_eq!(push_tx_size, 0);
 

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -107,6 +107,7 @@ impl Datatype for TransactionalDatatype {
     }
 
     fn sync(&self) -> Result<(), DatatypeError> {
+        self.check_disabled("sync")?;
         self.event_loop.send_push_transaction_with_guarantee()
     }
 
@@ -164,18 +165,30 @@ impl TransactionalDatatype {
     pub fn check_writable(&self) -> Result<(), DatatypeError> {
         use crate::errors::with_err_out;
 
+        let state = self.get_state();
+        if !state.is_read_writable() {
+            return Err(with_err_out!(DatatypeError::Disallowed(format!(
+                "Datatype '{}' cannot be modified for {:?} state",
+                self.attr.key, state
+            ))));
+        }
+
         if self.attr.is_readonly {
-            return Err(with_err_out!(DatatypeError::FailedToWrite(format!(
+            return Err(with_err_out!(DatatypeError::Disallowed(format!(
                 "Datatype '{}' is readonly",
                 self.attr.key
             ))));
         }
-        let state = self.get_state();
-        if !state.is_read_writable() {
-            return Err(with_err_out!(DatatypeError::FailedToWrite(format!(
-                "Datatype '{}' is not in writable state: {:?}",
-                self.attr.key, state
-            ))));
+
+        Ok(())
+    }
+
+    fn check_disabled(&self, op: &str) -> Result<(), DatatypeError> {
+        if self.mutable.read().get_state() == DatatypeState::Disabled {
+            return Err(DatatypeError::Disallowed(format!(
+                "{} is not allowed in Disabled state",
+                op
+            )));
         }
         Ok(())
     }

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -1,18 +1,21 @@
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use tracing::{error, instrument};
+use tracing::instrument;
 
 #[cfg(test)]
 use crate::datatypes::wired_interceptor::WiredInterceptor;
 use crate::{
-    DatatypeState,
+    DatatypeError, DatatypeState,
     datatypes::{
         common::Attribute, mutable::MutableDatatype, pull_handler::PullHandler,
         push_buffer::PushBuffer,
     },
     defaults,
-    errors::push_pull::ClientPushPullError,
+    errors::{
+        datatypes::{DatatypeAction, DatatypeErrorWithActions},
+        push_pull::ClientPushPullError,
+    },
     observability::macros::add_span_event,
     operations::transaction::Transaction,
     types::{push_pull_pack::PushPullPack, uid::Cuid},
@@ -57,23 +60,34 @@ impl WiredDatatype {
         self.interceptor.clone()
     }
 
-    pub fn push_if_needed(&self) {
+    pub fn push_if_needed(&self) -> bool {
         if !self.attr.client_common.connectivity.is_realtime() || !self.mutable.read().need_push() {
-            return;
+            return false;
         }
-        if let Err(e) = self.push_pull() {
-            error!("push_pull failed: {}", e);
+        true
+    }
+
+    pub fn handle_error(&self, _err: &DatatypeError, action: DatatypeAction) {
+        match action {
+            DatatypeAction::Normal => {}
+            DatatypeAction::Reset => {
+                self.mutable.write().reset();
+            }
+            DatatypeAction::Disable => self.mutable.write().disable(),
+            DatatypeAction::Recovery => {
+                self.mutable.write().do_rollback();
+            }
         }
     }
 
     #[instrument(skip_all)]
-    pub fn push_pull(&self) -> Result<(), ClientPushPullError> {
+    pub fn push_pull(&self) -> Result<(), DatatypeErrorWithActions> {
         let connectivity = &self.attr.client_common.connectivity;
 
         #[cfg_attr(not(test), allow(unused_mut))]
         let mut pushing_ppp = {
             let mut mutable = self.mutable.write();
-            mutable.create_push_pull_pack()?
+            mutable.create_push_pull_pack().map_err(|e| e.mapping())?
         };
 
         #[cfg(test)]
@@ -81,7 +95,9 @@ impl WiredDatatype {
 
         add_span_event!("send PUSH PushPullPack", "ppp"=> pushing_ppp.to_string());
         #[cfg_attr(not(test), allow(unused_mut))]
-        let mut pulled_ppp = connectivity.push_and_pull(&pushing_ppp)?;
+        let mut pulled_ppp = connectivity
+            .push_and_pull(&pushing_ppp)
+            .map_err(|e| e.mapping())?;
 
         #[cfg(test)]
         self.interceptor.after_pull(&mut pulled_ppp)?;
@@ -112,7 +128,7 @@ impl MutableDatatype {
     fn create_push_pull_pack(&mut self) -> Result<PushPullPack, ClientPushPullError> {
         let mut ppp = PushPullPack::new(&self.attr, self.get_state());
 
-        let (transactions, _tx_size) = self.push_buffer.get_after(
+        let (transactions, _tx_size) = self.push_buffer.get_pushing_transactions(
             self.checkpoint.cseq + 1,
             defaults::DEFAULT_MAX_TRANSMISSION_SIZE,
         )?;

--- a/src/datatypes/wired_interceptor.rs
+++ b/src/datatypes/wired_interceptor.rs
@@ -2,15 +2,15 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::{errors::push_pull::ClientPushPullError, types::push_pull_pack::PushPullPack};
+use crate::{errors::datatypes::DatatypeErrorWithActions, types::push_pull_pack::PushPullPack};
 
-pub type BeforePushFn = Box<dyn Fn(&mut PushPullPack) + Send + Sync + 'static>;
+pub type BeforePushFn = dyn Fn(&mut PushPullPack) + Send + Sync + 'static;
 pub type AfterPullFn =
-    Box<dyn Fn(&mut PushPullPack) -> Result<(), ClientPushPullError> + Send + Sync + 'static>;
+    dyn Fn(&mut PushPullPack) -> Result<(), DatatypeErrorWithActions> + Send + Sync + 'static;
 
 pub struct WiredInterceptor {
-    before_push: RwLock<BeforePushFn>,
-    after_pull: RwLock<AfterPullFn>,
+    before_push: RwLock<Box<BeforePushFn>>,
+    after_pull: RwLock<Box<AfterPullFn>>,
 }
 
 impl WiredInterceptor {
@@ -28,7 +28,7 @@ impl WiredInterceptor {
 
     pub fn set_after_pull(
         &self,
-        f: impl Fn(&mut PushPullPack) -> Result<(), ClientPushPullError> + Send + Sync + 'static,
+        f: impl Fn(&mut PushPullPack) -> Result<(), DatatypeErrorWithActions> + Send + Sync + 'static,
     ) -> &Self {
         *self.after_pull.write() = Box::new(f);
         self
@@ -38,7 +38,10 @@ impl WiredInterceptor {
         (self.before_push.read())(push)
     }
 
-    pub(crate) fn after_pull(&self, pull: &mut PushPullPack) -> Result<(), ClientPushPullError> {
+    pub(crate) fn after_pull(
+        &self,
+        pull: &mut PushPullPack,
+    ) -> Result<(), DatatypeErrorWithActions> {
         (self.after_pull.read())(pull)
     }
 }

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -7,3 +7,5 @@ pub(crate) const LOWER_MAX_MEM_SIZE_OF_PUSH_BUFFER: u64 = ByteUnit::MB.as_u64();
 pub(crate) const UPPER_MAX_MEM_SIZE_OF_PUSH_BUFFER: u64 = ByteUnit::GB.as_u64();
 
 pub(crate) const DEFAULT_MAX_TRANSMISSION_SIZE: u64 = 4 * ByteUnit::MB.as_u64();
+
+pub(crate) const DEFAULT_EVENT_LOOP_TIMEOUT_MS: u64 = 100;

--- a/src/errors/connectivity.rs
+++ b/src/errors/connectivity.rs
@@ -1,5 +1,10 @@
 use thiserror::Error;
 
+use crate::{
+    DatatypeError,
+    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
+};
+
 /// Errors related to connectivity operations.
 ///
 /// These errors occur when interacting with the underlying synchronization
@@ -9,7 +14,7 @@ use thiserror::Error;
 /// Two `ConnectivityError` values are considered equal if they have the same
 /// variant and message content.
 #[non_exhaustive]
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
 pub enum ConnectivityError {
     /// The requested resource was not found.
     ///
@@ -17,4 +22,16 @@ pub enum ConnectivityError {
     /// does not exist in the connectivity backend.
     #[error("[ConnectivityError] the demanded resource is not found: {_0}")]
     ResourceNotFound(String),
+}
+
+impl ConnectivityError {
+    pub(crate) fn mapping(self) -> DatatypeErrorWithActions {
+        match self {
+            ConnectivityError::ResourceNotFound(_) => DatatypeErrorWithActions::new(
+                DatatypeError::FailedInConnectivity(self),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Disable,
+            ),
+        }
+    }
 }

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -1,6 +1,9 @@
 use thiserror::Error;
 
-use crate::errors::{BoxedError, push_pull::ClientPushPullError};
+use crate::{
+    ConnectivityError,
+    errors::{BoxedError, push_pull::ClientPushPullError},
+};
 
 /// Errors that can occur while working with Qortoo datatypes.
 ///
@@ -16,8 +19,10 @@ use crate::errors::{BoxedError, push_pull::ClientPushPullError};
 #[repr(i32)]
 #[derive(Debug, Error)]
 pub enum DatatypeError {
-    #[error("[DatatypeError] failed to build datatype: {0}")]
-    FailedBuildDatatype(String) = 201,
+    #[error("[DatatypeError] failed to create datatype: {0}")]
+    FailedToCreate(String) = 200,
+    #[error("[DatatypeError] failed to create datatype: {0}")]
+    FailedInConnectivity(ConnectivityError) = 201,
     /// Transaction execution failed.
     ///
     /// Returned when a closure passed to `transaction` returns an error or when the
@@ -41,14 +46,47 @@ pub enum DatatypeError {
     FailedToExecuteOperation(String) = 204,
     #[error("[DatatypeError] failure in EventLoop")]
     FailedInEventLoop(BoxedError) = 205,
-    #[error("[DatatypeError] not allowed to write")]
-    FailedToWrite(String) = 206,
-    #[error("[DatatypeError] failed to sync: {0}")]
-    FailedToSync(ClientPushPullError) = 207,
+    #[error("[DatatypeError] disallowed to {0}")]
+    Disallowed(String) = 206,
+    #[error("[DatatypeError] failed to push and pull: {0}")]
+    FailedToPushPull(ClientPushPullError) = 207,
 }
 
 impl PartialEq for DatatypeError {
     fn eq(&self, other: &Self) -> bool {
         std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}
+
+pub enum EventLoopAction {
+    Normal,
+    BackOff,
+    PauseSync,
+}
+
+pub enum DatatypeAction {
+    Normal,
+    Reset,
+    Disable,
+    Recovery,
+}
+
+pub struct DatatypeErrorWithActions {
+    pub error: DatatypeError,
+    pub event_loop_action: EventLoopAction,
+    pub datatype_action: DatatypeAction,
+}
+
+impl DatatypeErrorWithActions {
+    pub fn new(
+        error: DatatypeError,
+        event_loop_action: EventLoopAction,
+        datatype_action: DatatypeAction,
+    ) -> Self {
+        DatatypeErrorWithActions {
+            error,
+            event_loop_action,
+            datatype_action,
+        }
     }
 }

--- a/src/errors/push_pull.rs
+++ b/src/errors/push_pull.rs
@@ -1,6 +1,9 @@
 use thiserror::Error;
 
-use crate::ConnectivityError;
+use crate::{
+    ConnectivityError, DatatypeError,
+    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
+};
 
 pub(crate) const CLIENT_PUSHPULL_ERR_MSG_NO_SNAPSHOT: &str = "no snapshot operation";
 
@@ -16,51 +19,73 @@ pub enum ServerPushPullError {
     FailedToSubscribe(String) = 303,
 }
 
+impl ServerPushPullError {
+    pub fn mapping(&self) -> DatatypeErrorWithActions {
+        match self {
+            ServerPushPullError::IllegalPushRequest(msg) => DatatypeErrorWithActions::new(
+                DatatypeError::FailedToCreate(msg.to_owned()),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Disable,
+            ),
+            ServerPushPullError::FailedToCreate(msg) => DatatypeErrorWithActions::new(
+                DatatypeError::FailedToCreate(msg.to_owned()),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Disable,
+            ),
+            ServerPushPullError::FailedToSubscribe(msg) => DatatypeErrorWithActions::new(
+                DatatypeError::FailedToCreate(msg.to_owned()),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Disable,
+            ),
+        }
+    }
+}
+
 impl PartialEq for ServerPushPullError {
     fn eq(&self, other: &Self) -> bool {
         std::mem::discriminant(self) == std::mem::discriminant(other)
     }
 }
 
-#[allow(dead_code)]
-pub enum CaseAfterPushPullError {
-    // The case that can be resolved with backoff retry
-    BackOff,
-    // The case that can be resolved by resetting the datatype
-    Reset,
-    // The case that any illegal case happens
-    Abort,
-}
-
 #[non_exhaustive]
-#[derive(Debug, PartialEq, Eq, Error)]
+#[derive(Debug, PartialEq, Eq, Error, Clone)]
 pub enum ClientPushPullError {
     #[error("[ClientPushPullError] pushBuffer exceeded max size of memory")]
     ExceedMaxMemSize,
-    #[error("[ClientPushPullError] an operation of nonsequential cseq is enqued into PushBuffer")]
+    #[error("[ClientPushPullError] an operation of nonsequential cseq is enqueued into PushBuffer")]
     NonSequentialCseq,
     #[error("[ClientPushPullError] failed to get after")]
-    FailToGetAfter,
+    FailToGetPushingTransactions,
     #[error("[ClientPushPullError] failed in Connectivity: {0}")]
     FailedInConnectivity(ConnectivityError),
-    #[error("[ClientPushPullError] failed and abort datatype: {0}")]
-    FailedAndAbort(String),
     #[error("[ClientPushPullError] failed with protocol violation: {0}")]
     FailedWithProtocolViolation(String),
 }
 
 impl ClientPushPullError {
-    #[allow(dead_code)]
-    fn how_to_deal_with_error(&self) -> CaseAfterPushPullError {
+    pub fn mapping(self) -> DatatypeErrorWithActions {
         match self {
             ClientPushPullError::ExceedMaxMemSize => todo!(),
-            ClientPushPullError::NonSequentialCseq => CaseAfterPushPullError::Abort,
-            ClientPushPullError::FailToGetAfter => CaseAfterPushPullError::Abort,
-            ClientPushPullError::FailedInConnectivity(_ce) => {
-                todo!();
-            }
-            ClientPushPullError::FailedAndAbort(_) => todo!(),
-            ClientPushPullError::FailedWithProtocolViolation(_) => todo!(),
+            ClientPushPullError::NonSequentialCseq => DatatypeErrorWithActions::new(
+                DatatypeError::FailedToPushPull(self),
+                EventLoopAction::Normal,
+                DatatypeAction::Recovery,
+            ),
+            ClientPushPullError::FailToGetPushingTransactions => DatatypeErrorWithActions::new(
+                DatatypeError::FailedToPushPull(self),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Disable,
+            ),
+            ClientPushPullError::FailedInConnectivity(_) => DatatypeErrorWithActions::new(
+                DatatypeError::FailedToPushPull(self),
+                EventLoopAction::BackOff,
+                DatatypeAction::Normal,
+            ),
+            ClientPushPullError::FailedWithProtocolViolation(_) => DatatypeErrorWithActions::new(
+                DatatypeError::FailedToPushPull(self),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Disable,
+            ),
         }
     }
 }

--- a/src/types/datatype.rs
+++ b/src/types/datatype.rs
@@ -131,8 +131,13 @@ impl DatatypeState {
 #[cfg(test)]
 mod tests_datatype {
     use rstest::rstest;
+    use tracing::instrument;
 
     use super::*;
+    use crate::{
+        Client, Datatype,
+        utils::path::{get_test_collection_name, get_test_func_name},
+    };
 
     #[test]
     fn can_display_data_types() {
@@ -147,11 +152,38 @@ mod tests_datatype {
     #[case::due_to_subscribe_or_create(DatatypeState::DueToSubscribeOrCreate, true)]
     #[case::due_to_subscribe(DatatypeState::DueToSubscribe, false)]
     #[case::disabled(DatatypeState::Disabled, false)]
-    fn can_check_accessiblity_of_datatype_state(
+    fn can_check_accessibility_of_datatype_state(
         #[case] state: DatatypeState,
         #[case] expected: bool,
     ) {
         assert_eq!(state.is_read_writable(), expected);
         assert_eq!(state.is_readonly(), !expected);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_not_write_when_readonly() {
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .build()
+            .unwrap();
+
+        // DueToCreate state allows writing
+        let counter1 = client.create_datatype("c1").build_counter().unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::DueToCreate);
+        assert!(counter1.increase().is_ok());
+
+        // DueToSubscribe state prevents writing (state-based)
+        let counter2 = client.subscribe_datatype("c2").build_counter().unwrap();
+        assert_eq!(counter2.get_state(), DatatypeState::DueToSubscribe);
+        assert!(counter2.increase().is_err());
+
+        // Explicit read-only flag prevents writing (flag-based)
+        let counter3 = client
+            .create_datatype("c3")
+            .with_readonly()
+            .build_counter()
+            .unwrap();
+        assert_eq!(counter3.get_state(), DatatypeState::DueToCreate);
+        assert!(counter3.increase().is_err()); // read-only despite writable state
     }
 }


### PR DESCRIPTION
- closed #9 
-   Introduce DatatypeErrorWithActions to carry EventLoopAction (Normal / BackOff / PauseSync) and DatatypeAction (Normal / Reset / Recovery / Disable) alongside each error, replacing the flat ClientPushPullError return type throughout the push/pull path.
- EventLoop now enters exponential backoff (500ms–30s, unlimited retries) on transient connectivity errors. During backoff only the unbounded channel is polled, so explicit sync() calls bypass the wait immediately. On success the backoff iterator is reset; on PauseSync the loop stops auto-retrying entirely.
- Also rename enque→enqueue, get_after→get_pushing_transactions,  FailToGetAfter→FailToGetPushingTransactions, and FailedToWrite/FailedToSync→Disallowed/FailedToPushPull for clarity.
- PauseSync was only preventing auto-retry but still allowed explicit sync() calls to reach push_pull(). Add an early-continue guard in the PushTransaction arm so all sync attempts are dropped while PauseSync is active.
- Also fix test: ExceedMaxMemSize should map to BackOff (not PauseSync), reduce backoff test timeout from 50s to 10s, add inline comments for clarity, and add a debug message to the local_connectivity todo!().

