### PR TITLE
🧬feat(datatypes): implement full sync lifecycle and harden error types

### DIFF
--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -182,7 +182,7 @@ mod tests_client {
     use crate::{
         Datatype, DatatypeState, LocalConnectivity,
         clients::client::Client,
-        utils::path::{get_test_collection_name, get_test_func_name},
+        utils::test_utils::{get_test_collection_name, get_test_func_name},
     };
 
     #[test]

--- a/src/clients/common.rs
+++ b/src/clients/common.rs
@@ -73,7 +73,7 @@ impl Drop for ClientCommon {
 #[cfg(test)]
 macro_rules! new_client_common {
     () => {{
-        let paths = crate::utils::path::caller_path!();
+        let paths = crate::utils::test_utils::caller_path!();
         crate::clients::common::ClientCommon::new_for_test(paths)
     }};
 }

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -172,7 +172,15 @@ impl Connectivity for LocalConnectivity {
             DatatypeState::DueToSubscribe => {
                 local_datatype_server.process_due_to_subscribe(pushed)?
             }
-            _ => todo!("TODO: {}", pushed.state),
+            DatatypeState::DueToSubscribeOrCreate => {
+                local_datatype_server.process_due_to_subscribe_or_create(pushed)?
+            }
+            DatatypeState::Subscribed => local_datatype_server.process_subscribe(pushed)?,
+            DatatypeState::DueToUnsubscribe => {
+                local_datatype_server.process_due_to_unsubscribe(pushed)?
+            }
+            DatatypeState::DueToDelete => local_datatype_server.process_due_to_delete(pushed)?,
+            DatatypeState::Disabled => local_datatype_server.process_disabled(pushed)?,
         };
         Ok(pulled)
     }
@@ -190,7 +198,7 @@ mod tests_local_connectivity {
 
     use crate::{
         Client, Datatype, DatatypeState, connectivity::local_connectivity::LocalConnectivity,
-        utils::path::get_test_collection_name,
+        utils::test_utils::get_test_collection_name,
     };
 
     #[test]

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -73,9 +73,11 @@ impl LocalDatatypeServer {
             if tx.cseq <= client_cp.cseq {
                 continue;
             }
-            self.history.push(tx.clone());
-            client_cp.cseq = tx.cseq;
             self.sseq += 1;
+            let mut owned_tx = (**tx).clone();
+            owned_tx.sseq = self.sseq;
+            self.history.push(Arc::new(owned_tx));
+            client_cp.cseq = tx.cseq;
         }
         client_cp.sseq = self.sseq;
         client_cp.cseq
@@ -92,21 +94,78 @@ impl LocalDatatypeServer {
             pulled.error = Some(ServerPushPullError::FailedToCreate(
                 "already exist".to_string(),
             ));
+            pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         }
         if pulled.is_readonly {
-            pulled.error = Some(ServerPushPullError::FailedToCreate(
+            pulled.error = Some(ServerPushPullError::IllegalPushRequest(
                 "readonly client cannot create datatype".to_string(),
             ));
+            pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         }
-        pulled.state = DatatypeState::DueToCreate;
         self.created = true;
         self.creator = pushed.cuid.clone();
         self.duid = pushed.duid.clone();
         let cseq = self.push_transactions(pushed);
         pulled.checkpoint.sseq = self.sseq;
         pulled.checkpoint.cseq = cseq;
+        pulled.state = DatatypeState::Subscribed;
+        Ok(pulled)
+    }
+
+    pub fn process_due_to_subscribe_or_create(
+        &mut self,
+        pushed: &PushPullPack,
+    ) -> Result<PushPullPack, ConnectivityError> {
+        if self.created {
+            self.process_due_to_subscribe(pushed)
+        } else {
+            self.process_due_to_create(pushed)
+        }
+    }
+
+    pub fn process_subscribe(
+        &mut self,
+        pushed: &PushPullPack,
+    ) -> Result<PushPullPack, ConnectivityError> {
+        let mut pulled = pushed.get_pulled_stub();
+        if pulled.is_readonly && !pushed.transactions.is_empty() {
+            pulled.error = Some(ServerPushPullError::IllegalPushRequest(
+                "readonly client cannot push transactions".to_string(),
+            ));
+            pulled.state = DatatypeState::Disabled;
+            return Ok(pulled);
+        }
+        let cseq = self.push_transactions(pushed);
+        pulled.checkpoint.sseq = pushed.checkpoint.sseq;
+        pulled.checkpoint.cseq = cseq;
+        self.pull_transactions(&mut pulled);
+        pulled.state = DatatypeState::Subscribed;
+        Ok(pulled)
+    }
+
+    pub fn process_due_to_unsubscribe(
+        &mut self,
+        pushed: &PushPullPack,
+    ) -> Result<PushPullPack, ConnectivityError> {
+        let pulled = pushed.get_pulled_stub();
+        Ok(pulled)
+    }
+
+    pub fn process_due_to_delete(
+        &mut self,
+        pushed: &PushPullPack,
+    ) -> Result<PushPullPack, ConnectivityError> {
+        let pulled = pushed.get_pulled_stub();
+        Ok(pulled)
+    }
+
+    pub fn process_disabled(
+        &mut self,
+        pushed: &PushPullPack,
+    ) -> Result<PushPullPack, ConnectivityError> {
+        let pulled = pushed.get_pulled_stub();
         Ok(pulled)
     }
 
@@ -121,6 +180,7 @@ impl LocalDatatypeServer {
                 pushed.r#type,
                 pushed.resource_id(),
             )));
+            pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         }
         if self.r#type != pushed.r#type {
@@ -130,23 +190,26 @@ impl LocalDatatypeServer {
                 pushed.r#type,
                 self.r#type,
             )));
+            pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         }
         if !pushed.transactions.is_empty() {
             pulled.error = Some(ServerPushPullError::IllegalPushRequest(
                 "cannot push transactions when subscribing".to_string(),
             ));
+            pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         }
 
         pulled.duid = self.duid.clone();
-        let creator_wired = self
+        let wired_of_creator = self
             .get_creator_wired_datatype()
             .ok_or(ConnectivityError::ResourceNotFound(pushed.resource_id()))?;
-        let tx = creator_wired.get_subscribe_snapshot();
+        let tx = wired_of_creator.get_subscribe_snapshot();
         pulled.checkpoint.sseq = tx.sseq;
         pulled.snapshot_transaction = Some(Arc::new(tx));
-        self.pull_transactions();
+        self.pull_transactions(&mut pulled);
+        pulled.state = DatatypeState::Subscribed;
         Ok(pulled)
     }
 
@@ -154,7 +217,15 @@ impl LocalDatatypeServer {
         self.wired_map.get(&self.creator).cloned()
     }
 
-    pub fn pull_transactions(&self) {}
+    pub fn pull_transactions(&self, pulled: &mut PushPullPack) {
+        let from_sseq = pulled.checkpoint.sseq;
+        for tx in &self.history {
+            if tx.sseq > from_sseq {
+                pulled.transactions.push(tx.clone());
+            }
+        }
+        pulled.checkpoint.sseq = self.sseq;
+    }
 
     #[cfg(test)]
     pub fn get_wired_datatype(&self, cuid: &Cuid) -> Option<Arc<WiredDatatype>> {
@@ -164,36 +235,95 @@ impl LocalDatatypeServer {
 
 #[cfg(test)]
 mod tests_local_datatype_server {
+    use std::sync::Arc;
 
+    use rstest::rstest;
     use tracing::{info, instrument};
 
     use crate::{
-        Client, Datatype, DatatypeError, DatatypeState,
+        Client, Counter, DataType, Datatype, DatatypeError, DatatypeState,
         connectivity::local_connectivity::LocalConnectivity,
         errors::{
             datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
-            push_pull::{ClientPushPullError, ServerPushPullError},
+            push_pull::ServerPushPullError,
         },
+        operations::transaction::Transaction,
         types::{checkpoint::CheckPoint, push_pull_pack::PushPullPack, uid::Duid},
-        utils::path::{get_test_collection_name, get_test_func_name},
+        utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
     };
+
+    fn push_no_change(_push: &mut PushPullPack) {}
+    fn push_set_readonly(push: &mut PushPullPack) {
+        push.is_readonly = true;
+    }
+    fn push_set_new_duid(push: &mut PushPullPack) {
+        push.duid = Duid::new();
+    }
+    fn push_set_variable_type(push: &mut PushPullPack) {
+        push.r#type = DataType::Variable;
+    }
+    fn push_add_transaction(push: &mut PushPullPack) {
+        push.transactions.push(Arc::new(Transaction::default()));
+    }
 
     fn assert_push_pull_pack(
         pulled: &PushPullPack,
         is_readonly: bool,
         cp: CheckPoint,
-        state: DatatypeState,
         error: Option<ServerPushPullError>,
+        tx_len: usize,
     ) {
         assert_eq!(pulled.is_readonly, is_readonly);
         assert_eq!(pulled.checkpoint, cp);
-        assert_eq!(pulled.state, state);
+        if error.is_some() {
+            assert_eq!(pulled.state, DatatypeState::Disabled);
+        } else {
+            assert_eq!(pulled.state, DatatypeState::Subscribed);
+        }
+
         assert_eq!(pulled.error, error);
+        assert_eq!(pulled.transactions.len(), tx_len);
     }
 
-    #[test]
+    fn make_create_error() -> DatatypeErrorWithActions {
+        DatatypeErrorWithActions::new(
+            DatatypeError::FailedToCreate("".to_owned()),
+            EventLoopAction::Normal,
+            DatatypeAction::Normal,
+        )
+    }
+
+    #[rstest]
+    #[case::readonly(
+        false,
+        push_set_readonly,
+        true,
+        Some(ServerPushPullError::IllegalPushRequest("".to_string())),
+        CheckPoint::new(0, 0),
+        false,
+        0,
+    )]
+    #[case::normal(false, push_no_change, false, None, CheckPoint::new(10, 10), true, 10)]
+    #[case::duplicate(true, push_no_change, false, None, CheckPoint::new(10, 10), true, 10)]
+    #[case::already_created(
+        true,
+        push_set_new_duid,
+        false,
+        Some(ServerPushPullError::FailedToCreate("already exist".to_string())),
+        CheckPoint::new(0, 0),
+        true,
+        10,
+    )]
     #[instrument]
