### PR TITLE
🧬feat(connectivity): add realtime cross-client notification via Event::Notify

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign assignee and request reviewers
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_REVIEWERS: ${{ vars.PR_REVIEWERS }}
           PR_TEAM_REVIEWERS: ${{ vars.PR_TEAM_REVIEWERS }}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,8 @@ Each datatype is composed of five layers stacked vertically. A user operation pa
 └────────────────────────────────────────────────────┘
 ```
 
+> For event loop internals (channel architecture, BackOff, Notify flow) see [`docs/event-loop.md`](event-loop.md).
+
 ### Layer Responsibilities
 
 | Layer | Struct | Key Responsibility |
@@ -35,7 +37,7 @@ Each datatype is composed of five layers stacked vertically. A user operation pa
 | Public API | `Counter`, etc. | User-facing methods; implements `DatatypeBlanket` |
 | Transactional | `TransactionalDatatype` | Transaction scope via `TransactionContext` and `DeferGuard`; serializes concurrent ops via `op_mutex` / `tx_mutex` |
 | Mutable | `MutableDatatype` | Owns `Crdt`, `OperationId`, `PushBuffer`, `TxRecord`; executes and records operations |
-| Wired | `WiredDatatype` | Assembles `PushPullPack` and calls `Connectivity::push_and_pull`; drives the event loop |
+| Wired | `WiredDatatype` | Assembles `PushPullPack` and calls `Connectivity::push_pull`; drives the event loop |
 | CRDT | `CounterCrdt`, … | Pure state machine; no I/O, no locking |
 
 ## Shared State Model
@@ -87,7 +89,7 @@ EventLoop fires PushTransaction event
   ▼
 WiredDatatype::push_pull()
   ├── mutable.read() → assemble PushPullPack (push_buffer contents)
-  ├── connectivity.push_and_pull(&pack)
+  ├── connectivity.push_pull(&pack)
   ├── mutable.write() → apply pulled transactions
   │    ├── execute_remote_transaction() for each remote tx
   │    └── push_buffer.deque(acked_cseq)

--- a/docs/event-loop.md
+++ b/docs/event-loop.md
@@ -1,0 +1,238 @@
+# Event Loop
+
+## Overview
+
+Each datatype instance owns a dedicated `EventLoop`. It runs on a `spawn_blocking` thread and is responsible for:
+- Triggering push/pull sync after local writes complete
+- Reacting to server-side realtime notifications
+- Managing exponential backoff on transient errors
+
+```
+┌─────────────────────────────────────────────────┐
+│  TransactionalDatatype / Public API             │
+│  (counter.increase(), counter.sync())           │
+└──────────────────┬──────────────────────────────┘
+                   │ send Event
+        ┌──────────▼──────────┐
+        │     EventLoop       │  ← spawn_blocking thread
+        │  (run loop)         │
+        └──────────┬──────────┘
+                   │ push_pull()
+        ┌──────────▼──────────┐
+        │   WiredDatatype     │
+        └──────────┬──────────┘
+                   │ push_pull()
+        ┌──────────▼──────────┐
+        │   Connectivity      │  ← LocalConnectivity / NullConnectivity / ...
+        └─────────────────────┘
+```
+
+---
+
+## Channel Architecture
+
+The event loop receives events through two crossbeam channels.
+
+```
+                  ┌─────────────────┐
+                  │   EventLoop     │
+                  │                 │
+  unbounded_tx ──►│  unbounded_rx   │  capacity: unlimited
+                  │                 │
+    bounded_tx ──►│    bounded_rx   │  capacity: 1
+                  └─────────────────┘
+```
+
+| Channel | Purpose | Behavior |
+|---------|---------|----------|
+| `unbounded` | `Stop`, explicit `sync()`, `Notify` | Always polled; read even during BackOff |
+| `bounded` | Realtime auto-push, Notify-triggered push | Capacity=1; silently dropped if already queued |
+
+The `unbounded_tx` registered via `connectivity.register(wired, unbounded_tx)` is the handle the server uses to send `Notify` events to this client.
+
+---
+
+## Event Types
+
+```rust
+pub enum Event {
+    Stop(Sender<()>),                              // Shut down the event loop (includes ack channel)
+    PushTransaction(Option<oneshot::Sender<...>>), // Request push/pull (response channel optional)
+    BackOff,                                       // BackOff timer expired (internal signal)
+    Notify(Notification),                          // Realtime notification from the server
+}
+```
+
+`PushTransaction` response channel (`resp_tx`):
+- `Some(tx)` — sent by `sync()`; blocks caller until complete, returns error if any
+- `None` — sent by realtime auto-push or Notify-triggered push; result is discarded
+
+---
+
+## EventLoopAction States
+
+The event loop tracks its current sync policy via `EventLoopAction`.
+
+```
+            sync succeeds
+  ┌──────────────────────────────────────────┐
+  │                                          │
+  ▼       error: BackOff              error: PauseSync
+Normal ──────────────────► BackOff      ──► PauseSync
+  ▲                          │
+  │   BackOff timer expires  │
+  └──────────────────────────┘
+  ▲        or explicit sync() succeeds
+  └──────────────────────────────────────────┘
+```
+
+| State | Behavior |
+|-------|----------|
+| `Normal` | Auto-push allowed; both channels polled |
+| `BackOff` | Auto-push blocked; only `unbounded_rx` polled; retries after timeout |
+| `PauseSync` | Auto-push blocked; any `PushTransaction` immediately returns an error |
+
+---
+
+## receive_event Logic
+
+`receive_event` is called at the start of every loop iteration.
+
+```
+receive_event()
+  │
+  ├── [Normal] push_if_needed && wired.push_if_needed()
+  │     → return Ok(Event::PushTransaction(None))   ← auto-push trigger
+  │
+  ├── [BackOff] compute next backoff duration
+  │     crossbeam select! {
+  │       recv(unbounded_rx) → handle immediately (Stop, explicit sync, Notify)
+  │       default(duration)  → timer expired → return Ok(Event::BackOff)
+  │     }
+  │
+  └── [Normal / PauseSync] no timeout
+        crossbeam select! {
+          recv(unbounded_rx) → handle
+          recv(bounded_rx)   → handle
+        }
+```
+
+`push_if_needed()` returns `true` only when `is_realtime() && need_push()`. This prevents auto-push from firing in manual sync mode.
+
+---
+
+## Event Handling
+
+### PushTransaction
+
+```
+PushTransaction(resp_tx)
+  │
+  ├── [PauseSync] → immediately return error → process_blocking_resp()
+  │
+  └── wired.push_pull()
+        ├── Ok  → event_loop_action = Normal
+        │         backoff = None (cleared if not BackOff)
+        │         process_blocking_resp(None)
+        │
+        └── Err(DatatypeErrorWithActions)
+              ├── event_loop_action = dewa.event_loop_action
+              ├── wired.handle_error(error, datatype_action)
+              └── process_blocking_resp(Some(error))
+```
+
+### Notify
+
+```
+Notify(notification)
+  │
+  └── wired.handle_notification(notification) → bool
+        ├── false: self-notification (trace) or mismatched duid (warn) → skip
+        ├── false: cp_sseq >= notify.sseq → already up-to-date → skip
+        │
+        └── true: cp_sseq < notify.sseq → push-pull needed
+                bounded_tx.try_send(PushTransaction(None))
+                  ├── Ok  → processed in next iteration as PushTransaction
+                  └── Err → already queued → drop (best-effort)
+```
+
+> **Notify during BackOff**: `bounded_rx` is not polled during BackOff. A PushTransaction queued via `bounded_tx` will only be processed after the BackOff timer expires. This is intentional — Notify must not bypass BackOff protection. Explicit `sync()` uses `unbounded_tx` and bypasses BackOff immediately.
+
+### Stop
+
+```
+Stop(ack_tx)
+  └── ack_tx.send(()) → event loop exits
+```
+
+---
+
+## BackOff Details
+
+Exponential backoff is implemented via `backon::ExponentialBuilder`.
+
+| Parameter | Value |
+|-----------|-------|
+| Minimum delay | 500ms |
+| Maximum delay | 30s |
+| Max retry count | Unlimited |
+| Growth factor | Exponential (×2) |
+
+**BackOff entry**: Transient errors such as `ClientPushPullError::FailedInConnectivity` map to `EventLoopAction::BackOff` via `.mapping()`.
+
+**BackOff exit**:
+- Explicit `sync()` succeeds (via unbounded channel, bypasses wait)
+- BackOff timer expires → automatic retry succeeds
+
+---
+
+## DatatypeAction — Post-Error State Transitions
+
+On push_pull failure, `DatatypeErrorWithActions.datatype_action` determines the datatype state change.
+
+| Action | Effect |
+|--------|--------|
+| `Normal` | No state change |
+| `Restart` | Transition to `DueToSubscribeOrCreate` (reconnect attempt) |
+| `Disable` | Transition to `Disabled` (sync permanently stopped) |
+| `Reset` | Call `do_rollback()`, then recover from server snapshot |
+
+---
+
+## Realtime Notification Flow (LocalConnectivity)
+
+In realtime mode, when one client pushes transactions the server immediately notifies all other clients subscribed to the same datatype.
+
+```
+Client A                LocalDatatypeServer         Client B
+   │                          │                        │
+   │── push_pull() ──────►│                        │
+   │                          │ notify_pushed()        │
+   │                          │── Notify ─────────────►│ (via unbounded_tx)
+   │◄── PushPullPack ─────────│                        │
+   │                          │                EventLoop::run()
+   │                          │                  handle_notification()
+   │                          │                    cp_sseq < notify.sseq?
+   │                          │                  bounded_tx.try_send(PushTransaction)
+   │                          │                        │
+   │                          │◄── push_pull() ────│
+   │                          │─── PushPullPack ──────►│
+```
+
+`handle_notification` filtering logic:
+1. `identical_cuid` — notification originated from this client → skip (`trace`)
+2. `different_duid` — notification for a different datatype misrouted → skip (`warn`)
+3. `cp_sseq >= notify.sseq` — already at or ahead of the notified sseq → skip (`trace`)
+4. Otherwise → schedule `PushTransaction` via `bounded_tx`
+
+---
+
+## Event Sender API
+
+| Method | Channel | Blocking | Use case |
+|--------|---------|----------|----------|
+| `send_push_transaction_with_best_effort()` | bounded | No | Realtime auto-push after local write |
+| `send_push_transaction_with_guarantee()` | unbounded | Yes (oneshot wait) | `sync()` call |
+| `send_stop()` | unbounded | Yes (ack wait) | Datatype shutdown |
+
+`send_push_transaction_with_best_effort` returns immediately if `is_realtime()` is `false`, preventing accidental auto-push in manual mode.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -127,6 +127,25 @@ data_key
 duid
 ```
 
