### PR TITLE
🧬feat(observability): add Prometheus-compatible metrics via metrics crate facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +274,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +296,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -415,6 +448,15 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -657,7 +699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -768,6 +810,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "metrics",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "rand",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628de41fe064cc3f0cf07f3d299ee3e73521adaff72278731d5c8cae3797873"
 dependencies = [
  "rand",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -901,6 +982,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1044,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1035,6 +1131,8 @@ dependencies = [
  "futures",
  "itoa",
  "libc 1.0.0-alpha.3",
+ "metrics",
+ "metrics-util",
  "nanoid",
  "once_cell",
  "opentelemetry",
@@ -1043,6 +1141,7 @@ dependencies = [
  "parking_lot",
  "regex",
  "rstest",
+ "serial_test",
  "strum_macros",
  "thiserror",
  "time",
@@ -1051,6 +1150,21 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ubyte",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc 0.2.184",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1067,6 +1181,16 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -1095,6 +1219,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1226,10 +1368,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "semver"
@@ -1292,6 +1449,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,6 +1497,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc 0.2.184",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -1757,6 +1946,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +2065,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ tracing-subscriber = { version = "^0.3.23", features = [
     "fmt",
     "env-filter",
 ], optional = true }
-opentelemetry_sdk = { version = "^0.31.0", optional = true }
-opentelemetry-otlp = { version = "^0.31.1", features = [
+opentelemetry_sdk = { version = "^0.31", optional = true }
+opentelemetry-otlp = { version = "^0.31", features = [
     "grpc-tonic",
 ], optional = true }
-ctor = { version = "0.10.0", optional = true }
+ctor = { version = "^0.10", optional = true }
 
 tracing = "^0.1.44"
 nanoid = "^0.5.0"
@@ -54,8 +54,11 @@ strum_macros = "^0.28.0"
 regex = "^1.12.3"
 dyn-fmt = "^0.4.3"
 backon = { version = "^1.6.0", default-features = false, features = ["tokio-sleep"] }
+metrics = "^0.24"
 
 [dev-dependencies]
 rstest = "^0.26.1"
 awaitility = "^0.4.1"
 tokio = { version = "^1.52.1", features = ["full", "test-util"] }
+metrics-util = { version = "0.20.1", features = ["debugging"] }
+serial_test = "^3.4"

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,220 @@
+# Observability
+
+## Overview
+
+Qortoo-rs provides two complementary observability pillars:
+
+| Pillar | Mechanism | Location |
+|--------|-----------|----------|
+| **Tracing** | OpenTelemetry spans and events (opt-in via `tracing` feature) | `src/observability/tracing_layer.rs` |
+| **Metrics** | `metrics` crate facade — Prometheus-compatible counters and histograms | `src/observability/metrics.rs` |
+
+Both follow a **facade pattern**: the library only calls a thin abstraction layer; the actual backend (Jaeger, Prometheus, etc.) is registered by the application at startup. No backend = zero runtime cost.
+
+---
+
+## Tracing
+
+### Enabling
+
+Tracing is disabled by default. Enable it with the `tracing` feature:
+
+```toml
+[dependencies]
+qortoo = { version = "...", features = ["tracing"] }
+```
+
+This pulls in `opentelemetry_sdk`, `opentelemetry-otlp`, and `tracing-subscriber`. Without the feature, the `tracing` facade calls compile to no-ops.
+
+### What is instrumented
+
+| Span | Trigger |
+|------|---------|
+| `datatype_event_loop` | Event loop lifetime per datatype |
+| `push_pull` | Each push/pull sync cycle |
+| `execute_local_operation` | Each local write |
+| `create_push_pull_pack` | Assembly of outgoing `PushPullPack` |
+
+Span events (via `add_span_event!`) annotate key moments within a span:
+
+```
+datatype_event_loop
+  ├── "start event_loop"
+  ├── "send PUSH PushPullPack"   (ppp = <serialized pack>)
+  ├── "recv PULL PushPullPack"
+  └── "quiting event_loop"
+```
+
+### Span fields
+
+Every datatype span carries these fields for filtering in Jaeger/Tempo:
+
+```
+qortoo.col   — collection name
+qortoo.cl    — client alias
+qortoo.cuid  — client unique ID
+qortoo.dt    — datatype key
+qortoo.duid  — datatype unique ID
+```
+
+### Running locally with Jaeger
+
+```shell
+make enable-jaeger          # starts Jaeger via docker-compose
+cargo test --all-features   # tests emit spans to Jaeger
+# open http://localhost:16686
+```
+
+---
+
+## Metrics
+
+### Design: facade pattern
+
+```
+Qortoo-rs (library)
+  └─ metrics::counter!("qortoo_sync_total", ...)   ← facade call
+       └─ [global recorder, set by application]
+            ├─ metrics-exporter-prometheus  (user's choice)
+            ├─ metrics-exporter-statsd
+            └─ no recorder → AtomicPtr no-op, zero cost
+```
+
+The `metrics` crate (`^0.24`) is always a dependency. Heavy exporters live in the application, not the library — no version conflicts, no forced backend.
+
+### Metric catalogue
+
+All metric names follow the Prometheus convention (`snake_case`, unit suffix).
+
+#### `qortoo_sync_total` — counter
+
+Counts every push/pull sync cycle.
+
+| Label | Values | Description |
+|-------|--------|-------------|
+| `collection` | string | Collection name |
+| `key` | string | Datatype key |
+| `type` | `Counter` / … | CRDT type |
+| `result` | `success` / `failure` | Outcome of the sync |
+
+```
+qortoo_sync_total{collection="orders",key="visits",type="Counter",result="success"} 42
+qortoo_sync_total{collection="orders",key="visits",type="Counter",result="failure"} 1
+```
+
+#### `qortoo_sync_duration_seconds` — histogram
+
+End-to-end latency of a single `push_pull()` call, in seconds. Includes both the connectivity round-trip and local state application.
+
+| Label | Values |
+|-------|--------|
+| `collection` | string |
+| `key` | string |
+| `type` | CRDT type |
+
+#### `qortoo_backoff_total` — counter
+
+Incremented on each recoverable connectivity failure that results in a `BackOff` action, including retries that fail while already in backoff. Useful for alerting on degraded connectivity.
+
+| Label | Values |
+|-------|--------|
+| `collection` | string |
+| `key` | string |
+| `type` | CRDT type |
+
+### Instrumentation points
+
+```
+WiredDatatype::push_pull()            ← records sync_total + sync_duration_seconds
+  └── do_push_pull()
+        └── connectivity.push_and_pull()
+
+EventLoop::run()  [PushTransaction error path]
+  └── if event_loop_action == BackOff  ← records backoff_total
+```
+
+### Connecting to Prometheus
+
+In the application, install a recorder once at startup:
+
+```toml
+# application Cargo.toml
+metrics-exporter-prometheus = "0.16"
+```
+
+```rust
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+fn main() {
+    // registers the global recorder; all metrics::counter!() calls route here
+    let handle = PrometheusBuilder::new()
+        .install_recorder()
+        .unwrap();
+
+    // expose /metrics endpoint (example with axum)
+    let app = axum::Router::new()
+        .route("/metrics", axum::routing::get(move || {
+            let body = handle.render();
+            async move { body }
+        }));
+    // ...
+}
+```
+
+The `/metrics` endpoint is then scraped by Prometheus:
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: qortoo-app
+    static_configs:
+      - targets: ['localhost:3000']
+    scrape_interval: 15s
+```
+
+### Testing metrics
+
+Unit and integration tests use `metrics-util`'s `DebuggingRecorder` — an in-memory recorder that captures metric values without any network or file I/O.
+
+```toml
+# dev-dependencies only
+metrics-util = { version = "^0.20", features = ["debugging"] }
+```
+
+```rust
+use metrics_util::debugging::DebuggingRecorder;
+
+let recorder = DebuggingRecorder::new();
+let snapshotter = recorder.snapshotter();
+recorder.install().unwrap();  // sets the global recorder for this process
+
+// ... trigger sync ...
+
+let snap = snapshotter.snapshot().into_vec();
+// inspect snap for expected counter/histogram values
+```
+
+**Important — metrics-util 0.20 semantics:**
+`snapshot()` resets (consumes) **all** registered metrics to zero — counters and histograms alike. This is a breaking change from 0.18 which only drained histograms.
+
+Consequences for test design:
+
+| Rule | Reason |
+|------|--------|
+| Call `snapshot()` exactly once per assertion group | Each call resets everything; two calls drain each other's values |
+| Mark metrics tests `#[serial_test::serial]` | Parallel tests share the global recorder; one test's snapshot resets another's counters |
+| Use `extract_counter!` on an already-drained vec | Avoids a second snapshot that would lose histogram samples |
+
+See `src/observability/metrics.rs` (`tests_metrics` module) for the full test pattern.
+
+---
+
+## Key Types Quick Reference
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `add_span_event!` | `src/observability/macros.rs` | Add an OpenTelemetry span event at the current tracing scope |
+| `metrics::emit_sync` | `src/observability/metrics.rs` | Emit `sync_total` + `sync_duration_seconds` for one push/pull |
+| `metrics::emit_backoff` | `src/observability/metrics.rs` | Emit `backoff_total` on BackOff entry |
+| `SYNC_TOTAL`, `BACKOFF_TOTAL`, … | `src/observability/metrics.rs` | Metric name constants (module-private; single source of truth within the module) |
+

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -15,7 +15,7 @@ use crate::{
         datatypes::{DatatypeAction, EventLoopAction},
         with_err_out,
     },
-    observability::macros::add_span_event,
+    observability::{macros::add_span_event, metrics},
 };
 
 const BACKOFF_MIN_DELAY: Duration = Duration::from_millis(500);
@@ -116,6 +116,9 @@ impl EventLoop {
                                     }
                                     Err(dewa) => {
                                         event_loop_action = dewa.event_loop_action;
+                                        if matches!(event_loop_action, EventLoopAction::BackOff) {
+                                            metrics::emit_backoff(&wired.attr);
+                                        }
                                         wired
                                             .handle_error(dewa.error.clone(), dewa.datatype_action);
                                         Some(dewa.error)

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -16,7 +16,7 @@ use crate::{
         datatypes::{DatatypeAction, DatatypeErrorWithActions},
         push_pull::ClientPushPullError,
     },
-    observability::macros::add_span_event,
+    observability::{macros::add_span_event, metrics},
     operations::transaction::Transaction,
     types::{push_pull_pack::PushPullPack, uid::Cuid},
 };
@@ -85,6 +85,13 @@ impl WiredDatatype {
 
     #[instrument(skip_all)]
     pub fn push_pull(&self) -> Result<(), DatatypeErrorWithActions> {
+        let start = std::time::Instant::now();
+        let result = self.do_push_pull();
+        metrics::emit_sync(&self.attr, result.is_ok(), start.elapsed());
+        result
+    }
+
+    fn do_push_pull(&self) -> Result<(), DatatypeErrorWithActions> {
         let connectivity = &self.attr.client_common.connectivity;
 
         #[cfg_attr(not(test), allow(unused_mut))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,5 +86,5 @@ pub(crate) mod utils;
 #[ctor::ctor]
 pub fn init_tracing_subscriber() {
     use tracing::level_filters::LevelFilter;
-    observability::tracing_for_test::init(LevelFilter::TRACE);
+    observability::subscriber::init(LevelFilter::TRACE);
 }

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -1,0 +1,179 @@
+use crate::datatypes::common::Attribute;
+
+// --- Metric name constants (Prometheus naming convention) ---
+
+const SYNC_TOTAL: &str = "qortoo_sync_total";
+const SYNC_DURATION_SECONDS: &str = "qortoo_sync_duration_seconds";
+const BACKOFF_TOTAL: &str = "qortoo_backoff_total";
+
+// --- Label key constants ---
+
+const LABEL_COLLECTION: &str = "collection";
+const LABEL_KEY: &str = "key";
+const LABEL_TYPE: &str = "type";
+const LABEL_RESULT: &str = "result";
+
+// --- Label value constants ---
+
+const RESULT_SUCCESS: &str = "success";
+const RESULT_FAILURE: &str = "failure";
+
+// --- Helper functions ---
+
+pub fn emit_sync(attr: &Attribute, success: bool, duration: std::time::Duration) {
+    let result = if success {
+        RESULT_SUCCESS
+    } else {
+        RESULT_FAILURE
+    };
+    let col = attr.client_common.collection.to_string();
+    let key = attr.key.to_string();
+    let dt = attr.r#type.to_string();
+    metrics::counter!(
+        SYNC_TOTAL,
+        LABEL_COLLECTION => col.clone(),
+        LABEL_KEY => key.clone(),
+        LABEL_TYPE => dt.clone(),
+        LABEL_RESULT => result,
+    )
+    .increment(1);
+    metrics::histogram!(
+        SYNC_DURATION_SECONDS,
+        LABEL_COLLECTION => col,
+        LABEL_KEY => key,
+        LABEL_TYPE => dt,
+    )
+    .record(duration.as_secs_f64());
+}
+
+pub fn emit_backoff(attr: &Attribute) {
+    metrics::counter!(
+        BACKOFF_TOTAL,
+        LABEL_COLLECTION => attr.client_common.collection.to_string(),
+        LABEL_KEY => attr.key.to_string(),
+        LABEL_TYPE => attr.r#type.to_string(),
+    )
+    .increment(1);
+}
+
+#[cfg(test)]
+mod tests_metrics {
+    use std::sync::OnceLock;
+
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+    use tracing::instrument;
+
+    use crate::{
+        Client, ConnectivityError,
+        connectivity::local_connectivity::LocalConnectivity,
+        datatypes::datatype::Datatype,
+        errors::push_pull::ClientPushPullError,
+        utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
+    };
+
+    static SNAPSHOTTER: OnceLock<Snapshotter> = OnceLock::new();
+
+    fn snapshotter() -> &'static Snapshotter {
+        SNAPSHOTTER.get_or_init(|| {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            let _ = recorder.install();
+            snapshotter
+        })
+    }
+
+    // snapshot() drains ALL registered metrics globally, not just the queried one.
+    macro_rules! drain {
+        ($s:expr) => {
+            $s.snapshot().into_vec()
+        };
+    }
+
+    macro_rules! extract_counter {
+        ($vec:expr, $name:expr, $lk:expr, $lv:expr) => {{
+            $vec.iter()
+                .filter(|(ck, _, _, _)| {
+                    ck.key().name() == $name
+                        && ck
+                            .key()
+                            .labels()
+                            .any(|l| l.key() == $lk && l.value() == $lv)
+                })
+                .map(|(_, _, _, v)| match v {
+                    DebugValue::Counter(n) => *n,
+                    _ => 0,
+                })
+                .sum::<u64>()
+        }};
+        ($vec:expr, $name:expr) => {{
+            $vec.iter()
+                .filter(|(ck, _, _, _)| ck.key().name() == $name)
+                .map(|(_, _, _, v)| match v {
+                    DebugValue::Counter(n) => *n,
+                    _ => 0,
+                })
+                .sum::<u64>()
+        }};
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[instrument]
+    fn can_record_sync_success() {
+        let s = snapshotter();
+        drain!(s);
+
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype("c").build_counter().unwrap();
+        counter.sync().unwrap();
+
+        let after = drain!(s);
+        assert!(
+            extract_counter!(after, "qortoo_sync_total", "result", "success") >= 1,
+            "sync_total[success] should be recorded"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[instrument]
+    fn can_record_sync_failure_and_backoff() {
+        let s = snapshotter();
+        let (collection, key, resource_id) = get_test_ids!();
+        drain!(s);
+
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let client = Client::builder(collection, "client")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype(key).build_counter().unwrap();
+
+        let interceptor = connectivity
+            .get_wired_interceptor(&resource_id, &client.get_cuid())
+            .unwrap();
+        interceptor.set_after_pull(|_| {
+            Err(
+                ClientPushPullError::FailedInConnectivity(ConnectivityError::ResourceNotFound(
+                    "injected".into(),
+                ))
+                .mapping(),
+            )
+        });
+
+        let _ = counter.sync();
+
+        let after = drain!(s);
+        assert!(
+            extract_counter!(after, "qortoo_sync_total", "result", "failure") >= 1,
+            "sync_total[failure] should be recorded"
+        );
+        assert!(
+            extract_counter!(after, "qortoo_backoff_total") >= 1,
+            "backoff_total should be recorded"
+        );
+    }
+}

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,7 +1,7 @@
 pub mod macros;
 pub mod metrics;
 #[cfg(feature = "tracing")]
-pub mod tracing_for_test;
+pub mod subscriber;
 #[cfg(feature = "tracing")]
 pub mod tracing_layer;
 #[cfg(feature = "tracing")]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,4 +1,5 @@
 pub mod macros;
+pub mod metrics;
 #[cfg(feature = "tracing")]
 pub mod tracing_for_test;
 #[cfg(feature = "tracing")]

--- a/src/observability/subscriber.rs
+++ b/src/observability/subscriber.rs
@@ -17,16 +17,18 @@ static PROVIDER: OnceLock<Mutex<SdkTracerProvider>> = OnceLock::new();
 static TRACING_INITIALIZED: OnceLock<()> = OnceLock::new();
 
 extern "C" fn shutdown_provider() {
-    let provider = PROVIDER.get().unwrap();
+    let Some(provider) = PROVIDER.get() else {
+        return;
+    };
     let provider = provider.lock();
 
     if let Err(e) = provider.shutdown() {
-        println!("failed to shutdown provider: {:?}", e);
+        println!("failed to shutdown SDK tracer provider: {:?}", e);
     }
 }
 
 pub fn init(level: LevelFilter) {
-    // Ensure initialization happens only once across all tests
+    // Ensure initialization happens only once across all ctor/test paths.
     TRACING_INITIALIZED.get_or_init(|| {
         init_once(level);
     });
@@ -34,59 +36,79 @@ pub fn init(level: LevelFilter) {
 
 fn init_once(level: LevelFilter) {
     let handle = get_or_init_runtime_handle("observability");
+    // tonic exporter init requires an active Tokio runtime context
+    let _enter = handle.enter();
+    if constants::is_otel_enabled() {
+        init_otel_subscriber(level);
+    } else {
+        init_local_subscriber(level);
+    }
+}
 
-    handle.block_on(async move {
-        if constants::is_otel_enabled() {
-            println!(
-                "Initialize open-telemetry tracing with service '{}' for '{}' level",
-                constants::get_agent(),
-                level
-            );
-            let exporter = SpanExporter::builder()
-                .with_tonic()
-                .with_protocol(Protocol::Grpc)
-                .build()
-                .expect("failed to create otlp exporter");
+fn init_otel_subscriber(level: LevelFilter) {
+    println!(
+        "Initialize open-telemetry tracing with service '{}' for '{}' level",
+        constants::get_agent(),
+        level
+    );
 
-            let provider = SdkTracerProvider::builder()
-                .with_batch_exporter(exporter)
-                .with_resource(
-                    Resource::builder()
-                        .with_service_name(constants::get_agent())
-                        .build(),
-                )
-                .build();
+    let provider = init_otel_provider();
+    let tracer = provider.tracer(constants::get_agent());
+    let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+    let filter = tracing_subscriber::EnvFilter::from_default_env()
+        .add_directive("qortoo=trace".parse().unwrap())
+        .add_directive("integration=trace".parse().unwrap());
 
-            PROVIDER
-                .set(Mutex::new(provider.clone()))
-                .expect("failed to set provider");
+    let subscriber = Registry::default()
+        .with(telemetry)
+        .with(filter)
+        .with(QortooTracingLayer { opt: Some(level) });
+    set_global_subscriber(subscriber);
+}
 
-            unsafe {
-                let _ = atexit(shutdown_provider);
-            }
+fn init_local_subscriber(level: LevelFilter) {
+    let subscriber = Registry::default().with(QortooTracingLayer { opt: Some(level) });
+    set_global_subscriber(subscriber);
+}
 
-            let tracer = provider.tracer(constants::get_agent());
-            let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-            let filter = tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("qortoo=trace".parse().unwrap())
-                .add_directive("integration=trace".parse().unwrap());
+fn init_otel_provider() -> SdkTracerProvider {
+    let exporter = SpanExporter::builder()
+        .with_tonic()
+        .with_protocol(Protocol::Grpc)
+        .build()
+        .expect("failed to create otlp exporter");
 
-            let subscriber = Registry::default()
-                .with(telemetry)
-                .with(filter)
-                .with(QortooTracingLayer { opt: Some(level) });
-            tracing::subscriber::set_global_default(subscriber)
-                .expect("failed to set global default subscriber");
-        } else {
-            let subscriber = Registry::default().with(QortooTracingLayer { opt: Some(level) });
-            tracing::subscriber::set_global_default(subscriber)
-                .expect("failed to set global default subscriber");
-        }
-    });
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(
+            Resource::builder()
+                .with_service_name(constants::get_agent())
+                .build(),
+        )
+        .build();
+
+    PROVIDER
+        .set(Mutex::new(provider.clone()))
+        .expect("failed to set provider");
+
+    unsafe {
+        let _ = atexit(shutdown_provider);
+    }
+
+    provider
+}
+
+fn set_global_subscriber<S>(subscriber: S)
+where
+    S: tracing::Subscriber + Send + Sync + 'static,
+{
+    // A host application may install its own global subscriber before this
+    // library ctor runs. In that case, leave the existing subscriber intact.
+    let _ = tracing::subscriber::set_global_default(subscriber);
 }
 
 #[cfg(test)]
-mod tests_tracing {
+mod tests_subscriber {
     use tracing::{Level, debug, error, info, instrument, span, trace, warn};
 
     #[derive(Debug)]

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -1,0 +1,107 @@
+mod tests_metrics {
+    use std::sync::OnceLock;
+
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+    use qortoo::{Client, Datatype};
+    use serial_test::serial;
+    use tracing::instrument;
+
+    static SNAPSHOTTER: OnceLock<Snapshotter> = OnceLock::new();
+
+    fn snapshotter() -> &'static Snapshotter {
+        SNAPSHOTTER.get_or_init(|| {
+            let recorder = DebuggingRecorder::new();
+            let snapshotter = recorder.snapshotter();
+            recorder.install().unwrap();
+            snapshotter
+        })
+    }
+
+    macro_rules! counter_val {
+        ($s:expr, $name:expr, $lk:expr, $lv:expr) => {{
+            $s.snapshot()
+                .into_vec()
+                .into_iter()
+                .filter(|(ck, _, _, _)| {
+                    ck.key().name() == $name
+                        && ck
+                            .key()
+                            .labels()
+                            .any(|l| l.key() == $lk && l.value() == $lv)
+                })
+                .map(|(_, _, _, v)| match v {
+                    DebugValue::Counter(n) => n,
+                    _ => 0,
+                })
+                .sum::<u64>()
+        }};
+    }
+
+    macro_rules! histogram_samples {
+        ($snap_vec:expr, $name:expr) => {{
+            $snap_vec
+                .into_iter()
+                .filter(|(ck, _, _, _)| ck.key().name() == $name)
+                .map(|(_, _, _, v)| match v {
+                    DebugValue::Histogram(xs) => xs.len(),
+                    _ => 0,
+                })
+                .sum::<usize>()
+        }};
+    }
+
+    #[test]
+    #[serial]
+    #[instrument]
+    fn can_record_sync_success_metrics() {
+        let s = snapshotter();
+        let base_ok = counter_val!(s, "qortoo_sync_total", "result", "success");
+
+        let client = Client::builder("metrics-test", "can_record_sync_success_metrics")
+            .build()
+            .unwrap();
+        let counter = client.create_datatype("c1").build_counter().unwrap();
+        counter.sync().unwrap();
+
+        let after = s.snapshot().into_vec();
+        let after_ok: u64 = after
+            .iter()
+            .filter(|(ck, _, _, _)| {
+                ck.key().name() == "qortoo_sync_total"
+                    && ck
+                        .key()
+                        .labels()
+                        .any(|l| l.key() == "result" && l.value() == "success")
+            })
+            .map(|(_, _, _, v)| match v {
+                DebugValue::Counter(n) => *n,
+                _ => 0,
+            })
+            .sum();
+        let after_fail: u64 = after
+            .iter()
+            .filter(|(ck, _, _, _)| {
+                ck.key().name() == "qortoo_sync_total"
+                    && ck
+                        .key()
+                        .labels()
+                        .any(|l| l.key() == "result" && l.value() == "failure")
+            })
+            .map(|(_, _, _, v)| match v {
+                DebugValue::Counter(n) => *n,
+                _ => 0,
+            })
+            .sum();
+        let dur_samples = histogram_samples!(after, "qortoo_sync_duration_seconds");
+
+        assert!(after_ok > base_ok, "sync_total[success] should increase");
+        assert!(
+            dur_samples >= 1,
+            "sync_duration_seconds should have at least one sample"
+        );
+        assert_eq!(
+            after_fail, 0,
+            "NullConnectivity always succeeds — no failure metric expected"
+        );
+    }
+}


### PR DESCRIPTION
🧬feat(observability): add Prometheus-compatible metrics via metrics crate facade

- Instrument push_pull() and the event loop with three metrics: qortoo_sync_total (counter), qortoo_sync_duration_seconds (histogram), and qortoo_backoff_total (counter). 
- Uses the metrics crate facade so applications can plug in any backend (Prometheus, StatsD, etc.) without imposing a hard dependency. Adds unit + integration tests with 
- DebuggingRecorder and serial_test for global-recorder isolation.
- Includes docs/observability.md covering both tracing and metrics pillars.

💄refactor(observability): rename tracing_for_test to subscriber with robustness fixes

- Replace block_on(async move) with handle.enter() for clearer Tokio runtime context entry during subscriber init. Guard shutdown_provider against panic by returning early if PROVIDER is unset instead of unwrapping.