-    fn can_process_due_to_create() {
+    fn can_process_due_to_create(
+        #[case] pre_create: bool,
+        #[case] modify_push: fn(&mut PushPullPack),
+        #[case] expected_is_readonly: bool,
+        #[case] expected_error: Option<ServerPushPullError>,
+        #[case] expected_cp: CheckPoint,
+        #[case] expected_created: bool,
+        #[case] expected_history_len: usize,
+    ) {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
         let resource_id = format!("{}/{}", get_test_collection_name!(), get_test_func_name!());
@@ -217,104 +347,78 @@ mod tests_local_datatype_server {
             .get_wired_interceptor(&resource_id, &client1.get_cuid())
             .unwrap();
 
-        // readonly client should fail
+        if pre_create {
+            wired_interceptor1
+                .set_before_push(|_push| {})
+                .set_after_pull(|_pull| Err(make_create_error()));
+            let _ = counter1.sync();
+            assert!(server.read().created);
+        }
+
+        let expected_error = Arc::new(expected_error);
+        let expected_error2 = expected_error.clone();
+
         wired_interceptor1
-            .set_before_push(|push| {
-                push.is_readonly = true;
+            .set_before_push(move |push| {
+                modify_push(push);
                 info!("PUSH:{push}");
             })
-            .set_after_pull(|pull| {
+            .set_after_pull(move |pull| {
                 info!("PULL:{pull}");
                 assert_push_pull_pack(
                     pull,
-                    true,
-                    CheckPoint::new(0, 0),
-                    DatatypeState::DueToCreate,
-                    Some(ServerPushPullError::FailedToCreate("".to_string())),
+                    expected_is_readonly,
+                    expected_cp,
+                    (*expected_error2).clone(),
+                    0,
                 );
-
-                Err(DatatypeErrorWithActions::new(
-                    DatatypeError::FailedToCreate("".to_owned()),
-                    EventLoopAction::Normal,
-                    DatatypeAction::Normal,
-                ))
-            });
-        assert!(counter1.sync().is_err());
-        assert!(!server.read().created);
-
-        // normal DUE_TO_CREATE case
-        wired_interceptor1
-            .set_before_push(|push| {
-                info!("PUSH:{push}");
-            })
-            .set_after_pull(|pull| {
-                info!("PULL:{pull}");
-                assert_push_pull_pack(
-                    pull,
-                    false,
-                    CheckPoint::new(10, 10),
-                    DatatypeState::DueToCreate,
-                    None,
-                );
-                Err(DatatypeErrorWithActions::new(
-                    DatatypeError::FailedToCreate("".to_owned()),
-                    EventLoopAction::Normal,
-                    DatatypeAction::Normal,
-                ))
-            });
-        assert!(counter1.sync().is_err());
-        assert!(server.read().created);
-        assert_eq!(server.read().history.len(), 10);
-
-        // duplicated DUE_TO_CREATE case
-        wired_interceptor1
-            .set_before_push(|push| {
-                assert_eq!(push.state, DatatypeState::DueToCreate);
-                info!("PUSH:{push}");
-            })
-            .set_after_pull(|pull| {
-                info!("PULL:{pull}");
-                assert_push_pull_pack(
-                    pull,
-                    false,
-                    CheckPoint::new(10, 10),
-                    DatatypeState::DueToCreate,
-                    None,
-                );
-                Err(ClientPushPullError::FailToGetPushingTransactions.mapping())
+                Ok(())
             });
 
-        assert!(counter1.sync().is_err());
-        assert!(server.read().created);
-        assert_eq!(server.read().history.len(), 10);
-
-        // already-created case
-        wired_interceptor1
-            .set_before_push(|push| {
-                push.duid = Duid::new();
-                info!("PUSH:{push}");
-            })
-            .set_after_pull(|pull| {
-                info!("PULL:{pull}");
-                assert_push_pull_pack(
-                    pull,
-                    false,
-                    CheckPoint::new(0, 0),
-                    DatatypeState::DueToCreate,
-                    Some(ServerPushPullError::FailedToCreate(
-                        "already exist".to_string(),
-                    )),
-                );
-                Err(ClientPushPullError::FailToGetPushingTransactions.mapping())
-            });
-        assert!(counter1.sync().is_err());
-        assert!(server.read().created);
+        let sync_result = counter1.sync();
+        if expected_error.is_some() {
+            assert!(matches!(
+                sync_result.unwrap_err(),
+                DatatypeError::FailedToCreate(_)
+            ));
+            // assert!(equal_errors!(&sync_result.unwrap_err(), &expected_error.unwrap()));
+            assert_eq!(counter1.get_state(), DatatypeState::Disabled);
+        } else {
+            assert!(sync_result.is_ok());
+            assert_eq!(counter1.get_state(), DatatypeState::Subscribed);
+        }
+        assert_eq!(server.read().created, expected_created);
+        assert_eq!(server.read().history.len(), expected_history_len);
         info!("{}", server.read());
     }
 
-    #[test]
+    #[rstest]
+    #[case::success(true, push_no_change, None, CheckPoint::new(5, 0))]
+    #[case::not_created(
+        false,
+        push_no_change,
+        Some(ServerPushPullError::FailedToSubscribe("".to_string())),
+        CheckPoint::new(0, 0),
+    )]
+    #[case::type_mismatch(
+        true,
+        push_set_variable_type,
+        Some(ServerPushPullError::FailedToSubscribe("".to_string())),
+        CheckPoint::new(0, 0),
+    )]
+    #[case::with_transactions(
+        true,
+        push_add_transaction,
+        Some(ServerPushPullError::IllegalPushRequest("".to_string())),
+        CheckPoint::new(0, 0),
+    )]
     #[instrument]