+### Shipping Test Logs to Loki
+
+The test subscriber (`src/observability/test_subscriber.rs`) is installed once per process via `#[ctor]`. By default it uses the OpenTelemetry subscriber. Setting `QORTOO_RS_LOKI_URL` switches it to ship logs to Loki instead:
+
+```shell
+make obs-up
+QORTOO_RS_LOKI_URL=http://localhost:3100 RUST_LOG=debug cargo test
+# Grafana -> Explore -> Loki -> {app="qortoo", source="test"}
+```
+
+Labels attached to every test log line:
+
+| Label | Value |
+|-------|-------|
+| `app` | `qortoo` |
+| `source` | `test` |
+
+If the URL is missing or invalid, the subscriber silently falls back to the OTel backend.
+
 ---
 
 ## Metrics

--- a/qortoo-rs-docker/docker-compose.yml
+++ b/qortoo-rs-docker/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   tempo:
     image: grafana/tempo:latest
     container_name: qortoo-tempo
-    command: [-config.file=/etc/tempo/tempo.yaml]
+    command: ["-target=all", "-config.file=/etc/tempo/tempo.yaml"]
     volumes:
       - ./tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
       - tempo_data:/var/tempo
@@ -39,6 +39,7 @@ services:
       - "4317:4317"   # OTLP gRPC  (Rust app → Tempo)
       - "4318:4318"   # OTLP HTTP
       - "3200:3200"   # Tempo query API (Grafana → Tempo)
