### PR TITLE
🧬feat(datatypes): implement remote transaction execution and pull handling

### DIFF
--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -220,7 +220,7 @@ impl LocalDatatypeServer {
     pub fn pull_transactions(&self, pulled: &mut PushPullPack) {
         let from_sseq = pulled.checkpoint.sseq;
         for tx in &self.history {
-            if tx.sseq > from_sseq {
+            if tx.sseq > from_sseq && tx.cuid != pulled.cuid {
                 pulled.transactions.push(tx.clone());
             }
         }
@@ -421,19 +421,19 @@ mod tests_local_datatype_server {
     ) {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
-        let resource_id = format!("{}/{}", get_test_collection_name!(), get_test_func_name!());
+        let (collection, key, resource_id) = get_test_ids!();
 
-        let client1 = Client::builder(get_test_collection_name!(), get_test_func_name!())
+        let client1 = Client::builder(collection.clone(), key.clone())
             .with_connectivity(connectivity.clone())
             .build()
             .unwrap();
-        let client2 = Client::builder(get_test_collection_name!(), get_test_func_name!())
+        let client2 = Client::builder(collection.clone(), key.clone())
             .with_connectivity(connectivity.clone())
             .build()
             .unwrap();
 
         let counter1 = client1
-            .create_datatype(get_test_func_name!())
+            .create_datatype(key.clone())
             .build_counter()
             .unwrap();
         for i in 0..5 {
@@ -446,7 +446,7 @@ mod tests_local_datatype_server {
         }
 
         let counter2 = client2
-            .subscribe_datatype(get_test_func_name!())
+            .subscribe_datatype(key.clone())
             .build_counter()
             .unwrap();
         let interceptor2 = connectivity
@@ -490,7 +490,7 @@ mod tests_local_datatype_server {
     }
 
     #[rstest]
-    #[case::normal(5, false, push_no_change, false, None, CheckPoint::new(10, 10), 5)]
+    #[case::normal(5, false, push_no_change, false, None, CheckPoint::new(10, 10), 0)]
     #[case::readonly_with_transactions(
         5,
         false,
@@ -623,5 +623,117 @@ mod tests_local_datatype_server {
             assert!(sync_result.is_ok());
             assert_eq!(counter.get_state(), DatatypeState::Subscribed);
         }
+    }
+
+    #[test]
+    #[instrument]
+    fn can_sync_bidirectionally_between_two_clients() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+
+        let client1 = Client::builder(collection.clone(), "client1-1")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let client2 = Client::builder(collection.clone(), "client1-2")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+
+        let counter1 = client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+
+        let interceptor1 = connectivity
+            .get_wired_interceptor(&resource_id, &client1.get_cuid())
+            .unwrap();
+        interceptor1
+            .set_before_push(|push| {
+                info!("counter1 PUSH:{push}");
+            })
+            .set_after_pull(|pull| {
+                info!("counter1 PULL:{pull}");
+                Ok(())
+            });
+
+        counter1.sync().unwrap();
+
+        let counter2 = client2
+            .subscribe_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+
+        let interceptor2 = connectivity
+            .get_wired_interceptor(&resource_id, &client2.get_cuid())
+            .unwrap();
+        interceptor2
+            .set_before_push(|push| {
+                info!("counter2 PUSH:{push}");
+            })
+            .set_after_pull(|pull| {
+                info!("counter2 PULL:{pull}");
+                Ok(())
+            });
+        counter2.sync().unwrap();
+
+        // === A: one-way convergence counter1 → counter2 ===
+        for i in 0..5 {
+            counter1.increase_by(i).unwrap();
+        }
+        // 0+1+2+3+4 = 10
+        let expected_after_a = 10;
+        assert_eq!(counter1.get_value(), expected_after_a);
+
+        counter1.sync().unwrap();
+        // counter1 must not re-apply its own transactions
+        assert_eq!(counter1.get_value(), expected_after_a);
+
+        counter2.sync().unwrap();
+        assert_eq!(counter2.get_value(), expected_after_a);
+        assert_eq!(counter1.get_value(), counter2.get_value());
+
+        // === B: reverse convergence counter2 → counter1 ===
+        counter2.increase_by(5).unwrap();
+        counter2.increase_by(5).unwrap();
+        let expected_after_b = expected_after_a + 10;
+
+        counter2.sync().unwrap();
+        assert_eq!(counter2.get_value(), expected_after_b);
+
+        counter1.sync().unwrap();
+        assert_eq!(counter1.get_value(), expected_after_b);
+
+        // === C: bidirectional convergence after concurrent writes ===
+        counter1.increase_by(3).unwrap();
+        counter2.increase_by(7).unwrap();
+        let expected_after_c = expected_after_b + 3 + 7;
+
+        counter1.sync().unwrap();
+        counter2.sync().unwrap();
+        counter1.sync().unwrap(); // counter1 fetches counter2's tx
+        assert_eq!(counter1.get_value(), expected_after_c);
+        assert_eq!(counter2.get_value(), expected_after_c);
+
+        // === D: checkpoint consistency and idempotent sync ===
+        // both clients must see the same server state
+        assert_eq!(counter1.get_server_version(), counter2.get_server_version());
+        // all local transactions of each client must be confirmed by the server
+        assert_eq!(
+            counter1.get_client_version(),
+            counter1.get_synced_client_version()
+        );
+        assert_eq!(
+            counter2.get_client_version(),
+            counter2.get_synced_client_version()
+        );
+
+        // repeated syncs must not change values (idempotent)
+        let value_before = counter1.get_value();
+        counter1.sync().unwrap();
+        counter2.sync().unwrap();
+        assert_eq!(counter1.get_value(), value_before);
+        assert_eq!(counter2.get_value(), value_before);
     }
 }

--- a/src/datatypes/crdts/counter_crdt.rs
+++ b/src/datatypes/crdts/counter_crdt.rs
@@ -21,7 +21,10 @@ impl CounterCrdt {
         self.value
     }
 
-    pub fn execute_local_operation(&mut self, op: &Operation) -> Result<ReturnType, DatatypeError> {
+    pub fn execute_common_operation(
+        &mut self,
+        op: &Operation,
+    ) -> Result<ReturnType, DatatypeError> {
         match op.body {
             OperationBody::CounterIncrease(ref body) => {
                 let ret = self.increase_by(body.delta);

--- a/src/datatypes/crdts/mod.rs
+++ b/src/datatypes/crdts/mod.rs
@@ -35,7 +35,25 @@ impl Crdt {
             }
         }
         match self {
-            Crdt::Counter(c) => c.execute_local_operation(op),
+            Crdt::Counter(c) => c.execute_common_operation(op),
+        }
+    }
+
+    pub fn execute_remote_operation(
+        &mut self,
+        op: &Operation,
+    ) -> Result<ReturnType, DatatypeError> {
+        #[cfg(test)]
+        {
+            if let OperationBody::Delay4Test(body) = &op.body {
+                return match body.run() {
+                    Ok(_) => Ok(ReturnType::None),
+                    Err(_) => Err(DatatypeError::FailedToExecuteOperation(format!("{body}"))),
+                };
+            }
+        }
+        match self {
+            Crdt::Counter(c) => c.execute_common_operation(op),
         }
     }
 

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -11,7 +11,10 @@ use crate::{
         push_buffer::{MemoryPushBuffer, PushBuffer},
         rollback::Rollback,
     },
-    errors::push_pull::{CLIENT_PUSHPULL_ERR_MSG_NO_SNAPSHOT, ClientPushPullError},
+    errors::{
+        push_pull::{CLIENT_PUSHPULL_ERR_MSG_NO_SNAPSHOT, ClientPushPullError},
+        with_err_out,
+    },
     operations::{Operation, body::OperationBody, transaction::Transaction},
     types::{checkpoint::CheckPoint, operation_id::OperationId},
 };
@@ -149,6 +152,20 @@ impl MutableDatatype {
                 // TODO: replay remote operation
             }
         }
+    }
+
+    pub fn execute_remote_transaction(
+        &mut self,
+        tx: Arc<Transaction>,
+    ) -> Result<(), DatatypeError> {
+        for op in tx.iter() {
+            self.op_id.lamport = self.op_id.lamport.max(op.lamport);
+            self.crdt.execute_remote_operation(op)?;
+            if let Err(e) = self.rollback.shadow_crdt.execute_remote_operation(op) {
+                with_err_out!(e);
+            }
+        }
+        Ok(())
     }
 
     #[instrument(skip_all)]

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -1,11 +1,11 @@
-use tracing::instrument;
+use tracing::{debug, instrument};
 
 use crate::{
     DatatypeError, DatatypeState,
     datatypes::mutable::MutableDatatype,
     errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
     observability::macros::add_span_event,
-    types::push_pull_pack::PushPullPack,
+    types::{checkpoint::CheckPoint, push_pull_pack::PushPullPack},
 };
 
 type PendingStep<'b> = fn(&mut PullHandler<'b>) -> Result<(), DatatypeErrorWithActions>;