-    fn can_process_due_to_subscribe() {
+    fn can_process_due_to_subscribe(
+        #[case] creator_sync: bool,
+        #[case] modify_push: fn(&mut PushPullPack),
+        #[case] expected_error: Option<ServerPushPullError>,
+        #[case] expected_cp: CheckPoint,
+    ) {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
         let resource_id = format!("{}/{}", get_test_collection_name!(), get_test_func_name!());
@@ -332,8 +436,14 @@ mod tests_local_datatype_server {
             .create_datatype(get_test_func_name!())
             .build_counter()
             .unwrap();
-        let _ = counter1.increase_by(42);
-        assert!(counter1.sync().is_ok());
+        for i in 0..5 {
+            counter1.increase_by(i).unwrap();
+        }
+
+        if creator_sync {
+            assert!(counter1.sync().is_ok());
+            assert_eq!(counter1.get_state(), DatatypeState::Subscribed);
+        }
 
         let counter2 = client2
             .subscribe_datatype(get_test_func_name!())
@@ -342,25 +452,176 @@ mod tests_local_datatype_server {
         let interceptor2 = connectivity
             .get_wired_interceptor(&resource_id, &client2.get_cuid())
             .unwrap();
+
+        let expected_error = Arc::new(expected_error);
+        let expected_error2 = expected_error.clone();
+
         interceptor2
-            .set_before_push(|push| {
-                info!("{push}");
+            .set_before_push(move |push| {
+                modify_push(push);
+                info!("PUSH: {push}");
             })
-            .set_after_pull(|pull| {
-                info!("{pull}");
+            .set_after_pull(move |pull| {
+                info!("PULL: {pull}");
+                assert_push_pull_pack(pull, false, expected_cp, (*expected_error2).clone(), 0);
                 Ok(())
             });
-        assert!(counter2.sync().is_ok());
-        assert_eq!(counter1.get_value(), counter2.get_value());
 
-        assert_ne!(
-            counter1.get_attr().get_cuid(),
-            counter2.get_attr().get_cuid()
-        );
+        let sync_result = counter2.sync();
+        if expected_error.is_some() {
+            assert!(matches!(
+                sync_result.unwrap_err(),
+                DatatypeError::FailedToSubscribe(_)
+            ));
+            assert_eq!(counter2.get_state(), DatatypeState::Disabled);
+        } else {
+            assert!(sync_result.is_ok());
+            assert_eq!(counter1.get_value(), counter2.get_value());
+            assert_eq!(counter2.get_state(), DatatypeState::Subscribed);
+            assert_ne!(
+                counter1.get_attr().get_cuid(),
+                counter2.get_attr().get_cuid()
+            );
+            assert_eq!(
+                counter1.get_attr().get_duid(),
+                counter2.get_attr().get_duid()
+            );
+        }
+    }
 
-        assert_eq!(
-            counter1.get_attr().get_duid(),
-            counter2.get_attr().get_duid()
-        );
+    #[rstest]
+    #[case::normal(5, false, push_no_change, false, None, CheckPoint::new(10, 10), 5)]
+    #[case::readonly_with_transactions(
+        5,
+        false,
+        push_set_readonly,
+        true,
+        Some(ServerPushPullError::IllegalPushRequest("".to_string())),
+        CheckPoint::new(0, 0),
+        0,
+    )]
+    #[case::readonly_no_transactions(
+        0,
+        false,
+        push_set_readonly,
+        true,
+        None,
+        CheckPoint::new(5, 5),
+        0
+    )]
+    #[case::pull_from_another_client(
+        3,
+        true,
+        push_no_change,
+        false,
+        None,
+        CheckPoint::new(8, 0),
+        3
+    )]
+    #[instrument]
+    fn can_process_subscribe(
+        #[case] extra_ops: i64,
+        #[case] use_subscriber: bool,
+        #[case] modify_push: fn(&mut PushPullPack),
+        #[case] expected_is_readonly: bool,
+        #[case] expected_error: Option<ServerPushPullError>,
+        #[case] expected_cp: CheckPoint,
+        #[case] expected_tx_len: usize,
+    ) {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+
+        let client1 = Client::builder(collection.clone(), "client1")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter1 = client1
+            .subscribe_or_create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+        for i in 0..5 {
+            counter1.increase_by(i).unwrap();
+        }
+        assert!(counter1.sync().is_ok());
+        assert_eq!(counter1.get_state(), DatatypeState::Subscribed);
+
+        if use_subscriber {
+            let client2 = Client::builder(collection, "client2")
+                .with_connectivity(connectivity.clone())
+                .build()
+                .unwrap();
+            let counter2 = client2.subscribe_datatype(key).build_counter().unwrap();
+            assert!(counter2.sync().is_ok());
+            assert_eq!(counter2.get_state(), DatatypeState::Subscribed);
+
+            for i in 0..extra_ops {
+                counter1.increase_by(i).unwrap();
+            }
+            assert!(counter1.sync().is_ok());
+
+            let interceptor2 = connectivity
+                .get_wired_interceptor(&resource_id, &client2.get_cuid())
+                .unwrap();
+            let expected_error = Arc::new(expected_error);
+            let expected_error2 = expected_error.clone();
+            interceptor2
+                .set_before_push(move |push| {
+                    modify_push(push);
+                })
+                .set_after_pull(move |pull| {
+                    assert_push_pull_pack(
+                        pull,
+                        expected_is_readonly,
+                        expected_cp,
+                        (*expected_error2).clone(),
+                        expected_tx_len,
+                    );
+                    Ok(())
+                });
+            check_error(expected_error, &counter2);
+        } else {
+            for i in 0..extra_ops {
+                counter1.increase_by(i).unwrap();
+            }
+            let interceptor1 = connectivity
+                .get_wired_interceptor(&resource_id, &client1.get_cuid())
+                .unwrap();
+            let expected_error = Arc::new(expected_error);
+            let expected_error2 = expected_error.clone();
+            interceptor1
+                .set_before_push(move |push| {
+                    info!("PUSH: {push}");
+                    modify_push(push);
+                })
+                .set_after_pull(move |pull| {
+                    info!("PULL: {pull}");
+                    assert_push_pull_pack(
+                        pull,
+                        expected_is_readonly,
+                        expected_cp,
+                        (*expected_error2).clone(),
+                        expected_tx_len,
+                    );
+                    Ok(())
+                });
+            check_error(expected_error, &counter1);
+        }
+    }
+
+    fn check_error(expected_error: Arc<Option<ServerPushPullError>>, counter: &Counter) {
+        let sync_result = counter.sync();
+        if expected_error.is_some() {
+            assert_eq!(
+                sync_result.unwrap_err(),
+                DatatypeError::FailedByServerPushPullError(
+                    ServerPushPullError::IllegalPushRequest("".to_string())
+                )
+            );
+            assert_eq!(counter.get_state(), DatatypeState::Disabled);
+        } else {
+            assert!(sync_result.is_ok());
+            assert_eq!(counter.get_state(), DatatypeState::Subscribed);
+        }
     }
 }

--- a/src/connectivity/null_connectivity.rs
+++ b/src/connectivity/null_connectivity.rs
@@ -46,11 +46,10 @@ impl Connectivity for NullConnectivity {
                     );
                     return Ok(pulled);
                 }