+      - "7946:7946"
     networks:
       - observability
     restart: unless-stopped

--- a/qortoo-rs-docker/tempo/tempo.yaml
+++ b/qortoo-rs-docker/tempo/tempo.yaml
@@ -10,6 +10,27 @@ distributor:
         http:
           endpoint: 0.0.0.0:4318
 
+ingester:
+  trace_idle_period: 10s
+  max_block_duration: 5m
+
+metrics_generator:
+  storage:
+    path: /var/tempo/generator/wal
+  ring:
+    kvstore:
+      store: memberlist
+  processor:
+    local_blocks:
+      flush_to_storage: true
+      filter_server_spans: false
+    service_graphs: {}
+    span_metrics: {}
+
+memberlist:
+  join_members:
+    - tempo:7946
+
 storage:
   trace:
     backend: local
@@ -21,3 +42,9 @@ storage:
 compactor:
   compaction:
     block_retention: 24h
+
+overrides:
+  metrics_generator_processors:
+    - local-blocks
+    - service-graphs
+    - span-metrics

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -160,7 +160,13 @@ impl Connectivity for LocalConnectivity {
         server.write().insert_client_item(wired, sender);
     }
 
-    fn push_and_pull(&self, pushed: &PushPullPack) -> Result<PushPullPack, ConnectivityError> {
+    #[tracing::instrument(name = "LocalConnectivity::push_pull", skip_all, fields(
+        collection=%pushed.collection,
+        cuid=%pushed.cuid,
+        duid=%pushed.duid,
+        key=%pushed.key,
+    ))]
+    fn push_pull(&self, pushed: &PushPullPack) -> Result<PushPullPack, ConnectivityError> {
         let resource_id = pushed.resource_id();
 
         let local_datatype_server_with_lock = self
@@ -175,7 +181,9 @@ impl Connectivity for LocalConnectivity {
             DatatypeState::DueToSubscribeOrCreate => {
                 local_datatype_server.process_due_to_subscribe_or_create(pushed)?
             }
-            DatatypeState::Subscribed => local_datatype_server.process_subscribe(pushed)?,
+            DatatypeState::Subscribed => {
+                local_datatype_server.process_subscribed(pushed, self.is_realtime())?
+            }
             DatatypeState::DueToUnsubscribe => {
                 local_datatype_server.process_due_to_unsubscribe(pushed)?
             }
@@ -197,8 +205,9 @@ mod tests_local_connectivity {
     use tracing::instrument;
 
     use crate::{
-        Client, Datatype, DatatypeState, connectivity::local_connectivity::LocalConnectivity,
-        utils::test_utils::get_test_collection_name,
+        Client, Datatype, DatatypeState,
+        connectivity::local_connectivity::LocalConnectivity,
+        utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
     };
 
     #[test]
@@ -232,5 +241,74 @@ mod tests_local_connectivity {
 
         counter_manual.sync().unwrap();
         assert_eq!(counter_manual.get_state(), DatatypeState::Subscribed);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_notify_other_clients_after_realtime_push() {
+        let connectivity = LocalConnectivity::new_arc();
+        let (collection, key, _) = get_test_ids!();
+        let client1 = Client::builder(collection.clone(), "client1")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let client2 = Client::builder(collection, "client2")
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+
+        let counter1 = client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+        awaitility::at_most(Duration::from_secs(1))
+            .poll_interval(Duration::from_micros(100))
+            .until(|| counter1.get_state() == DatatypeState::Subscribed);
+
+        let counter2 = client2.subscribe_datatype(key).build_counter().unwrap();
+        awaitility::at_most(Duration::from_secs(1))
+            .poll_interval(Duration::from_micros(100))
+            .until(|| counter2.get_state() == DatatypeState::Subscribed);
+
+        counter1.increase_by(7).unwrap();
+
+        awaitility::at_most(Duration::from_secs(1))
+            .poll_interval(Duration::from_micros(100))
+            .until(|| counter2.get_value() == 7);
+        assert_eq!(counter1.get_server_version(), counter2.get_server_version());
+    }
+
+    #[test]
+    #[instrument]
+    fn does_not_notify_other_clients_in_manual_mode() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, _) = get_test_ids!();
+        let client1 = Client::builder(collection.clone(), "client1")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let client2 = Client::builder(collection, "client2")
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+
+        let counter1 = client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+        counter1.sync().unwrap();
+
+        let counter2 = client2.subscribe_datatype(key).build_counter().unwrap();
+        counter2.sync().unwrap();
+
+        counter1.increase_by(7).unwrap();
+        counter1.sync().unwrap();
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(counter2.get_value(), 0);
+
+        counter2.sync().unwrap();
+        assert_eq!(counter2.get_value(), 7);
     }
 }

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
 use crossbeam_channel::Sender;
+use tracing::{instrument, trace};
 
 use crate::{
     ConnectivityError, DataType, DatatypeState,
@@ -10,14 +11,32 @@ use crate::{
     types::{
         checkpoint::CheckPoint,
         common::ArcStr,
+        notification::Notification,
         push_pull_pack::PushPullPack,
         uid::{Cuid, Duid},
     },
 };
 
+macro_rules! datatype_server_instrument {
+    ($(#[$attr:meta])* $vis:vis fn $name:ident $($rest:tt)*) => {
+        $(#[$attr])*
+        #[tracing::instrument(skip_all,
+            fields(
+                collection=%self.collection,
+                data_key=%self.key,
+                duid=%self.duid,
+                r#type=%self.r#type,
+                sseq=%self.sseq,
+            )
+        )]
+        $vis fn $name $($rest)*
+    };
+}
+
 pub struct LocalDatatypeServer {
     wired_map: HashMap<Cuid, Arc<WiredDatatype>>,
     sender_map: HashMap<Cuid, Sender<Event>>,
+    collection: ArcStr,
     key: ArcStr,
     r#type: DataType,
     duid: Duid,
@@ -49,6 +68,7 @@ impl LocalDatatypeServer {
             created: false,
             // creator is temporarily assigned; it should be reassigned when this datatype is created
             creator: attr.get_cuid(),
+            collection: attr.client_common.collection.clone(),
             sseq: 0,
             cseq_map: HashMap::new(),
             history: Vec::new(),
@@ -63,16 +83,18 @@ impl LocalDatatypeServer {
         self.sender_map.insert(wired.cuid(), sender);
     }
 
-    pub fn push_transactions(&mut self, pushed: &PushPullPack) -> u64 {
+    pub fn push_transactions(&mut self, pushed: &PushPullPack) -> (u64, bool) {
         let client_cp = self
             .cseq_map
             .entry(pushed.cuid.clone())
             .or_insert(CheckPoint::new(0, 0));
+        let mut pushed_any = false;
 
         for tx in pushed.transactions.iter() {
             if tx.cseq <= client_cp.cseq {
                 continue;
             }
+            pushed_any = true;
             self.sseq += 1;
             let mut owned_tx = (**tx).clone();
             owned_tx.sseq = self.sseq;
@@ -80,9 +102,10 @@ impl LocalDatatypeServer {
             client_cp.cseq = tx.cseq;
         }
         client_cp.sseq = self.sseq;
-        client_cp.cseq
+        (client_cp.cseq, pushed_any)
     }
 
+    datatype_server_instrument! {
     pub fn process_due_to_create(
         &mut self,
         pushed: &PushPullPack,
@@ -107,13 +130,14 @@ impl LocalDatatypeServer {
         self.created = true;
         self.creator = pushed.cuid.clone();
         self.duid = pushed.duid.clone();
-        let cseq = self.push_transactions(pushed);
+        let (cseq, _) = self.push_transactions(pushed);
         pulled.checkpoint.sseq = self.sseq;
         pulled.checkpoint.cseq = cseq;
         pulled.state = DatatypeState::Subscribed;
         Ok(pulled)
-    }
+    }}
 
+    datatype_server_instrument! {
     pub fn process_due_to_subscribe_or_create(
         &mut self,
         pushed: &PushPullPack,
@@ -123,11 +147,13 @@ impl LocalDatatypeServer {
         } else {
             self.process_due_to_create(pushed)
         }
-    }
+    }}
 
-    pub fn process_subscribe(
+    datatype_server_instrument! {
+    pub fn process_subscribed(
         &mut self,
         pushed: &PushPullPack,
+        is_realtime: bool,
     ) -> Result<PushPullPack, ConnectivityError> {
         let mut pulled = pushed.get_pulled_stub();
         if pulled.is_readonly && !pushed.transactions.is_empty() {
@@ -137,38 +163,65 @@ impl LocalDatatypeServer {
             pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         }
-        let cseq = self.push_transactions(pushed);
+        let (cseq, pushed_any) = self.push_transactions(pushed);
         pulled.checkpoint.sseq = pushed.checkpoint.sseq;
         pulled.checkpoint.cseq = cseq;
         self.pull_transactions(&mut pulled);
         pulled.state = DatatypeState::Subscribed;
+        if is_realtime && pushed_any {
+            self.notify_pushed(&pushed.cuid);
+        }
+
         Ok(pulled)
+    }}
+
+    #[instrument(skip_all)]
+    fn notify_pushed(&self, cuid: &Cuid) {
+        let notification = Notification::new(cuid.clone(), self.duid.clone(), self.sseq, 0);
+        let mut notified_cuids = Vec::new();
+        for (registered_cuid, sender) in &self.sender_map {
+            if registered_cuid == cuid {
+                continue;
+            }
+            match sender.try_send(Event::Notify(notification.clone())) {
+                Ok(_) => notified_cuids.push(registered_cuid.to_string()),
+                Err(e) => trace!("failed to notify {registered_cuid}: {e:?}"),
+            }
+        }
+        trace!(
+            "notified {} client(s): {notified_cuids:?} of {notification}",
+            notified_cuids.len()
+        );
     }
 
+    datatype_server_instrument! {
     pub fn process_due_to_unsubscribe(
         &mut self,
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
         let pulled = pushed.get_pulled_stub();
         Ok(pulled)
-    }
+    }}
 
+    datatype_server_instrument! {
     pub fn process_due_to_delete(
         &mut self,
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
         let pulled = pushed.get_pulled_stub();
         Ok(pulled)
-    }
+    }}
 
+    datatype_server_instrument! {
     pub fn process_disabled(
         &mut self,
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
         let pulled = pushed.get_pulled_stub();
         Ok(pulled)
-    }
+    }}
 
+    datatype_server_instrument! {
     pub fn process_due_to_subscribe(
         &mut self,
         pushed: &PushPullPack,
@@ -211,7 +264,7 @@ impl LocalDatatypeServer {
         self.pull_transactions(&mut pulled);
         pulled.state = DatatypeState::Subscribed;
         Ok(pulled)
-    }
+    }}
 
     fn get_creator_wired_datatype(&self) -> Option<Arc<WiredDatatype>> {
         self.wired_map.get(&self.creator).cloned()

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -15,6 +15,6 @@ pub mod null_connectivity;
 
 pub trait Connectivity: Send + Sync + Debug {
     fn register(&self, wired: Arc<WiredDatatype>, sender: Sender<Event>);
-    fn push_and_pull(&self, ppp: &PushPullPack) -> Result<PushPullPack, ConnectivityError>;
+    fn push_pull(&self, ppp: &PushPullPack) -> Result<PushPullPack, ConnectivityError>;
     fn is_realtime(&self) -> bool;
 }

--- a/src/connectivity/null_connectivity.rs
+++ b/src/connectivity/null_connectivity.rs
@@ -34,7 +34,7 @@ impl Connectivity for NullConnectivity {
         // do nothing
     }
 
-    fn push_and_pull(&self, pushed: &PushPullPack) -> Result<PushPullPack, ConnectivityError> {
+    fn push_pull(&self, pushed: &PushPullPack) -> Result<PushPullPack, ConnectivityError> {
         let mut pulled = pushed.get_pulled_stub();
 
         match pushed.state {
@@ -101,7 +101,7 @@ mod tests_null_connectivity {
 
         let mut pushed1 = PushPullPack::new(&attr, DatatypeState::DueToCreate);
         pushed1.is_readonly = true;
-        let res1 = null_connectivity.push_and_pull(&pushed1);
+        let res1 = null_connectivity.push_pull(&pushed1);
         assert!(res1.is_ok());
         let pulled1 = res1.unwrap();
         assert_eq!(
@@ -115,7 +115,7 @@ mod tests_null_connectivity {
         pushed2
             .transactions
             .push(Arc::new(Transaction::new(&op_id.cuid, cseq)));
-        let res2 = null_connectivity.push_and_pull(&pushed2);
+        let res2 = null_connectivity.push_pull(&pushed2);
         assert!(res2.is_ok());
         let pulled2 = res2.unwrap();
         assert_eq!(

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -16,6 +16,7 @@ use crate::{
         with_err_out,
     },
     observability::{metrics, trace::add_span_event},
+    types::notification::Notification,
 };
 
 const BACKOFF_MIN_DELAY: Duration = Duration::from_millis(500);
@@ -29,6 +30,8 @@ pub enum Event {
     PushTransaction(Option<oneshot::Sender<Option<DatatypeError>>>),
     #[display("BackOff")]
     BackOff,
+    #[display("Notify")]
+    Notify(Notification),
 }
 
 #[derive(Debug)]
@@ -75,6 +78,7 @@ impl EventLoop {
         let bounded_rx = self.bounded_rx.clone();
         let rt_handle = wired.attr.client_common.handle.clone();
         let unbounded_tx = self.unbounded_tx.clone();
+        let bounded_tx = self.bounded_tx.clone();
         let connectivity = wired.attr.client_common.connectivity.clone();
         let span = Span::current();
         connectivity.register(wired.clone(), unbounded_tx);
@@ -130,6 +134,12 @@ impl EventLoop {
                                 Self::process_blocking_resp(resp_tx, opt_datatype_error);
                             }
                             Event::BackOff => {}
+                            Event::Notify(notify) => {
+                                if wired.handle_notification(notify) {
+                                    // best-effort: drop if a PushTransaction is already queued
+                                    let _ = bounded_tx.try_send(Event::PushTransaction(None));
+                                }
+                            }
                         },
                         Err(err) => {
                             wired.handle_error(err, DatatypeAction::Disable);

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use tracing::instrument;
+use tracing::{instrument, trace, warn};
 
 #[cfg(test)]
 use crate::datatypes::wired_interceptor::WiredInterceptor;
@@ -18,7 +18,7 @@ use crate::{
     },
     observability::{metrics, trace::add_span_event},
     operations::transaction::Transaction,
-    types::{push_pull_pack::PushPullPack, uid::Cuid},
+    types::{notification::Notification, push_pull_pack::PushPullPack, uid::Cuid},
 };
 
 pub struct WiredDatatype {
@@ -84,6 +84,34 @@ impl WiredDatatype {
     }
 
     #[instrument(skip_all)]
+    pub fn handle_notification(&self, notify: Notification) -> bool {
+        if self.attr.get_duid() != notify.duid {
+            warn!(
+                "ignore {notify}: different duid(expected={})",
+                self.attr.get_duid()
+            );
+            return false;
+        }
+        if self.attr.get_cuid() == notify.cuid {
+            trace!("ignore {notify}: self-notification");
+            return false;
+        }
+        let cp_sseq = self.mutable.read().checkpoint.sseq;
+        if cp_sseq >= notify.sseq {
+            trace!(
+                "ignore {notify} due to current sseq({cp_sseq}) >= notification.sseq({})",
+                notify.sseq
+            );
+            return false;
+        }
+        trace!(
+            "schedule push-pull due to current sseq({cp_sseq}) < notification.sseq({})",
+            notify.sseq
+        );
+        true
+    }
+
+    #[instrument(skip_all)]
     pub fn push_pull(&self) -> Result<(), DatatypeErrorWithActions> {
         let start = std::time::Instant::now();
         let result = self.do_push_pull();
@@ -106,7 +134,7 @@ impl WiredDatatype {
         add_span_event!("send PUSH PushPullPack", "ppp"=> pushing_ppp.to_string());
         #[cfg_attr(not(test), allow(unused_mut))]
         let mut pulled_ppp = connectivity
-            .push_and_pull(&pushing_ppp)
+            .push_pull(&pushing_ppp)
             .map_err(|e| e.mapping())?;
 
         #[cfg(test)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod checkpoint;
 pub mod common;
 pub mod datatype;
+pub mod notification;
 pub mod operation_id;
 pub mod push_pull_pack;
 pub mod uid;

--- a/src/types/notification.rs
+++ b/src/types/notification.rs
@@ -1,0 +1,39 @@
+use derive_more::Display;
+
+use crate::types::uid::{Cuid, Duid};
+
+#[derive(Debug, Clone, Display)]
+#[display("Notification{{ cuid:{cuid}, duid:{duid}, sseq:{sseq}, safe:{safe} }}")]
+pub struct Notification {
+    pub cuid: Cuid,
+    pub duid: Duid,
+    pub sseq: u64,
+    pub safe: u64,
+}
+
+impl Notification {
+    pub fn new(cuid: Cuid, duid: Duid, sseq: u64, safe: u64) -> Self {
+        Self {
+            cuid,
+            duid,
+            sseq,
+            safe,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests_notification {
+    use tracing::info;
+
+    use crate::types::{
+        notification::Notification,
+        uid::{Cuid, Duid},
+    };
+
+    #[test]
+    fn can_display() {
+        let notification = Notification::new(Cuid::new_nil(), Duid::new_nil(), 1, 1);
+        info!("{}", notification);
+    }
+}


### PR DESCRIPTION
- Add Notification type (cuid, duid, sseq) as the wire format for server-to-client push signals.
- Add notify_pushed in LocalDatatypeServer to fan out Event::Notify to all other registered clients after a successful push in realtime mode.
- Add Event::Notify variant to EventLoop and handle it by scheduling a PushTransaction via the bounded channel, so notifications respect BackOff protection.
- Add handle_notification in WiredDatatype as a pure validation gate (returns bool) that filters self-notifications and stale sseq before allowing a push-pull.
- Rename Connectivity::push_and_pull to push_pull across the trait, all implementations, and call sites.
- Add docs/event-loop.md documenting channel architecture, EventLoopAction states, and the realtime notification flow.

## Commits included
- 🧩chore(docker and document): document QORTOO_RS_LOKI_URL for shipping test logs to Loki and enable Tempo metrics generator with service-graphs and span-metrics