@@ -17,6 +17,7 @@ pub struct PullHandler<'a> {
     new_state: DatatypeState,
     is_created: bool,
     pending_steps: Vec<PendingStep<'a>>,
+    skip: usize,
 }
 
 impl<'a> PullHandler<'a> {
@@ -29,6 +30,7 @@ impl<'a> PullHandler<'a> {
             new_state: old_state,
             is_created: false,
             pending_steps: Vec::new(),
+            skip: 0,
         }
     }
 
@@ -36,12 +38,12 @@ impl<'a> PullHandler<'a> {
     pub fn apply(&mut self) -> Result<(), DatatypeErrorWithActions> {
         let result = (|| -> Result<(), DatatypeErrorWithActions> {
             self.handle_error_and_datatype_state()?;
-            self.skip_duplicated_transactions()?;
-            self.execute_transactions()?;
-            self.sync_checkpoint()?;
+            self.enqueue_step(Self::skip_duplicated_transactions);
+            self.enqueue_step(Self::execute_transactions);
+            self.enqueue_step(Self::sync_checkpoint);
             Ok(())
         })();
-        self.wrap_up()?;
+        self.commit()?;
         result
     }
 
@@ -125,12 +127,27 @@ impl<'a> PullHandler<'a> {
     }
 
     fn skip_duplicated_transactions(&mut self) -> Result<(), DatatypeErrorWithActions> {
-        // TODO: skip duplicated transactions
+        let need_to_pull = self.calculate_pulling_transactions(&self.pulled_ppp.checkpoint);
+        let len_pulled_txs = self.pulled_ppp.transactions.len();
+        if len_pulled_txs > need_to_pull {
+            self.skip = len_pulled_txs - need_to_pull;
+            debug!("skip {} duplicated transactions", self.skip);
+        }
         Ok(())
     }
 
+    fn calculate_pulling_transactions(&self, new_cp: &CheckPoint) -> usize {
+        let old_cp = &self.mutable.checkpoint;
+        (new_cp.sseq - old_cp.sseq) as usize - (new_cp.cseq - old_cp.cseq) as usize
+    }
+
     fn execute_transactions(&mut self) -> Result<(), DatatypeErrorWithActions> {
-        // TODO: execute transactions
+        let transactions = self.pulled_ppp.transactions[self.skip..].to_vec();
+        for tx in transactions {
+            self.mutable.execute_remote_transaction(tx).map_err(|e| {
+                DatatypeErrorWithActions::new(e, EventLoopAction::Normal, DatatypeAction::Restart)
+            })?;
+        }
         Ok(())
     }
 
@@ -141,7 +158,7 @@ impl<'a> PullHandler<'a> {
         Ok(())
     }
 
-    fn wrap_up(&mut self) -> Result<(), DatatypeErrorWithActions> {
+    fn commit(&mut self) -> Result<(), DatatypeErrorWithActions> {
         let steps = std::mem::take(&mut self.pending_steps);
         for step in steps {
             step(self)?;

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -103,7 +103,7 @@ impl Datatype for TransactionalDatatype {
     }
 
     fn get_synced_client_version(&self) -> u64 {
-        self.mutable.read().op_id.cseq
+        self.mutable.read().checkpoint.cseq
     }
 
     fn sync(&self) -> Result<(), DatatypeError> {


### PR DESCRIPTION
  - Add execute_remote_transaction() to MutableDatatype: applies ops to both crdt and rollback.shadow_crdt; logs shadow failures via with_err_out!
  - Implement skip_duplicated_transactions and execute_transactions in PullHandler; remote tx failure triggers DatatypeAction::Restart
  - Fix pull_transactions in LocalDatatypeServer to filter out requester's own cuid, preventing clients from re-applying their own transactions
  - Add execute_remote_operation to Crdt; rename CounterCrdt method to execute_common_operation shared by local and remote paths
  - Fix get_synced_client_version to return checkpoint.cseq instead of op_id.cseq
  - Add can_sync_bidirectionally_between_two_clients test covering unidirectional, reverse, bidirectional convergence, and idempotent sync