-                pulled.state = DatatypeState::DueToCreate;
+                pulled.state = DatatypeState::Subscribed;
                 self.push_transaction(pushed, &mut pulled);
             }
             DatatypeState::DueToSubscribe => {
-                pulled.state = DatatypeState::DueToSubscribe;
                 if !pushed.transactions.is_empty() {
                     self.set_illegal_push_request(
                         &mut pulled,
@@ -58,6 +57,7 @@ impl Connectivity for NullConnectivity {
                     );
                     return Ok(pulled);
                 }
+                pulled.state = DatatypeState::Subscribed;
             }
             DatatypeState::Subscribed => {
                 pulled.state = DatatypeState::Subscribed;

--- a/src/datatypes/builder.rs
+++ b/src/datatypes/builder.rs
@@ -185,7 +185,7 @@ mod tests_datatype_builder {
 
     use crate::{
         Client, ClientError, Datatype, DatatypeError, DatatypeState,
-        utils::path::{get_test_collection_name, get_test_func_name},
+        utils::test_utils::{get_test_collection_name, get_test_func_name},
     };
 
     #[test]
@@ -217,17 +217,20 @@ mod tests_datatype_builder {
         assert_eq!(counter.get_value(), 0);
 
         // Write operations should fail
-        assert_eq!(
+        assert!(matches!(
             counter.increase().unwrap_err(),
-            DatatypeError::Disallowed("".into())
-        );
+            DatatypeError::Disallowed(_)
+        ));
 
         // Transaction should fail
         let tx_result = counter.transaction("test-tx", |c| {
             c.increase().unwrap();
             Ok(())
         });
-        assert_eq!(tx_result.unwrap_err(), DatatypeError::Disallowed("".into()));
+        assert!(matches!(
+            tx_result.unwrap_err(),
+            DatatypeError::Disallowed(_)
+        ));
         assert_eq!(counter.get_value(), 0);
     }
 
@@ -247,10 +250,10 @@ mod tests_datatype_builder {
             .build_counter()
             .unwrap();
         assert_eq!(counter.get_state(), DatatypeState::DueToSubscribe);
-        assert_eq!(
+        assert!(matches!(
             counter.increase().unwrap_err(),
-            DatatypeError::Disallowed("".into())
-        );
+            DatatypeError::Disallowed(_)
+        ));
 
         let counter = client
             .subscribe_or_create_datatype("subscribe_or_create_dt")

--- a/src/datatypes/common.rs
+++ b/src/datatypes/common.rs
@@ -156,7 +156,7 @@ impl Attribute {
 #[cfg(test)]
 macro_rules! new_attribute {
     ($enum_variant:path) => {{
-        let paths = crate::utils::path::caller_path!();
+        let paths = crate::utils::test_utils::caller_path!();
         crate::datatypes::common::Attribute::new_for_test(paths, $enum_variant)
     }};
 }
@@ -174,7 +174,7 @@ mod tests_attribute {
 
     use tracing::info;
 
-    use crate::{DataType, types::uid::Duid, utils::path::caller_path};
+    use crate::{DataType, types::uid::Duid, utils::test_utils::caller_path};
 
     #[test]
     fn can_new_attribute_for_test() {

--- a/src/datatypes/counter.rs
+++ b/src/datatypes/counter.rs
@@ -171,7 +171,7 @@ impl Counter {
             counter_clone.tx_ctx = this_tx_ctx_clone.clone();
             match tx_func(counter_clone) {
                 Ok(_) => Ok(()),
-                Err(e) => Err(DatatypeError::FailedTransaction(e)),
+                Err(e) => Err(DatatypeError::FailedTransaction(e.to_string())),
             }
         };
         self.datatype.do_transaction(this_tx_ctx, do_tx_func)
@@ -192,7 +192,7 @@ mod tests_counter {
     use crate::{
         DataType, DatatypeState,
         datatypes::{counter::Counter, datatype::Datatype},
-        utils::path::get_test_func_name,
+        utils::test_utils::get_test_func_name,
     };
 
     #[test]

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -54,7 +54,7 @@ pub trait Datatype {
     ///
     /// # Errors
     ///
-    /// Returns [`DatatypeError::FailedToPushPull`] if the synchronization fails.
+    /// Returns [`DatatypeError::FailedByClientPushPullError`] if the synchronization fails.
     ///
     /// # Examples
     ///
@@ -144,7 +144,7 @@ mod tests_datatype_trait {
             datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
             push_pull::ClientPushPullError,
         },
-        utils::path::{get_test_collection_name, get_test_func_name},
+        utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
     };
 
     #[test]
@@ -170,15 +170,13 @@ mod tests_datatype_trait {
     fn can_use_sync_method() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
-        let resource_id = format!("{}/{}", get_test_collection_name!(), get_test_func_name!());
-        let client1 = Client::builder(get_test_collection_name!(), get_test_collection_name!())
+        let (collection, key, resource_id) = get_test_ids!();
+
+        let client1 = Client::builder(collection, key.clone())
             .with_connectivity(connectivity.clone())
             .build()
             .unwrap();
-        let counter1 = client1
-            .create_datatype(get_test_func_name!())
-            .build_counter()
-            .unwrap();
+        let counter1 = client1.create_datatype(key).build_counter().unwrap();
 
         let interceptor1 = connectivity
             .get_wired_interceptor(&resource_id, &client1.get_cuid())
@@ -187,15 +185,15 @@ mod tests_datatype_trait {
         // produce push_pull error
         interceptor1.set_after_pull(|_pull| {
             Err(DatatypeErrorWithActions::new(
-                DatatypeError::FailedToPushPull(ClientPushPullError::ExceedMaxMemSize),
+                DatatypeError::FailedByClientPushPullError(ClientPushPullError::ExceedMaxMemSize),
                 EventLoopAction::BackOff,
-                DatatypeAction::Recovery,
+                DatatypeAction::Reset,
             ))
         });
 
         assert_eq!(
             counter1.sync().unwrap_err(),
-            DatatypeError::FailedToPushPull(ClientPushPullError::ExceedMaxMemSize)
+            DatatypeError::FailedByClientPushPullError(ClientPushPullError::ExceedMaxMemSize)
         );
         assert_eq!(counter1.get_state(), DatatypeState::DueToCreate);
 

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -61,7 +61,7 @@ impl EventLoop {
         })
     }
 
-    #[instrument(skip_all, name="datatype_event_loop", 
+    #[instrument(skip_all, name="datatype_event_loop",
         fields(
             qortoo.col=%wired.attr.client_common.collection,
             qortoo.cl=%wired.attr.client_common.alias,
@@ -99,40 +99,54 @@ impl EventLoop {
                                 }
                                 break;
                             }
-                            Event::PushTransaction(blocking_resp_tx) => {
+                            Event::PushTransaction(resp_tx) => {
                                 if matches!(event_loop_action, EventLoopAction::PauseSync) {
+                                    Self::process_blocking_resp(
+                                        resp_tx,
+                                        Some(DatatypeError::FailedInEventLoop(
+                                            "event loop paused".into(),
+                                        )),
+                                    );
                                     continue;
                                 }
-                                let response = match wired.push_pull() {
+                                let opt_datatype_error = match wired.push_pull() {
                                     Ok(_) => {
                                         event_loop_action = EventLoopAction::Normal;
                                         None
                                     }
                                     Err(dewa) => {
                                         event_loop_action = dewa.event_loop_action;
-                                        wired.handle_error(&dewa.error, dewa.datatype_action);
+                                        wired
+                                            .handle_error(dewa.error.clone(), dewa.datatype_action);
                                         Some(dewa.error)
                                     }
                                 };
                                 if !matches!(event_loop_action, EventLoopAction::BackOff) {
                                     backoff = None;
                                 }
-                                if let Some(sender) = blocking_resp_tx {
-                                    if sender.send(response).is_err() {
-                                        error!("failed to respond PushTransaction event");
-                                    }
-                                }
+                                Self::process_blocking_resp(resp_tx, opt_datatype_error);
                             }
                             Event::BackOff => {}
                         },
                         Err(err) => {
-                            wired.handle_error(&err, DatatypeAction::Disable);
+                            wired.handle_error(err, DatatypeAction::Disable);
                         }
                     }
                 }
                 add_span_event!("quiting event_loop");
             });
         });
+    }
+
+    fn process_blocking_resp(
+        blocking_resp_tx: Option<oneshot::Sender<Option<DatatypeError>>>,
+        opt_datatype_error: Option<DatatypeError>,
+    ) {
+        if let Some(sender) = blocking_resp_tx {
+            if sender.send(opt_datatype_error).is_err() {
+                error!("failed to respond PushTransaction event");
+            }
+        }
     }
 
     #[instrument(skip_all)]
@@ -158,8 +172,8 @@ impl EventLoop {
         }
 
         let map_err = |e, ch: &str| {
-            error!("{ch} channel error {e:?}; stopping event loop");
-            DatatypeError::FailedInEventLoop(Box::new(e))
+            let err_msg = format!("{ch} channel error {e:?}; stopping event loop");
+            with_err_out!(DatatypeError::FailedInEventLoop(err_msg))
         };
 
         if let Some(duration) = backoff_duration {
@@ -199,14 +213,14 @@ impl EventLoop {
     fn send_to_unbounded(&self, ev: Event) -> Result<(), DatatypeError> {
         self.unbounded_tx
             .try_send(ev)
-            .map_err(|e| with_err_out!(DatatypeError::FailedInEventLoop(Box::new(e))))
+            .map_err(|e| with_err_out!(DatatypeError::FailedInEventLoop(format!("{e:?}"))))
     }
 
     fn send_to_bounded(&self, ev: Event) -> Result<(), DatatypeError> {
         let ev_str = format!("{ev}");
         self.bounded_tx.try_send(ev).map_err(|e| {
             add_span_event!(ev_str, "result"=>"fail");
-            DatatypeError::FailedInEventLoop(Box::new(e))
+            DatatypeError::FailedInEventLoop(format!("{e:?}"))
         })?;
         add_span_event!(ev_str, "result"=>"succeed");
         Ok(())
@@ -227,9 +241,9 @@ impl EventLoop {
             match rx.await {
                 Ok(Some(err)) => Err(err),
                 Ok(None) => Ok(()),
-                Err(e) => Err(DatatypeError::FailedInEventLoop(
-                    format!("failed to receive response of sync(): {e}").into(),
-                )),
+                Err(e) => Err(DatatypeError::FailedInEventLoop(format!(
+                    "failed to receive response of sync(): {e}"
+                ))),
             }
         })
     }
@@ -252,7 +266,7 @@ mod tests_event_loop {
         connectivity::local_connectivity::LocalConnectivity,
         datatypes::datatype::Datatype,
         errors::{datatypes::DatatypeErrorWithActions, push_pull::ClientPushPullError},
-        utils::path::{get_test_collection_name, get_test_func_name},
+        utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
     };
 
     fn make_backoff_error() -> DatatypeErrorWithActions {
@@ -274,9 +288,7 @@ mod tests_event_loop {
     fn can_manually_retry_after_backoff_error() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
-        let collection = get_test_collection_name!();
-        let key = get_test_func_name!();
-        let resource_id = format!("{collection}/{key}");
+        let (collection, key, resource_id) = get_test_ids!();
         let client = Client::builder(collection, "client")
             .with_connectivity(connectivity.clone())
             .build()
@@ -291,7 +303,7 @@ mod tests_event_loop {
         interceptor.set_after_pull(|_| Err(make_backoff_error()));
 
         let err = counter.sync().unwrap_err();
-        assert!(matches!(err, DatatypeError::FailedToPushPull(_)));
+        assert!(matches!(err, DatatypeError::FailedByClientPushPullError(_)));
         // DatatypeAction::Normal → no state change
         assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
 
@@ -308,9 +320,7 @@ mod tests_event_loop {
     #[instrument]
     fn can_auto_retry_after_backoff_timeout() {
         let connectivity = LocalConnectivity::new_arc();
-        let collection = get_test_collection_name!();
-        let key = get_test_func_name!();
-        let resource_id = format!("{collection}/{key}");
+        let (collection, key, resource_id) = get_test_ids!();
 
         let client = Client::builder(collection, "client")
             .with_connectivity(connectivity.clone())
@@ -347,9 +357,8 @@ mod tests_event_loop {
     fn can_block_extra_retry_after_successful_manual_retry() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
-        let collection = get_test_collection_name!();
-        let key = get_test_func_name!();
-        let resource_id = format!("{collection}/{key}");
+        let (collection, key, resource_id) = get_test_ids!();
+
         let client = Client::builder(collection, "client")
             .with_connectivity(connectivity.clone())
             .build()
@@ -389,14 +398,13 @@ mod tests_event_loop {
     }
 
     /// Test that PauseSync + Disable transitions datatype to Disabled and
-    /// does not keep retrying automatically afterwards.
+    /// does not keep retrying automatically afterward.
     #[test]
     #[instrument]
     fn can_handle_pause_sync_error_without_auto_retry_loop() {
         let connectivity = LocalConnectivity::new_arc();
-        let collection = get_test_collection_name!();
-        let key = get_test_func_name!();
-        let resource_id = format!("{collection}/{key}");
+        let (collection, key, resource_id) = get_test_ids!();
+
         let client = Client::builder(collection, "client")
             .with_connectivity(connectivity.clone())
             .build()

--- a/src/datatypes/handler.rs
+++ b/src/datatypes/handler.rs
@@ -15,7 +15,7 @@ pub type OnStateChangeFn = Box<dyn Fn(DatatypeSet, DatatypeState, DatatypeState)
 /// Signature for an error handler.
 ///
 /// Receives: `(datatype_set, error)`
-pub type OnErrorFn = Box<dyn Fn(DatatypeSet, &DatatypeError) + Send + Sync>;
+pub type OnErrorFn = Box<dyn Fn(DatatypeSet, DatatypeError) + Send + Sync>;
 
 /// Holds per-datatype event handlers for state changes and errors.
 /// Default handlers are no-ops.
@@ -42,7 +42,7 @@ impl DatatypeHandler {
 
     pub fn set_on_error(
         mut self,
-        f: impl Fn(DatatypeSet, &DatatypeError) + Send + Sync + 'static,
+        f: impl Fn(DatatypeSet, DatatypeError) + Send + Sync + 'static,
     ) -> Self {
         self.on_error = Box::new(f);
         self
@@ -61,8 +61,7 @@ impl DatatypeHandler {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn notify_error(&self, datatype_set: DatatypeSet, error: &DatatypeError) {
+    pub(crate) fn notify_error(&self, datatype_set: DatatypeSet, error: DatatypeError) {
         if let Err(e) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             (self.on_error)(datatype_set, error)
         })) {
@@ -111,8 +110,10 @@ impl HandlersManager {
             .and_then(|arc| Arc::try_unwrap(arc).ok())
     }
 
-    #[instrument]
-    pub(crate) fn notify_state_change(&self, old_state: DatatypeState, new_state: DatatypeState) {
+    fn dispatch<F>(&self, event_name: &'static str, notify: F)
+    where
+        F: Fn(&DatatypeHandler, DatatypeSet) + Send + 'static,
+    {
         let rt_handle = self.attr.client_common.handle.clone();
         if let Some(ds) = self.attr.get_datatype_set() {
             let handlers: Vec<(usize, Arc<DatatypeHandler>)> =
@@ -121,12 +122,26 @@ impl HandlersManager {
             rt_handle.spawn(async move {
                 for (priority, handler) in handlers {
                     span.in_scope(|| {
-                        add_span_event!(format!("notify_state_change priority={priority}"));
-                        handler.notify_state_change(ds.clone(), old_state, new_state);
+                        add_span_event!(format!("{event_name} priority={priority}"));
+                        notify(&handler, ds.clone());
                     });
                 }
             });
         }
+    }
+
+    #[instrument]
+    pub(crate) fn notify_state_change(&self, old_state: DatatypeState, new_state: DatatypeState) {
+        self.dispatch("notify_state_change", move |handler, ds| {
+            handler.notify_state_change(ds, old_state, new_state);
+        });
+    }
+
+    #[instrument]
+    pub(crate) fn notify_error(&self, err: DatatypeError) {
+        self.dispatch("notify_error", move |handler, ds| {
+            handler.notify_error(ds, err.clone());
+        });
     }
 }
 
@@ -140,11 +155,11 @@ mod tests_handers_manager {
         time::Duration,
     };
 
-    use tracing::instrument;
+    use tracing::{info, instrument};
 
     use crate::{
-        Client, Datatype, DatatypeHandler, DatatypeState, LocalConnectivity,
-        utils::path::{get_test_collection_name, get_test_func_name},
+        Client, Datatype, DatatypeError, DatatypeHandler, DatatypeState, LocalConnectivity,
+        utils::test_utils::{get_test_collection_name, get_test_func_name},
     };
 
     #[test]
@@ -185,6 +200,53 @@ mod tests_handers_manager {
 
         counter.set_handler(0, handler1);
         counter.sync().unwrap();
+        awaitility::at_most(Duration::from_secs(2))
+            .poll_interval(Duration::from_micros(100))
+            .until(|| call_count.load(Ordering::Relaxed) == 2);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_notify_error() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let count_for_h1 = call_count.clone();
+        let count_for_h2 = call_count.clone();
+
+        let handler1 = DatatypeHandler::new().set_on_error(move |ds, err| {
+            info!("error1: {:?}", err);
+            assert!(matches!(err, DatatypeError::FailedToSubscribe(_)));
+            let a = count_for_h1.fetch_add(1, Ordering::Relaxed);
+            assert_eq!(a, 1);
+            assert_eq!(ds.get_state(), DatatypeState::Disabled);
+        });
+
+        let handler2 = DatatypeHandler::new().set_on_error(move |ds, err| {
+            info!("error2: {:?}", err);
+            assert!(matches!(err, DatatypeError::FailedToSubscribe(_)));
+            let a = count_for_h2.fetch_add(1, Ordering::Relaxed);
+            assert_eq!(a, 0);
+            assert_eq!(ds.get_state(), DatatypeState::Disabled);
+        });
+
+        let counter1 = client
+            .subscribe_datatype(get_test_func_name!())
+            .with_handler(1, handler1)
+            .with_handler(0, handler2)
+            .build_counter()
+            .unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::DueToSubscribe);
+        assert!(matches!(
+            counter1.sync().unwrap_err(),
+            DatatypeError::FailedToSubscribe(_)
+        ));
+        assert_eq!(counter1.get_state(), DatatypeState::Disabled);
         awaitility::at_most(Duration::from_secs(2))
             .poll_interval(Duration::from_micros(100))
             .until(|| call_count.load(Ordering::Relaxed) == 2);

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -203,4 +203,8 @@ impl MutableDatatype {
                 .notify_state_change(old_state, new_state);
         }
     }
+
+    pub fn call_error_handler(&self, err: DatatypeError) {
+        self.handlers_manager.notify_error(err)
+    }
 }

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -1,10 +1,14 @@
 use tracing::instrument;
 
 use crate::{
-    DatatypeState, datatypes::mutable::MutableDatatype,
-    errors::datatypes::DatatypeErrorWithActions, observability::macros::add_span_event,
+    DatatypeError, DatatypeState,
+    datatypes::mutable::MutableDatatype,
+    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
+    observability::macros::add_span_event,
     types::push_pull_pack::PushPullPack,
 };
+
+type PendingStep<'b> = fn(&mut PullHandler<'b>) -> Result<(), DatatypeErrorWithActions>;
 
 pub struct PullHandler<'a> {
     pulled_ppp: &'a mut PushPullPack,
@@ -12,6 +16,7 @@ pub struct PullHandler<'a> {
     old_state: DatatypeState,
     new_state: DatatypeState,
     is_created: bool,
+    pending_steps: Vec<PendingStep<'a>>,
 }
 
 impl<'a> PullHandler<'a> {
@@ -23,73 +28,99 @@ impl<'a> PullHandler<'a> {
             old_state,
             new_state: old_state,
             is_created: false,
+            pending_steps: Vec::new(),
         }
     }
 
     #[instrument(skip_all, name = "applyPull")]
     pub fn apply(&mut self) -> Result<(), DatatypeErrorWithActions> {
-        self.handle_error_and_datatype_state()?;
-        self.skip_duplicated_transactions()?;
-        self.execute_transactions()?;
-        self.sync_checkpoint()?;
+        let result = (|| -> Result<(), DatatypeErrorWithActions> {
+            self.handle_error_and_datatype_state()?;
+            self.skip_duplicated_transactions()?;
+            self.execute_transactions()?;
+            self.sync_checkpoint()?;
+            Ok(())
+        })();
         self.wrap_up()?;
-        Ok(())
+        result
+    }
+
+    fn process_illegal_state_response(
+        &self,
+        old: DatatypeState,
+        new: DatatypeState,
+    ) -> Result<(), DatatypeErrorWithActions> {
+        Err(DatatypeErrorWithActions::new(
+            DatatypeError::FailedByProtocolViolation(format!(
+                "illegal state from push-pull: received {new} for {old}"
+            )),
+            EventLoopAction::PauseSync,
+            DatatypeAction::Disable,
+        ))
     }
 
     fn handle_error_and_datatype_state(&mut self) -> Result<(), DatatypeErrorWithActions> {
+        self.new_state = self.pulled_ppp.state;
         if let Some(sppe) = self.pulled_ppp.error.as_ref() {
-            return Err(sppe.mapping());
+            return Err(sppe.mapping(self.old_state, self.pulled_ppp.state));
         }
 
         match self.old_state {
             DatatypeState::DueToCreate => {
-                if self.pulled_ppp.state == DatatypeState::DueToCreate {
-                    self.new_state = DatatypeState::Subscribed;
-                    self.is_created = true;
-                } else {
-                    // TODO: handle error
+                if self.pulled_ppp.state != DatatypeState::Subscribed {
+                    self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
+                self.is_created = true;
             }
             DatatypeState::DueToSubscribe => {
-                if self.pulled_ppp.state == DatatypeState::DueToSubscribe {
-                    self.new_state = DatatypeState::Subscribed;
-                    if let Some(snapshot_tx) = self.pulled_ppp.snapshot_transaction.take() {
-                        self.mutable
-                            .apply_snapshot_transaction(snapshot_tx)
-                            .map_err(|e| e.mapping())?;
-                    }
-                    self.mutable.attr.set_duid(self.pulled_ppp.duid.clone());
-                } else {
-                    // TODO: handle error
+                if self.pulled_ppp.state != DatatypeState::Subscribed {
+                    self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
+                self.enqueue_step(Self::apply_subscribe_response);
             }
             DatatypeState::DueToSubscribeOrCreate => {
-                if self.pulled_ppp.state == DatatypeState::DueToCreate {
-                    self.new_state = DatatypeState::Subscribed;
+                if self.pulled_ppp.state != DatatypeState::Subscribed {
+                    self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
+                }
+                if self.pulled_ppp.duid == self.mutable.attr.get_duid() {
                     self.is_created = true;
-                } else if self.pulled_ppp.state == DatatypeState::DueToSubscribe {
-                    self.new_state = DatatypeState::Subscribed;
                 } else {
-                    // TODO: handle error
+                    self.enqueue_step(Self::apply_subscribe_response);
                 }
             }
             DatatypeState::Subscribed => {
-                if self.pulled_ppp.state == DatatypeState::Subscribed {}
-                // TODO: Handle Subscribed state
+                if self.pulled_ppp.state != DatatypeState::Subscribed {
+                    self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
+                }
             }
             DatatypeState::DueToUnsubscribe => {
-                // TODO: Handle DueToUnsubscribe state
+                todo!()
             }
             DatatypeState::DueToDelete => {
-                // TODO: Handle DueToDelete state
+                todo!()
             }
             DatatypeState::Disabled => {
-                // TODO: Handle Disabled state
+                todo!()
             }
         }
+
         if self.new_state != self.old_state {
             add_span_event!("changeState", "old" => format!("{}", self.old_state), "new" => format!("{}", self.new_state));
         }
+        Ok(())
+    }
+
+    fn enqueue_step(&mut self, step: PendingStep<'a>) {
+        self.pending_steps.push(step);
+    }
+
+    fn apply_subscribe_response(&mut self) -> Result<(), DatatypeErrorWithActions> {
+        if let Some(snapshot_tx) = self.pulled_ppp.snapshot_transaction.take() {
+            self.mutable
+                .apply_snapshot_transaction(snapshot_tx)
+                .map_err(|e| e.mapping())?;
+        }
+        self.mutable.attr.set_duid(self.pulled_ppp.duid.clone());
         Ok(())
     }
 
@@ -111,6 +142,10 @@ impl<'a> PullHandler<'a> {
     }
 
     fn wrap_up(&mut self) -> Result<(), DatatypeErrorWithActions> {
+        let steps = std::mem::take(&mut self.pending_steps);
+        for step in steps {
+            step(self)?;
+        }
         self.mutable.set_state(self.new_state);
         Ok(())
     }
@@ -124,7 +159,7 @@ mod tests_push_handlers {
 
     use crate::{
         Client, Datatype, DatatypeState,
-        utils::path::{get_test_collection_name, get_test_func_name},
+        utils::test_utils::{get_test_collection_name, get_test_func_name},
     };
 
     #[test]

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -353,7 +353,7 @@ mod tests_transactional {
             transactional::{TransactionContext, TransactionalDatatype},
         },
         operations::Operation,
-        utils::path::{get_test_collection_name, get_test_func_name},
+        utils::test_utils::{get_test_collection_name, get_test_func_name},
     };
 
     #[test]

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -67,17 +67,20 @@ impl WiredDatatype {
         true
     }
 
-    pub fn handle_error(&self, _err: &DatatypeError, action: DatatypeAction) {
+    pub fn handle_error(&self, err: DatatypeError, action: DatatypeAction) {
         match action {
             DatatypeAction::Normal => {}
-            DatatypeAction::Reset => {
-                self.mutable.write().reset();
+            DatatypeAction::Restart => {
+                let mut mutable = self.mutable.write();
+                mutable.reset();
+                mutable.set_state(DatatypeState::DueToSubscribeOrCreate);
             }
             DatatypeAction::Disable => self.mutable.write().disable(),
-            DatatypeAction::Recovery => {
+            DatatypeAction::Reset => {
                 self.mutable.write().do_rollback();
             }
         }
+        self.mutable.read().call_error_handler(err);
     }
 
     #[instrument(skip_all)]

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -1,8 +1,8 @@
 use thiserror::Error;
 
 use crate::{
-    ConnectivityError,
-    errors::{BoxedError, push_pull::ClientPushPullError},
+    ConnectivityError, DatatypeState,
+    errors::push_pull::{ClientPushPullError, ServerPushPullError},
 };
 
 /// Errors that can occur while working with Qortoo datatypes.
@@ -17,46 +17,53 @@ use crate::{
 ///
 #[non_exhaustive]
 #[repr(i32)]
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
 pub enum DatatypeError {
-    #[error("[DatatypeError] failed to create datatype: {0}")]
-    FailedToCreate(String) = 200,
-    #[error("[DatatypeError] failed to create datatype: {0}")]
-    FailedInConnectivity(ConnectivityError) = 201,
     /// Transaction execution failed.
     ///
     /// Returned when a closure passed to `transaction` returns an error or when the
     /// transactional context cannot be committed. The datatype state is left unchanged
     /// if a rollback succeeds.
     #[error("[DatatypeError] failed to do transaction: {0}")]
-    FailedTransaction(BoxedError) = 202,
+    FailedTransaction(String) = 201,
     /// Deserialization from bytes failed.
     ///
     /// Returned when decoding a datatype, operation, or internal state from a byte
     /// sequence is not possible (e.g., invalid length, unexpected format, or version
     /// mismatch).
     #[error("[DatatypeError] failed to deserialize: {0}")]
-    FailedToDeserialize(String) = 203,
+    FailedToDeserialize(String) = 202,
     /// Applying a local operation failed.
     ///
     /// Returned when an operation cannot be executed in the current state (e.g.,
     /// unsupported operation kind, precondition violations, or internal invariants
     /// not satisfied).
     #[error("[DatatypeError] failed to execute operation: {0}")]
-    FailedToExecuteOperation(String) = 204,
+    FailedToExecuteOperation(String) = 203,
     #[error("[DatatypeError] failure in EventLoop")]
-    FailedInEventLoop(BoxedError) = 205,
+    FailedInEventLoop(String) = 204,
     #[error("[DatatypeError] disallowed to {0}")]
-    Disallowed(String) = 206,
-    #[error("[DatatypeError] failed to push and pull: {0}")]
-    FailedToPushPull(ClientPushPullError) = 207,
+    Disallowed(String) = 205,
+
+    #[error("[DatatypeError] failed in connectivity: {0}")]
+    FailedInConnectivity(ConnectivityError) = 210,
+    #[error("[DatatypeError] failed by client push-pull error: {0}")]
+    FailedByClientPushPullError(ClientPushPullError) = 211,
+    #[error("[DatatypeError] failed by server push-pull error: {0}")]
+    FailedByServerPushPullError(ServerPushPullError) = 212,
+    #[error("[DatatypeError] failed by protocol violation: {0}")]
+    FailedByProtocolViolation(String) = 213,
+    #[error("[DatatypeError] failed to create datatype: {0}")]
+    FailedToCreate(String) = 214,
+    #[error("[DatatypeError] failed to subscribe datatype: {0}")]
+    FailedToSubscribe(String) = 215,
 }
 
-impl PartialEq for DatatypeError {
-    fn eq(&self, other: &Self) -> bool {
-        std::mem::discriminant(self) == std::mem::discriminant(other)
-    }
-}
+// impl PartialEq for DatatypeError {
+//     fn eq(&self, other: &Self) -> bool {
+//         std::mem::discriminant(self) == std::mem::discriminant(other)
+//     }
+// }
 
 pub enum EventLoopAction {
     Normal,
@@ -64,11 +71,29 @@ pub enum EventLoopAction {
     PauseSync,
 }
 
+#[derive(Debug, PartialEq)]
 pub enum DatatypeAction {
     Normal,
-    Reset,
+    // set the datatype state to 'Due_To_SubscribeOrCreate' so that the datatype should restart sync.
+    Restart,
+    // set the datatype state to 'Disabled' so that the datatype should stop sync.
     Disable,
-    Recovery,
+    // set the datatype state to 'Subscribed' and reset the datatype with the snapshot sent by the server.
+    Reset,
+}
+
+impl From<DatatypeState> for DatatypeAction {
+    fn from(value: DatatypeState) -> Self {
+        match value {
+            DatatypeState::DueToCreate => DatatypeAction::Restart,
+            DatatypeState::DueToSubscribe => DatatypeAction::Restart,
+            DatatypeState::DueToSubscribeOrCreate => DatatypeAction::Restart,
+            DatatypeState::Subscribed => DatatypeAction::Normal,
+            DatatypeState::DueToUnsubscribe => DatatypeAction::Normal,
+            DatatypeState::DueToDelete => DatatypeAction::Normal,
+            DatatypeState::Disabled => DatatypeAction::Disable,
+        }
+    }
 }
 
 pub struct DatatypeErrorWithActions {
@@ -88,5 +113,28 @@ impl DatatypeErrorWithActions {
             event_loop_action,
             datatype_action,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests_datatypes {
+    use rstest::rstest;
+
+    use crate::{DatatypeState, errors::datatypes::DatatypeAction};
+
+    #[rstest]
+    #[case(DatatypeState::DueToCreate, DatatypeAction::Restart)]
+    #[case(DatatypeState::DueToSubscribe, DatatypeAction::Restart)]
+    #[case(DatatypeState::DueToSubscribeOrCreate, DatatypeAction::Restart)]
+    #[case(DatatypeState::Subscribed, DatatypeAction::Normal)]
+    #[case(DatatypeState::DueToUnsubscribe, DatatypeAction::Normal)]
+    #[case(DatatypeState::DueToDelete, DatatypeAction::Normal)]
+    #[case(DatatypeState::Disabled, DatatypeAction::Disable)]
+    fn can_convert_datatype_state_into_action(
+        #[case] state: DatatypeState,
+        #[case] expected_action: DatatypeAction,
+    ) {
+        let datatype_action: DatatypeAction = state.into();
+        assert_eq!(datatype_action, expected_action);
     }
 }

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -60,6 +60,14 @@ macro_rules! with_err_out {
     }};
 }
 
+#[cfg(test)]
+macro_rules! equal_errors {
+    ($err1:expr, $err2:expr) => {{ std::mem::discriminant($err1) == std::mem::discriminant($err2) }};
+}
+
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use equal_errors;
 pub(crate) use with_err_out;
 
 #[cfg(test)]
@@ -79,14 +87,17 @@ mod tests_datatype_errors {
 
     #[test]
     fn can_compare_errors() {
-        let source_err1 = Box::new(Error::new(ErrorKind::InvalidData, "source err1"));
-        let source_err2 = Box::new(Error::new(ErrorKind::InvalidInput, "source err2"));
-        let e1 = DatatypeError::FailedTransaction(source_err1);
-        let e2 = DatatypeError::FailedTransaction(source_err2);
-        assert_eq!(e1, e2);
-
+        let source_err1 = Error::new(ErrorKind::InvalidData, "source err1");
+        let source_err2 = Error::new(ErrorKind::InvalidInput, "source err2");
+        let e1 = DatatypeError::FailedTransaction(source_err1.to_string());
+        let e2 = DatatypeError::FailedTransaction(source_err2.to_string());
+        assert_ne!(e1, e2);
         let e3 = DatatypeError::FailedToDeserialize("e2".to_string());
         assert_ne!(e2, e3);
+        assert!(equal_errors!(&e1, &e2));
+        assert!(!equal_errors!(&e1, &e3));
+        let e4 = e3.clone();
+        assert_eq!(e3, e4);
     }
 
     #[test]
@@ -94,11 +105,11 @@ mod tests_datatype_errors {
         let d1 = with_err_out!(DatatypeError::FailedToDeserialize(
             "datatype error".to_owned()
         ));
-        let source_err1 = Box::new(Error::new(ErrorKind::InvalidInput, "source err1"));
-        let d2 = with_err_out!(DatatypeError::FailedTransaction(source_err1));
+        let source_err1 = Error::new(ErrorKind::InvalidInput, "source err1");
+        let d2 = with_err_out!(DatatypeError::FailedTransaction(source_err1.to_string()));
         assert_ne!(d1, d2);
         let c1 = with_err_out!(ClientError::FailedToSubscribeOrCreateDatatype(
-            "clients error".to_owned()
+            "clients error".into()
         ));
         let c2 = with_err_out!(ClientError::FailedToSubscribeOrCreateDatatype("".into()));
         assert_eq!(c1, c2);
@@ -106,7 +117,7 @@ mod tests_datatype_errors {
     }
 
     fn into_next_stack() {
-        let err = Box::new(TrySendError::Full(Event::PushTransaction(None)));
-        let _d3 = with_err_out!(DatatypeError::FailedInEventLoop(err));
+        let err = TrySendError::Full(Event::PushTransaction(None));
+        let _d3 = with_err_out!(DatatypeError::FailedInEventLoop(err.to_string()));
     }
 }

--- a/src/errors/push_pull.rs
+++ b/src/errors/push_pull.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 use crate::{
-    ConnectivityError, DatatypeError,
+    ConnectivityError, DatatypeError, DatatypeState,
     errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
 };
 
@@ -9,7 +9,7 @@ pub(crate) const CLIENT_PUSHPULL_ERR_MSG_NO_SNAPSHOT: &str = "no snapshot operat
 
 #[non_exhaustive]
 #[repr(i32)]
-#[derive(Debug, Error, Eq)]
+#[derive(Debug, Error /*PartialEq*/, Eq, Clone)]
 pub enum ServerPushPullError {
     #[error("[ServerPushPullError] illegal push request - {0}")]
     IllegalPushRequest(String) = 301,
@@ -20,22 +20,35 @@ pub enum ServerPushPullError {
 }
 
 impl ServerPushPullError {
-    pub fn mapping(&self) -> DatatypeErrorWithActions {
+    pub fn mapping(
+        &self,
+        old_state: DatatypeState,
+        new_state: DatatypeState,
+    ) -> DatatypeErrorWithActions {
         match self {
-            ServerPushPullError::IllegalPushRequest(msg) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedToCreate(msg.to_owned()),
-                EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
-            ),
+            ServerPushPullError::IllegalPushRequest(msg) => {
+                let data_err = match old_state {
+                    DatatypeState::DueToCreate => DatatypeError::FailedToCreate(msg.to_owned()),
+                    DatatypeState::DueToSubscribe => {
+                        DatatypeError::FailedToSubscribe(msg.to_owned())
+                    }
+                    _ => DatatypeError::FailedByServerPushPullError(self.clone()),
+                };
+                DatatypeErrorWithActions::new(
+                    data_err,
+                    EventLoopAction::PauseSync,
+                    new_state.into(),
+                )
+            }
             ServerPushPullError::FailedToCreate(msg) => DatatypeErrorWithActions::new(
                 DatatypeError::FailedToCreate(msg.to_owned()),
                 EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
+                new_state.into(),
             ),
             ServerPushPullError::FailedToSubscribe(msg) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedToCreate(msg.to_owned()),
+                DatatypeError::FailedToSubscribe(msg.to_owned()),
                 EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
+                new_state.into(),
             ),
         }
     }
@@ -48,7 +61,7 @@ impl PartialEq for ServerPushPullError {
 }
 
 #[non_exhaustive]
-#[derive(Debug, PartialEq, Eq, Error, Clone)]
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
 pub enum ClientPushPullError {
     #[error("[ClientPushPullError] pushBuffer exceeded max size of memory")]
     ExceedMaxMemSize,
@@ -67,22 +80,22 @@ impl ClientPushPullError {
         match self {
             ClientPushPullError::ExceedMaxMemSize => todo!(),
             ClientPushPullError::NonSequentialCseq => DatatypeErrorWithActions::new(
-                DatatypeError::FailedToPushPull(self),
+                DatatypeError::FailedByClientPushPullError(self),
                 EventLoopAction::Normal,
-                DatatypeAction::Recovery,
+                DatatypeAction::Reset,
             ),
             ClientPushPullError::FailToGetPushingTransactions => DatatypeErrorWithActions::new(
-                DatatypeError::FailedToPushPull(self),
+                DatatypeError::FailedByClientPushPullError(self),
                 EventLoopAction::PauseSync,
                 DatatypeAction::Disable,
             ),
             ClientPushPullError::FailedInConnectivity(_) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedToPushPull(self),
+                DatatypeError::FailedByClientPushPullError(self),
                 EventLoopAction::BackOff,
                 DatatypeAction::Normal,
             ),
             ClientPushPullError::FailedWithProtocolViolation(_) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedToPushPull(self),
+                DatatypeError::FailedByClientPushPullError(self),
                 EventLoopAction::PauseSync,
                 DatatypeAction::Disable,
             ),

--- a/src/operations/transaction.rs
+++ b/src/operations/transaction.rs
@@ -14,7 +14,7 @@ const TRANSACTION_CONSTANT_SIZE: u64 = (size_of::<Vec<Operation>>() // operation
     + size_of::<bool>())  // event
     as u64;
 
-#[derive(PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct Transaction {
     pub cuid: Cuid,
     pub cseq: u64,

--- a/src/types/datatype.rs
+++ b/src/types/datatype.rs
@@ -136,7 +136,7 @@ mod tests_datatype {
     use super::*;
     use crate::{
         Client, Datatype,
-        utils::path::{get_test_collection_name, get_test_func_name},
+        utils::test_utils::{get_test_collection_name, get_test_func_name},
     };
 
     #[test]

--- a/src/types/push_pull_pack.rs
+++ b/src/types/push_pull_pack.rs
@@ -79,15 +79,6 @@ impl PushPullPack {
             error: None,
         }
     }
-
-    #[cfg(test)]
-    pub fn add_test_transactions(&mut self, cuid: &Cuid, from_cseq: u64, tx_size: usize) {
-        for cseq in from_cseq..from_cseq + tx_size as u64 {
-            let tx = Transaction::new_arc_for_test(cuid, cseq);
-            self.transactions.push(tx);
-            self.checkpoint.cseq = cseq;
-        }
-    }
 }
 
 impl Display for PushPullPack {
@@ -110,7 +101,7 @@ impl Display for PushPullPack {
 
         write!(
             f,
-            "[{:?}/{}/{} {} {} tx:{} {}:{}:{} {}]",
+            "[{:?}/{}/{} {} {} tx:{} s{}:c{}:sf{} {}]",
             self.r#type,
             self.key,
             self.duid,

--- a/src/types/uid.rs
+++ b/src/types/uid.rs
@@ -109,7 +109,7 @@ mod tests_uid {
         let _cuid = Cuid::new();
         assert_ne!(_duid.to_string(), _cuid.to_string());
         let default_duid = Duid::default();
-        info!("{default_duid}");
+        info!("{default_duid} {default_duid:?}");
     }
 
     #[rstest]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod defer_guard;
 pub mod name_validator;
 pub mod no_guard_mutex;
-pub mod path;
 pub mod runtime;
+#[cfg(test)]
+pub mod test_utils;

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -1,35 +1,40 @@
-#[cfg(test)]
 pub fn split_module_path(mod_path: &str) -> std::collections::VecDeque<String> {
     mod_path.split("::").map(|s| s.to_string()).collect()
 }
 
-#[cfg(test)]
 macro_rules! caller_path {
     () => {{
         let line = std::panic::Location::caller().line();
-        let mut ret = crate::utils::path::split_module_path(module_path!());
+        let mut ret = crate::utils::test_utils::split_module_path(module_path!());
         let last = ret.pop_back().unwrap();
         ret.push_back(format!("{last}:{line}"));
-        let test_func_name = crate::utils::path::get_test_func_name!();
+        let test_func_name = crate::utils::test_utils::get_test_func_name!();
         ret.push_back(test_func_name);
         ret
     }};
 }
 
-#[cfg(test)]
 macro_rules! get_test_func_name {
     () => {{
         let thread_name = std::thread::current()
             .name()
             .unwrap_or("unknown")
             .to_string();
-        let mut ret = crate::utils::path::split_module_path(&thread_name);
+        let mut ret = crate::utils::test_utils::split_module_path(&thread_name);
         let last = ret.pop_back().unwrap();
         last
     }};
 }
 
-#[cfg(test)]
+macro_rules! get_test_ids {
+    () => {{
+        let c = get_test_collection_name!();
+        let k = get_test_func_name!();
+        let r = format!("{c}/{k}");
+        (c, k, r)
+    }};
+}
+
 macro_rules! get_test_collection_name {
     () => {{
         let thread_name = std::thread::current()
@@ -49,12 +54,10 @@ macro_rules! get_test_collection_name {
     }};
 }
 
-#[cfg(test)]
 pub(crate) use caller_path;
-#[cfg(test)]
 pub(crate) use get_test_collection_name;
-#[cfg(test)]
 pub(crate) use get_test_func_name;
+pub(crate) use get_test_ids;
 
 #[cfg(test)]
 mod tests_path {
@@ -65,7 +68,11 @@ mod tests_path {
         let collection_name = get_test_collection_name!();
         let document_key = get_test_func_name!();
         info!("{collection_name} AND {document_key}");
-        assert_eq!(collection_name, "utils-path-tests_path");
-        assert_eq!(document_key, "can_use_path_macros")
+        assert_eq!(collection_name, "utils-test_utils-tests_path");
+        assert_eq!(document_key, "can_use_path_macros");
+        let (c, d, r) = get_test_ids!();
+        assert_eq!(c, collection_name);
+        assert_eq!(d, document_key);
+        assert_eq!(r, format!("{c}/{d}"));
     }
 }


### PR DESCRIPTION
  - closed #10 
  - Replace BoxedError with String in DatatypeError to enable Clone/PartialEq/Eq
  - Add FailedToSubscribe, FailedByClientPushPullError, FailedByServerPushPullError variants
  - Add DatatypeAction::Restart and From<DatatypeState> for DatatypeAction
  - Implement LocalDatatypeServer handlers for all DatatypeState transitions (process_subscribe, process_due_to_subscribe_or_create, etc.)
  - Assign sseq on the server side when pushing transactions
  - Extract HandlersManager::dispatch helper to remove notify_* duplication
  - Change OnErrorFn to take owned DatatypeError
  - Rename utils/path.rs to utils/test_utils.rs and gate with #[cfg(test)]
  - Add get_test_ids!() macro and parametrize local_datatype_server tests with rstest