### PR TITLE
🪲fix(event_loop): replace rendezvous channel with capacity-1 to prevent dropped realtime pushes

### DIFF
--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -58,10 +58,12 @@ pub trait Datatype {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// use qortoo::{Client, Datatype, DatatypeState};
+    /// ```
+    /// use qortoo::{Client, Datatype, DatatypeState, LocalConnectivity};
     ///
-    /// let client = Client::builder("collection", "alias")
+    /// let connectivity = LocalConnectivity::new_arc();
+    /// connectivity.set_realtime(false);
+    /// let client = Client::builder("doc-example", "Datatype-sync")
     ///     .with_connectivity(connectivity)
     ///     .build()
     ///     .unwrap();

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -51,7 +51,7 @@ impl EventLoop {
 
     pub fn new_arc(connectivity: Arc<dyn Connectivity>) -> Arc<Self> {
         let (unbounded_tx, unbounded_rx) = crossbeam_channel::unbounded::<Event>();
-        let (bounded_tx, bounded_rx) = crossbeam_channel::bounded::<Event>(0);
+        let (bounded_tx, bounded_rx) = crossbeam_channel::bounded::<Event>(1);
         Arc::new(Self {
             connectivity,
             unbounded_rx,


### PR DESCRIPTION
    A race window existed where try_send on the bounded(0) rendezvous channel
    failed if the event loop hadn't yet entered select! — causing realtime
    operations to be silently dropped and never synced.

    Also fixes the Datatype::sync doc test which was previously marked ignore
    due to an undefined `connectivity` variable.