### PR TITLE
📜docs(docs): add README and convert diagrams to mermaid

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,54 @@
+# Qortoo-rs Documentation
+
+Qortoo-rs is a Rust SDK for **conflict-free replicated data types (CRDTs)** with distributed synchronization. It provides atomic transactions with rollback, read-only observation modes, and pluggable connectivity backends.
+
+## Origin of the Name `Qortoo`
+
+`Qortoo` is **Quantum + Ortoo**. Qortoo is a new beginning for the [Orda project](https://github.com/orda-io). Orda is a name derived from [Yam / Ortoo](https://en.wikipedia.org/wiki/Yam_(route)), inspired by the similarity between the Mongol Empire's communication system and the synchronization functionality this project aims to implement. In fact, Ortoo was used first, but since it was already widely used elsewhere, the name Orda was chosen instead. As you can see from Qortoo's git history, this project was briefly named SyncYam, which also derives from Yam.
+
+Quantum is inspired by [Quantum Entanglement](https://en.wikipedia.org/wiki/Quantum_entanglement). Qortoo's approach of replicating data types and rapidly synchronizing them through operations was thought to be similar to quantum entanglement. Since Ortoo was already a commonly used name, Quantum + Ortoo were combined to create Qortoo for differentiation.
+
+This is just an unnecessarily detailed explanation of the name.
+
+## Architecture at a Glance
+
+Each datatype is composed of five layers stacked vertically. A user operation passes through all layers top-down:
+
+```
+┌─────────────────────────────────────────┐
+│  Public API  (e.g., Counter)            │  ← User-facing type
+├─────────────────────────────────────────┤
+│  Transactional Layer                    │  ← Atomic scope, DeferGuard commit/rollback
+├─────────────────────────────────────────┤
+│  Mutable Layer                          │  ← Local CRDT state, push buffer, TxRecord
+├─────────────────────────────────────────┤
+│  Wired Layer                            │  ← Sync with connectivity backend
+├─────────────────────────────────────────┤
+│  CRDT Layer  (e.g., CounterCrdt)        │  ← Pure CRDT implementation
+└─────────────────────────────────────────┘
+```
+
+## Core Architecture Documents
+
+| Document | Description |
+|----------|-------------|
+| [Architecture](architecture.md) | Layer stack, shared state model, operation flow, and concurrency model |
+| [Transaction and Rollback](transaction-and-rollback.md) | `TxRecord` structure, transaction lifecycle, and inverse-operation rollback |
+| [Event Loop](event-loop.md) | Priority-based event processing, channel types, and exponential backoff behavior |
+| [Observability](observability.md) | Tracing, log layer, Prometheus metrics, and Pyroscope profiling integration |
+
+## Usage Guides
+
+| Document | Description |
+|----------|-------------|
+| Getting Started | TBD — Installation, basic setup, and first datatype |
+| Client and DatatypeBuilder | TBD — `Client` builder pattern, collection scoping, and datatype registration |
+| Datatypes Reference | TBD — Counter API; planned `Variable` and `Map` types |
+| Connectivity Backends | TBD — `NullConnectivity`, `LocalConnectivity`, and implementing a custom backend |
+| Error Handling | TBD — Error types, `DatatypeErrorWithActions`, `EventLoopAction`, and recovery strategies |
+| Handler System | TBD — `DatatypeHandler`, `HandlersManager`, priority-based callback dispatch |
+| Testing Guide | TBD — Test macros, `LocalConnectivity` realtime pitfall, and async test patterns |
+
+## Maintaining This Documentation
+
+- New documents should be placed in this directory and linked in the tables above.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,24 +8,15 @@ Qortoo-rs is a Rust SDK for CRDTs (Conflict-free Replicated Data Types) with dis
 
 Each datatype is composed of five layers stacked vertically. A user operation passes through all layers top-down.
 
-```
-┌────────────────────────────────────────────────────┐
-│           Public API  (e.g., Counter)              │  ← User-facing type
-│           implements DatatypeBlanket               │
-├────────────────────────────────────────────────────┤
-│           Transactional Layer                      │  ← Transaction scope,
-│           TransactionalDatatype                    │     DeferGuard commit/rollback
-├────────────────────────────────────────────────────┤
-│           Mutable Layer                            │  ← Local state: CRDT, op_id,
-│           MutableDatatype                          │     push_buffer, tx_record
-├────────────────────────────────────────────────────┤
-│           Wired Layer                              │  ← Push/pull sync with
-│           WiredDatatype                            │     connectivity backend
-├────────────────────────────────────────────────────┤
-│           CRDT Layer   (e.g., CounterCrdt)         │  ← Pure CRDT: execute_local_operation,
-│           Crdt enum                                │     execute_remote_operation,
-│                                                    │     execute_inverse_operation
-└────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    API["<b>Public API</b> (e.g., Counter)<br/>implements DatatypeBlanket<br/>← User-facing type"]
+    TX["<b>Transactional Layer</b> — TransactionalDatatype<br/>← Transaction scope, DeferGuard commit/rollback"]
+    MU["<b>Mutable Layer</b> — MutableDatatype<br/>← Local state: CRDT, op_id, push_buffer, tx_record"]
+    WI["<b>Wired Layer</b> — WiredDatatype<br/>← Push/pull sync with connectivity backend"]
+    CR["<b>CRDT Layer</b> (e.g., CounterCrdt) — Crdt enum<br/>← Pure CRDT: execute_local_operation,<br/>execute_remote_operation, execute_inverse_operation"]
+
+    API --> TX --> MU --> WI --> CR
 ```
 
 > For event loop internals (channel architecture, BackOff, Notify flow) see [`docs/event-loop.md`](event-loop.md).
@@ -42,16 +33,26 @@ Each datatype is composed of five layers stacked vertically. A user operation pa
 
 ## Shared State Model
 
-```
-Arc<TransactionalDatatype>
- ├── attr: Arc<Attribute>          ← immutable config (cuid, type, option, handlers)
- ├── mutable: Arc<RwLock<MutableDatatype>>
- │    ├── crdt: Crdt               ← CRDT state
- │    ├── op_id: OperationId       ← lamport + cseq counter
- │    ├── push_buffer              ← committed-but-not-acked transactions
- │    ├── tx_record: TxRecord      ← pending transaction + rollback save point
- │    └── state: DatatypeState     ← lifecycle state
- └── (WiredDatatype wraps the same Arc<RwLock<MutableDatatype>>)
+```mermaid
+flowchart TD
+    ATD["Arc&lt;TransactionalDatatype&gt;"]
+    ATTR["attr: Arc&lt;Attribute&gt;\nimmutable config (key, type, duid, option, is_readonly)"]
+    MUT["mutable: Arc&lt;RwLock&lt;MutableDatatype&gt;&gt;"]
+    CRDT["crdt: Crdt — CRDT state"]
+    OPID["op_id: OperationId — lamport + cseq counter"]
+    PB["push_buffer — committed-but-not-acked transactions"]
+    TXR["tx_record: TxRecord — pending transaction + rollback save point"]
+    STATE["state: DatatypeState — lifecycle state"]
+    WD["WiredDatatype\n(shares the same Arc&lt;RwLock&lt;MutableDatatype&gt;&gt;)"]
+
+    ATD --> ATTR
+    ATD --> MUT
+    MUT --> CRDT
+    MUT --> OPID
+    MUT --> PB
+    MUT --> TXR
+    MUT --> STATE
+    WD -.->|shares| MUT
 ```
 
 `Arc<Attribute>` is shared across all layers and is the best place for per-datatype cross-cutting concerns (handler registry, push buffer options, etc.).
@@ -60,40 +61,30 @@ Arc<TransactionalDatatype>
 
 ### Local write
 
-```
-User calls counter.increase(1)
-  │
-  ▼
-TransactionalDatatype::execute_local_operation_as_tx()
-  ├── acquire op_mutex
-  ├── begin_transaction_if_needed()   ← creates TransactionContext + DeferGuard
-  │
-  ▼
-MutableDatatype::execute_local_operation()
-  ├── op.set_lamport(op_id.lamport + 1)
-  ├── crdt.execute_local_operation(&op)   ─── succeeds?
-  │     YES → tx_record.record_operation()  ← append op + update rollback save point
-  │           op_id.next(is_new_tx)         ← advance lamport (and cseq if new tx)
-  │     NO  → return Err (op_id unchanged)
-  │
-  ▼
-DeferGuard drop → end_transaction(committed=true)
-  └── push_buffer.enqueue(tx)   ← ready to sync
+```mermaid
+flowchart TD
+    User["User calls counter.increase(1)"]
+    TX["TransactionalDatatype::execute_local_operation_as_tx()\n──────────────────────────────────────\nacquire op_mutex\nbegin_transaction_if_needed()\n→ creates TransactionContext + DeferGuard"]
+    MU["MutableDatatype::execute_local_operation()\n──────────────────────────────────────\nop.set_lamport(op_id.lamport + 1)\ncrdt.execute_local_operation(&op)"]
+    Ok["YES: succeeds\ntx_record.record_operation() ← append op + update rollback save point\nop_id.next(is_new_tx) ← advance lamport (and cseq if new tx)"]
+    Err["NO: fails\nreturn Err (op_id unchanged)"]
+    Defer["DeferGuard drop → end_transaction(committed=true)\npush_buffer.enqueue(tx) ← ready to sync"]
+
+    User --> TX --> MU
+    MU -->|"succeeds"| Ok --> Defer
+    MU -->|"fails"| Err
 ```
 
 ### Sync (push/pull)
 
-```
-EventLoop fires PushTransaction event
-  │
-  ▼
-WiredDatatype::push_pull()
-  ├── mutable.read() → assemble PushPullPack (push_buffer contents)
-  ├── connectivity.push_pull(&pack)
-  ├── mutable.write() → apply pulled transactions
-  │    ├── execute_remote_transaction() for each remote tx
-  │    └── push_buffer.deque(acked_cseq)
-  └── set_state(pulled.state)
+```mermaid
+flowchart TD
+    EL["EventLoop fires PushTransaction event"]
+    PP["WiredDatatype::push_pull()\n──────────────────────────────────────\nmutable.read() → assemble PushPullPack (push_buffer contents)\nconnectivity.push_pull(&pack)"]
+    Apply["mutable.write() → apply pulled transactions\n──────────────────────────────────────\nexecute_remote_transaction() for each remote tx\npush_buffer.deque(acked_cseq)"]
+    State["set_state(pulled.state)"]
+
+    EL --> PP --> Apply --> State
 ```
 
 ## Concurrency Model

--- a/docs/event-loop.md
+++ b/docs/event-loop.md
@@ -7,24 +7,16 @@ Each datatype instance owns a dedicated `EventLoop`. It runs on a `spawn_blockin
 - Reacting to server-side realtime notifications
 - Managing exponential backoff on transient errors
 
-```
-┌─────────────────────────────────────────────────┐
-│  TransactionalDatatype / Public API             │
-│  (counter.increase(), counter.sync())           │
-└──────────────────┬──────────────────────────────┘
-                   │ send Event
-        ┌──────────▼──────────┐
-        │     EventLoop       │  ← spawn_blocking thread
-        │  (run loop)         │
-        └──────────┬──────────┘
-                   │ push_pull()
-        ┌──────────▼──────────┐
-        │   WiredDatatype     │
-        └──────────┬──────────┘
-                   │ push_pull()
-        ┌──────────▼──────────┐
-        │   Connectivity      │  ← LocalConnectivity / NullConnectivity / ...
-        └─────────────────────┘
+```mermaid
+flowchart TD
+    API["TransactionalDatatype / Public API\n(counter.increase(), counter.sync())"]
+    EL["EventLoop\n(spawn_blocking thread)"]
+    WD["WiredDatatype"]
+    CN["Connectivity\n(LocalConnectivity / NullConnectivity / ...)"]
+
+    API -->|"send Event"| EL
+    EL -->|"push_pull()"| WD
+    WD -->|"push_pull()"| CN
 ```
 
 ---
@@ -33,14 +25,16 @@ Each datatype instance owns a dedicated `EventLoop`. It runs on a `spawn_blockin
 
 The event loop receives events through two crossbeam channels.
 
-```
-                  ┌─────────────────┐
-                  │   EventLoop     │
-                  │                 │
-  unbounded_tx ──►│  unbounded_rx   │  capacity: unlimited
-                  │                 │
-    bounded_tx ──►│    bounded_rx   │  capacity: 1
-                  └─────────────────┘
+```mermaid
+flowchart LR
+    UBT["unbounded_tx"]
+    BT["bounded_tx"]
+    subgraph EL["EventLoop"]
+        UBR["unbounded_rx\ncapacity: unlimited"]
+        BR["bounded_rx\ncapacity: 1"]
+    end
+    UBT --> UBR
+    BT --> BR
 ```
 
 | Channel | Purpose | Behavior |
@@ -73,17 +67,15 @@ pub enum Event {
 
 The event loop tracks its current sync policy via `EventLoopAction`.
 
-```
-            sync succeeds
-  ┌──────────────────────────────────────────┐
-  │                                          │
-  ▼       error: BackOff              error: PauseSync
-Normal ──────────────────► BackOff      ──► PauseSync
-  ▲                          │
-  │   BackOff timer expires  │
-  └──────────────────────────┘
-  ▲        or explicit sync() succeeds
-  └──────────────────────────────────────────┘
+```mermaid
+flowchart LR
+    N(["Normal"])
+    B(["BackOff"])
+    P(["PauseSync"])
+
+    N -->|"error: BackOff"| B
+    N -->|"error: PauseSync"| P
+    B -->|"timer expires or\nexplicit sync() succeeds"| N
 ```
 
 | State | Behavior |
@@ -98,23 +90,29 @@ Normal ──────────────────► BackOff      �
 
 `receive_event` is called at the start of every loop iteration.
 
-```
-receive_event()
-  │
-  ├── [Normal] push_if_needed && wired.push_if_needed()
-  │     → return Ok(Event::PushTransaction(None))   ← auto-push trigger
-  │
-  ├── [BackOff] compute next backoff duration
-  │     crossbeam select! {
-  │       recv(unbounded_rx) → handle immediately (Stop, explicit sync, Notify)
-  │       default(duration)  → timer expired → return Ok(Event::BackOff)
-  │     }
-  │
-  └── [Normal / PauseSync] no timeout
-        crossbeam select! {
-          recv(unbounded_rx) → handle
-          recv(bounded_rx)   → handle
-        }
+```mermaid
+flowchart TD
+    RE["receive_event()"]
+    State{"EventLoopAction?"}
+
+    AutoPush["[Normal] push_if_needed &&\nwired.push_if_needed()\n→ return Ok(Event::PushTransaction(None))"]
+
+    BOSelect["[BackOff]\ncompute next backoff duration\ncrossbeam select!"]
+    BOUnbounded["recv(unbounded_rx)\n→ handle immediately\n(Stop, explicit sync, Notify)"]
+    BOTimer["default(duration)\n→ timer expired\n→ return Ok(Event::BackOff)"]
+
+    NPSelect["[Normal / PauseSync]\ncrossbeam select!"]
+    NPUnbounded["recv(unbounded_rx) → handle"]
+    NPBounded["recv(bounded_rx) → handle"]
+
+    RE --> State
+    State -->|"Normal (push needed)"| AutoPush
+    State -->|"BackOff"| BOSelect
+    State -->|"Normal / PauseSync\n(no push needed)"| NPSelect
+    BOSelect --> BOUnbounded
+    BOSelect --> BOTimer
+    NPSelect --> NPUnbounded
+    NPSelect --> NPBounded
 ```
 
 `push_if_needed()` returns `true` only when `is_realtime() && need_push()`. This prevents auto-push from firing in manual sync mode.
@@ -125,44 +123,53 @@ receive_event()
 
 ### PushTransaction
 
-```
-PushTransaction(resp_tx)
-  │
-  ├── [PauseSync] → immediately return error → process_blocking_resp()
-  │
-  └── wired.push_pull()
-        ├── Ok  → event_loop_action = Normal
-        │         backoff = None (cleared if not BackOff)
-        │         process_blocking_resp(None)
-        │
-        └── Err(DatatypeErrorWithActions)
-              ├── event_loop_action = dewa.event_loop_action
-              ├── wired.handle_error(error, datatype_action)
-              └── process_blocking_resp(Some(error))
+```mermaid
+flowchart TD
+    PT["PushTransaction(resp_tx)"]
+    Pause{"[PauseSync]?"}
+    PauseErr["immediately return error\n→ process_blocking_resp()"]
+    PushPull["wired.push_pull()"]
+    Ok["Ok\nevent_loop_action = Normal\nbackoff = None\nprocess_blocking_resp(None)"]
+    Err["Err(DatatypeErrorWithActions)\nevent_loop_action = dewa.event_loop_action\nwired.handle_error(error, datatype_action)\nprocess_blocking_resp(Some(error))"]
+
+    PT --> Pause
+    Pause -->|"Yes"| PauseErr
+    Pause -->|"No"| PushPull
+    PushPull -->|"Ok"| Ok
+    PushPull -->|"Err"| Err
 ```
 
 ### Notify
 
-```
-Notify(notification)
-  │
-  └── wired.handle_notification(notification) → bool
-        ├── false: self-notification (trace) or mismatched duid (warn) → skip
-        ├── false: cp_sseq >= notify.sseq → already up-to-date → skip
-        │
-        └── true: cp_sseq < notify.sseq → push-pull needed
-                bounded_tx.try_send(PushTransaction(None))
-                  ├── Ok  → processed in next iteration as PushTransaction
-                  └── Err → already queued → drop (best-effort)
+```mermaid
+flowchart TD
+    N["Notify(notification)"]
+    Handle["wired.handle_notification(notification) → bool"]
+    Skip1["false: self-notification (trace)\nor mismatched duid (warn) → skip"]
+    Skip2["false: cp_sseq >= notify.sseq\n→ already up-to-date → skip"]
+    NeedPush["true: cp_sseq < notify.sseq\n→ push-pull needed"]
+    TrySend["bounded_tx.try_send(PushTransaction(None))"]
+    SendOk["Ok → processed in next iteration\nas PushTransaction"]
+    SendErr["Err → already queued\n→ drop (best-effort)"]
+
+    N --> Handle
+    Handle -->|"false (self / duid mismatch)"| Skip1
+    Handle -->|"false (up-to-date)"| Skip2
+    Handle -->|"true"| NeedPush
+    NeedPush --> TrySend
+    TrySend -->|"Ok"| SendOk
+    TrySend -->|"Err"| SendErr
 ```
 
 > **Notify during BackOff**: `bounded_rx` is not polled during BackOff. A PushTransaction queued via `bounded_tx` will only be processed after the BackOff timer expires. This is intentional — Notify must not bypass BackOff protection. Explicit `sync()` uses `unbounded_tx` and bypasses BackOff immediately.
 
 ### Stop
 
-```
-Stop(ack_tx)
-  └── ack_tx.send(()) → event loop exits
+```mermaid
+flowchart TD
+    Stop["Stop(ack_tx)"]
+    Exit["ack_tx.send(())\n→ event loop exits"]
+    Stop --> Exit
 ```
 
 ---
@@ -195,7 +202,7 @@ On push_pull failure, `DatatypeErrorWithActions.datatype_action` determines the 
 | `Normal` | No state change |
 | `Restart` | Transition to `DueToSubscribeOrCreate` (reconnect attempt) |
 | `Disable` | Transition to `Disabled` (sync permanently stopped) |
-| `Reset` | Call `do_rollback()`, then recover from server snapshot |
+| `Reset` | Call `do_rollback()` to undo the pending local transaction; the next sync cycle re-fetches state from the server |
 
 ---
 
@@ -203,20 +210,18 @@ On push_pull failure, `DatatypeErrorWithActions.datatype_action` determines the 
 
 In realtime mode, when one client pushes transactions the server immediately notifies all other clients subscribed to the same datatype.
 
-```
-Client A                LocalDatatypeServer         Client B
-   │                          │                        │
-   │── push_pull() ──────►│                        │
-   │                          │ notify_pushed()        │
-   │                          │── Notify ─────────────►│ (via unbounded_tx)
-   │◄── PushPullPack ─────────│                        │
-   │                          │                EventLoop::run()
-   │                          │                  handle_notification()
-   │                          │                    cp_sseq < notify.sseq?
-   │                          │                  bounded_tx.try_send(PushTransaction)
-   │                          │                        │
-   │                          │◄── push_pull() ────│
-   │                          │─── PushPullPack ──────►│
+```mermaid
+sequenceDiagram
+    participant A as Client A
+    participant S as LocalDatatypeServer
+    participant B as Client B
+
+    A->>S: push_pull()
+    S->>B: Notify (via unbounded_tx)
+    S-->>A: PushPullPack
+    Note over B: EventLoop::run()<br/>handle_notification()<br/>cp_sseq < notify.sseq?<br/>bounded_tx.try_send(PushTransaction)
+    B->>S: push_pull()
+    S-->>B: PushPullPack
 ```
 
 `handle_notification` filtering logic:

--- a/docs/transaction-and-rollback.md
+++ b/docs/transaction-and-rollback.md
@@ -23,39 +23,25 @@ pub struct TxRecord {
 
 ## Transaction Lifecycle
 
-```
-Idle (pending = None)
-  │
-  │  first execute_local_operation() succeeds
-  ▼
-record_operation() called
-  ├── pending = Some(Transaction::new(cuid, cseq+1))
-  ├── rollback_op_id = current op_id     ← save point set HERE
-  ├── rollback_state = current state     ← save point set HERE
-  └── op appended to pending.operations
-  │
-  │  op_id.next(is_new_tx=true)
-  │    → cseq += 1, lamport += 1
-  │
-  │  more operations succeed
-  ▼
-record_operation() called (is_new = false)
-  └── op appended to pending.operations
-  │
-  │  op_id.next(is_new_tx=false)
-  │    → lamport += 1  (cseq unchanged within same tx)
-  │
-  ├─── end_transaction(committed=true) ────────────────────────────────┐
-  │      pending.take() → push_buffer.enqueue(tx)                      │
-  │      pending = None                                                 │
-  │      (rollback_op_id / rollback_state remain stale — harmless)     │
-  │                                                              [Idle] ┘
-  │
-  └─── end_transaction(committed=false) → do_rollback() ───────────────┐
-         pending.take() → iter().rev() → execute_inverse_operation()   │
-         op_id = rollback_op_id                                         │
-         set_state(rollback_state)                                      │
-         pending = None                                          [Idle] ┘
+```mermaid
+flowchart TD
+    Idle["Idle\n(pending = None)"]
+    RecordFirst["record_operation()\n──────────────────────────────────────\npending = Some(Transaction::new(cuid, cseq+1))\nrollback_op_id = current op_id  ← save point set HERE\nrollback_state = current state  ← save point set HERE\nop appended to pending.operations"]
+    Advance1["op_id.next(is_new_tx=true)\n→ cseq += 1, lamport += 1"]
+    RecordMore["record_operation() (is_new = false)\nop appended to pending.operations"]
+    Advance2["op_id.next(is_new_tx=false)\n→ lamport += 1  (cseq unchanged within same tx)"]
+    Commit["end_transaction(committed=true)\npending.take() → push_buffer.enqueue(tx)\npending = None\n(rollback_op_id / rollback_state remain stale — harmless)"]
+    Rollback["end_transaction(committed=false) → do_rollback()\npending.take() → iter().rev() → execute_inverse_operation()\nop_id = rollback_op_id\nset_state(rollback_state)\npending = None"]
+    IdleEnd["Idle"]
+
+    Idle -->|"first execute_local_operation() succeeds"| RecordFirst
+    RecordFirst --> Advance1
+    Advance1 -->|"more operations succeed"| RecordMore
+    RecordMore --> Advance2
+    Advance2 -->|"committed=true"| Commit
+    Advance2 -->|"committed=false"| Rollback
+    Commit --> IdleEnd
+    Rollback --> IdleEnd
 ```
 
 ## Success-Only Advance Pattern
@@ -78,11 +64,17 @@ On failure: `op_id` is untouched, `pending` is unchanged. The next operation ret
 
 Instead of keeping a shadow clone of the CRDT, rollback applies the **inverse of each operation in reverse order**:
 
-```
-pending.operations = [op_A, op_B, op_C]  (applied in this order)
-
-rollback applies:
-  inverse(op_C) → inverse(op_B) → inverse(op_A)
+```mermaid
+flowchart LR
+    subgraph applied["Applied (in order)"]
+        direction LR
+        A[op_A] --> B[op_B] --> C[op_C]
+    end
+    subgraph rollback["Rollback (reversed)"]
+        direction LR
+        D["inverse(op_C)"] --> E["inverse(op_B)"] --> F["inverse(op_A)"]
+    end
+    applied -.->|rollback| rollback
 ```
 
 Each CRDT operation must implement `execute_inverse_operation`. For `CounterIncrease(delta)`, the inverse is `increase_by(-delta)`.
@@ -104,16 +96,23 @@ If `pending` is `None` (no op was ever applied), `do_rollback` is a no-op — no
 
 At the `TransactionalDatatype` level, a transaction is scoped by `TransactionContext` and `DeferGuard`:
 
-```
-execute_local_operation_as_tx(tx_ctx, op)
-  │
-  ├── begin_transaction(tx_ctx)
-  │     returns BeginTx(DeferGuard) or SameCtx or OtherCtx
-  │
-  ├── MutableDatatype::execute_local_operation(op)
-  │
-  └── DeferGuard::drop()
-        → end_transaction(committed = result.is_ok())
+```mermaid
+flowchart TD
+    Entry["execute_local_operation_as_tx(tx_ctx, op)"]
+    Begin["begin_transaction(tx_ctx)"]
+    BeginTx["BeginTx(DeferGuard)\nnew transaction scope opened"]
+    SameCtx["SameCtx\njoined into caller's ongoing transaction"]
+    OtherCtx["OtherCtx\nreturn error immediately"]
+    Execute["MutableDatatype::execute_local_operation(op)"]
+    Drop["DeferGuard::drop()\n→ end_transaction(committed = result.is_ok())"]
+
+    Entry --> Begin
+    Begin -->|BeginTx| BeginTx
+    Begin -->|SameCtx| SameCtx
+    Begin -->|OtherCtx| OtherCtx
+    BeginTx --> Execute
+    SameCtx --> Execute
+    Execute --> Drop
 ```
 
 - `SameCtx` — op is joined into the caller's ongoing transaction (no new `DeferGuard`).


### PR DESCRIPTION
- Add docs/README.md as the GitHub landing page for the docs directory, including project intro, origin of the name Qortoo, architecture overview, and a full document index with TBD placeholders for unwritten guides.
- Convert all ASCII diagrams in architecture.md, event-loop.md, and transaction-and-rollback.md to Mermaid format for better GitHub rendering.
- Fix stale content: correct Attribute field names in shared state diagram, fix DatatypeAction::Reset description (rollback only, no snapshot recovery), and replace the non-existent `tracing` feature flag with `log_layer`/`test`.