### PR TITLE
🧬feat(datatypes): implement unsubscribe lifecycle

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Each datatype is composed of five layers stacked vertically. A user operation pa
 | Document | Description |
 |----------|-------------|
 | [Architecture](architecture.md) | Layer stack, shared state model, operation flow, and concurrency model |
+| [Datatype State](datatype-state.md) | `DatatypeState` lifecycle, write access, sync intent states, and unsubscribe cleanup |
 | [Transaction and Rollback](transaction-and-rollback.md) | `TxRecord` structure, transaction lifecycle, and inverse-operation rollback |
 | [Event Loop](event-loop.md) | Priority-based event processing, channel types, and exponential backoff behavior |
 | [Observability](observability.md) | Tracing, log layer, Prometheus metrics, and Pyroscope profiling integration |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,7 @@ flowchart TD
 ```
 
 > For event loop internals (channel architecture, BackOff, Notify flow) see [`docs/event-loop.md`](event-loop.md).
+> For error taxonomy, `DatatypeErrorWithActions`, and recovery action enums see [`docs/error-handling.md`](error-handling.md).
 
 ### Layer Responsibilities
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ flowchart TD
     API --> TX --> MU --> WI --> CR
 ```
 
+> For datatype lifecycle states and write-access rules see [`docs/datatype-state.md`](datatype-state.md).
 > For event loop internals (channel architecture, BackOff, Notify flow) see [`docs/event-loop.md`](event-loop.md).
 > For error taxonomy, `DatatypeErrorWithActions`, and recovery action enums see [`docs/error-handling.md`](error-handling.md).
 
@@ -105,4 +106,4 @@ flowchart TD
 | `TxRecord` | `src/datatypes/tx_record.rs` | Pending transaction buffer + rollback save point |
 | `PushPullPack` | `src/types/push_pull_pack.rs` | Wire format for push/pull exchange |
 | `Attribute` | `src/datatypes/common.rs` | Immutable per-datatype config shared across layers |
-| `DatatypeState` | `src/types/datatype.rs` | Lifecycle state machine |
+| `DatatypeState` | `src/types/datatype.rs` | Lifecycle state machine; see [`docs/datatype-state.md`](datatype-state.md) |

--- a/docs/datatype-state.md
+++ b/docs/datatype-state.md
@@ -1,0 +1,65 @@
+# Datatype State
+
+`DatatypeState` represents the client-side lifecycle of a datatype and controls
+whether local writes and push/pull sync are allowed.
+
+The state is intentionally separate from the explicit read-only option set by
+`DatatypeBuilder::with_readonly()`. A datatype is writable only when both are
+true:
+
+- the current `DatatypeState` allows writes
+- the datatype was not built as read-only
+
+## State Reference
+
+| State | Meaning | Writes | Push target | Normal transition |
+|-------|---------|--------|-------------|-------------------|
+| `Creating` | The datatype exists locally and should be created on the backend. | Yes | Yes | `Subscribed` |
+| `Subscribing` | The datatype should subscribe to an existing backend datatype. | No | Yes | `Subscribed` |
+| `SubscribingOrCreating` | The datatype should subscribe if it exists, or create it otherwise. | Yes | Yes | `Subscribed` |
+| `Subscribed` | The datatype is attached to the backend and can exchange operations. | Yes | Yes, when there are pending transactions or remote notifications | `Unsubscribing`, `Deleting`, or `Disabled` |
+| `Unsubscribing` | The datatype has recorded a local unsubscribe intent and is waiting for backend acknowledgement. | No | Yes | `Disabled` |
+| `Deleting` | Reserved for backend delete lifecycle. | No | Yes | `Disabled` |
+| `Disabled` | The datatype is detached from normal sync and should no longer be used for writes. | No | No | Terminal for the local handle |
+
+`Creating`, `Subscribing`, `SubscribingOrCreating`, `Unsubscribing`, and
+`Deleting` are intent states. They mean the local datatype has work that must be
+sent to the connectivity backend. In realtime connectivity this push may be
+triggered automatically by the event loop. In manual connectivity, the caller
+must call `sync()`.
+
+## Write Access
+
+`DatatypeState::is_read_writable()` returns true for:
+
+- `Creating`
+- `SubscribingOrCreating`
+- `Subscribed`
+
+All other states are state-level read-only. The explicit read-only builder option
+can still prevent writes even when the state itself is writable.
+
+## Sync Flow
+
+Typical successful transitions are:
+
+```mermaid
+flowchart LR
+    Creating -->|create acknowledged| Subscribed
+    Subscribing -->|subscribe acknowledged| Subscribed
+    SubscribingOrCreating -->|subscribe or create acknowledged| Subscribed
+    Subscribed -->|unsubscribe called| Unsubscribing
+    Subscribed -->|delete called| Deleting
+    Unsubscribing -->|unsubscribe acknowledged| Disabled
+    Deleting -->|delete acknowledged| Disabled
+
+    Creating -.->|server rejection or protocol violation| Disabled
+    Subscribing -.->|server rejection or protocol violation| Disabled
+    SubscribingOrCreating -.->|server rejection or protocol violation| Disabled
+    Subscribed -.->|protocol violation| Disabled
+    Deleting -.->|server rejection or protocol violation| Disabled
+```
+
+On server rejection or protocol violation, a datatype can transition directly to
+`Disabled`. When this happens for a client-managed datatype, the datatype asks
+the owning `DatatypeManager` to detach it.

--- a/docs/event-loop.md
+++ b/docs/event-loop.md
@@ -197,12 +197,33 @@ Exponential backoff is implemented via `backon::ExponentialBuilder`.
 
 On push_pull failure, `DatatypeErrorWithActions.datatype_action` determines the datatype state change.
 
+For the full datatype lifecycle and write-access rules, see [`docs/datatype-state.md`](datatype-state.md).
+
 | Action | Effect |
 |--------|--------|
 | `Normal` | No state change |
-| `Restart` | Transition to `DueToSubscribeOrCreate` (reconnect attempt) |
+| `Restart` | Transition to `SubscribingOrCreating` (reconnect attempt) |
 | `Disable` | Transition to `Disabled` (sync permanently stopped) |
 | `Reset` | Call `do_rollback()` to undo the pending local transaction; the next sync cycle re-fetches state from the server |
+
+## Unsubscribe Lifecycle
+
+`Datatype::unsubscribe()` records local intent by moving the datatype from
+`Subscribed` to `Unsubscribing`. It does not wait for backend acknowledgement.
+
+```text
+Subscribed -> Unsubscribing -> Disabled -> manager detach
+```
+
+In realtime connectivity, the event loop can automatically schedule the
+push/pull because `Unsubscribing` is a push target. In manual connectivity, the
+caller must invoke `sync()` to send the unsubscribe request and receive the
+`Disabled` response.
+
+When `Disabled` is committed, a client-managed datatype asks its
+`DatatypeManager` to detach the same core instance. This keeps the public
+`Client` map aligned with the lifecycle without adding a separate public detach
+API.
 
 ---
 

--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -283,6 +283,57 @@ mod tests_client {
 
     #[test]
     #[instrument]
+    fn can_auto_detach_after_create_failure_disables_datatype() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let collection = get_test_collection_name!();
+        let key = get_test_func_name!();
+        let client1 = Client::builder(collection.clone(), "client1")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let client2 = Client::builder(collection, "client2")
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+
+        client1.create_datatype(key.clone()).build_counter().unwrap().sync().unwrap();
+
+        let counter = client2.create_datatype(key.clone()).build_counter().unwrap();
+        assert!(client2.get_datatype(&key).is_some());
+        assert!(matches!(
+            counter.sync().unwrap_err(),
+            crate::DatatypeError::FailedToCreate(_)
+        ));
+
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+        assert!(client2.get_datatype(&key).is_none());
+    }
+
+    #[test]
+    #[instrument]
+    fn can_auto_detach_after_subscribe_failure_disables_datatype() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+        let key = get_test_func_name!();
+
+        let counter = client.subscribe_datatype(key.clone()).build_counter().unwrap();
+        assert!(client.get_datatype(&key).is_some());
+        assert!(matches!(
+            counter.sync().unwrap_err(),
+            crate::DatatypeError::FailedToSubscribe(_)
+        ));
+
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+        assert!(client.get_datatype(&key).is_none());
+    }
+
+    #[test]
+    #[instrument]
     fn can_unsubscribe_datatype_from_client() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);

--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -4,7 +4,7 @@ use dyn_fmt::AsStrFormatExt;
 use parking_lot::RwLock;
 
 use crate::{
-    DataType, DatatypeBuilder, DatatypeHandler, DatatypeState, IntoString,
+    DataType, DatatypeBuilder, DatatypeError, DatatypeHandler, DatatypeState, IntoString,
     clients::{common::ClientCommon, datatype_manager::DatatypeManager},
     connectivity::{Connectivity, null_connectivity::NullConnectivity},
     datatypes::{datatype_set::DatatypeSet, option::DatatypeOption},
@@ -46,8 +46,10 @@ impl ClientBuilder {
 
         let common =
             ClientCommon::new_arc(self.collection.into(), self.alias.into(), self.connectivity);
+        let datatype_manager = Arc::new(RwLock::new(DatatypeManager::new(common.clone())));
+        common.set_datatype_manager(Arc::downgrade(&datatype_manager));
         Ok(Client {
-            datatypes: RwLock::new(DatatypeManager::new(common.clone())),
+            datatype_manager,
             common,
         })
     }
@@ -89,7 +91,7 @@ impl ClientBuilder {
 /// helpers to get specific datatypes.
 pub struct Client {
     common: Arc<ClientCommon>,
-    datatypes: RwLock<DatatypeManager>,
+    datatype_manager: Arc<RwLock<DatatypeManager>>,
 }
 
 impl Client {
@@ -119,7 +121,7 @@ impl Client {
         is_readonly: bool,
         handlers: BTreeMap<usize, DatatypeHandler>,
     ) -> Result<DatatypeSet, ClientError> {
-        self.datatypes.write().subscribe_or_create_datatype(
+        self.datatype_manager.write().subscribe_or_create_datatype(
             &key,
             r#type,
             state,
@@ -132,7 +134,27 @@ impl Client {
     /// Returns an existing datatype by `key`, if it has been created or
     /// subscribed via this client.
     pub fn get_datatype(&self, key: &str) -> Option<DatatypeSet> {
-        self.datatypes.read().get_datatype(key)
+        self.datatype_manager.read().get_datatype(key)
+    }
+
+    /// Unsubscribes the datatype identified by `key` from this client.
+    ///
+    /// This is a key-based convenience API over [`Datatype::unsubscribe`](crate::Datatype::unsubscribe):
+    /// it marks the datatype as `DueToUnsubscribe` and returns the handle in that state.
+    /// The client manager entry is removed only after the backend confirms `Disabled` via
+    /// the auto-detach hook — not immediately — so a sync failure leaves the datatype
+    /// reachable and retryable through the manager.
+    ///
+    /// The caller drives the datatype to `Disabled`:
+    /// - with manual connectivity, call `sync()` on the returned handle,
+    /// - with realtime connectivity, the event loop handles it automatically.
+    pub fn unsubscribe_datatype(&self, key: &str) -> Result<DatatypeSet, DatatypeError> {
+        let datatype = self.get_datatype(key).ok_or_else(|| {
+            DatatypeError::Disallowed(format!("Datatype '{key}' is not managed by this client"))
+        })?;
+
+        datatype.unsubscribe()?;
+        Ok(datatype)
     }
 
     /// Returns the collection name this client is associated with.
@@ -182,6 +204,7 @@ mod tests_client {
     use crate::{
         Datatype, DatatypeState, LocalConnectivity,
         clients::client::Client,
+        datatypes::datatype::DatatypeBlanket,
         utils::test_utils::{get_test_collection_name, get_test_func_name},
     };
 
@@ -256,5 +279,138 @@ mod tests_client {
         assert!(Client::builder("my-collection", "alias").build().is_ok());
         assert!(Client::builder("system", "alias").build().is_ok());
         assert!(Client::builder("hello.system", "alias").build().is_ok());
+    }
+
+    #[test]
+    #[instrument]
+    fn can_unsubscribe_datatype_from_client() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+
+        let counter = client
+            .create_datatype(get_test_func_name!())
+            .build_counter()
+            .unwrap();
+        counter.sync().unwrap();
+        let old_core = counter.get_core() as *const _;
+
+        let removed = client.unsubscribe_datatype(counter.get_key()).unwrap();
+        assert_eq!(removed.get_state(), DatatypeState::DueToUnsubscribe);
+        assert!(client.get_datatype(counter.get_key()).is_some());
+
+        counter.sync().unwrap();
+        assert_eq!(removed.get_state(), DatatypeState::Disabled);
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+        assert!(client.get_datatype(counter.get_key()).is_none());
+
+        let counter2 = client
+            .subscribe_datatype(counter.get_key())
+            .build_counter()
+            .unwrap();
+        let new_core = counter2.get_core() as *const _;
+        assert_ne!(old_core, new_core);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_auto_detach_after_datatype_unsubscribe_sync() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+
+        let counter = client
+            .create_datatype(get_test_func_name!())
+            .build_counter()
+            .unwrap();
+        counter.sync().unwrap();
+        let key = counter.get_key().to_owned();
+        let old_core = counter.get_core() as *const _;
+
+        counter.unsubscribe().unwrap();
+        counter.sync().unwrap();
+
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+        assert!(client.get_datatype(&key).is_none());
+
+        let counter2 = client.subscribe_datatype(&key).build_counter().unwrap();
+        let new_core = counter2.get_core() as *const _;
+        assert_ne!(old_core, new_core);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_auto_detach_after_datatype_unsubscribe_in_realtime() {
+        let connectivity = LocalConnectivity::new_arc();
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+
+        let counter = client
+            .create_datatype(get_test_func_name!())
+            .build_counter()
+            .unwrap();
+        awaitility::at_most(std::time::Duration::from_secs(1))
+            .poll_interval(std::time::Duration::from_micros(100))
+            .until(|| counter.get_state() == DatatypeState::Subscribed);
+
+        let key = counter.get_key().to_owned();
+        counter.unsubscribe().unwrap();
+
+        awaitility::at_most(std::time::Duration::from_secs(1))
+            .poll_interval(std::time::Duration::from_micros(100))
+            .until(|| {
+                counter.get_state() == DatatypeState::Disabled
+                    && client.get_datatype(&key).is_none()
+            });
+    }
+
+    #[test]
+    #[instrument]
+    fn can_unsubscribe_datatype_from_client_in_realtime() {
+        let connectivity = LocalConnectivity::new_arc();
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+
+        let counter = client
+            .create_datatype(get_test_func_name!())
+            .build_counter()
+            .unwrap();
+        awaitility::at_most(std::time::Duration::from_secs(1))
+            .poll_interval(std::time::Duration::from_micros(100))
+            .until(|| counter.get_state() == DatatypeState::Subscribed);
+
+        let removed = client.unsubscribe_datatype(counter.get_key()).unwrap();
+        assert_eq!(removed.get_state(), DatatypeState::DueToUnsubscribe);
+        assert!(client.get_datatype(counter.get_key()).is_some());
+
+        awaitility::at_most(std::time::Duration::from_secs(1))
+            .poll_interval(std::time::Duration::from_micros(100))
+            .until(|| {
+                removed.get_state() == DatatypeState::Disabled
+                    && client.get_datatype(counter.get_key()).is_none()
+            });
+    }
+
+    #[test]
+    #[instrument]
+    fn can_reject_unsubscribe_for_unmanaged_key() {
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .build()
+            .unwrap();
+
+        assert!(matches!(
+            client.unsubscribe_datatype("missing").err().unwrap(),
+            crate::DatatypeError::Disallowed(_)
+        ));
     }
 }

--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -140,7 +140,7 @@ impl Client {
     /// Unsubscribes the datatype identified by `key` from this client.
     ///
     /// This is a key-based convenience API over [`Datatype::unsubscribe`](crate::Datatype::unsubscribe):
-    /// it marks the datatype as `DueToUnsubscribe` and returns the handle in that state.
+    /// it marks the datatype as `Unsubscribing` and returns the handle in that state.
     /// The client manager entry is removed only after the backend confirms `Disabled` via
     /// the auto-detach hook — not immediately — so a sync failure leaves the datatype
     /// reachable and retryable through the manager.
@@ -170,25 +170,25 @@ impl Client {
     /// Get `DatatypeBuilder` to subscribe a `Datatype` identified by `key`.
     ///
     /// The `Datatype` built by this builder will be marked
-    /// with [`DatatypeState::DueToSubscribe`].
+    /// with [`DatatypeState::Subscribing`].
     pub fn subscribe_datatype(&self, key: impl IntoString) -> DatatypeBuilder<'_> {
-        DatatypeBuilder::new(self, key.into(), DatatypeState::DueToSubscribe)
+        DatatypeBuilder::new(self, key.into(), DatatypeState::Subscribing)
     }
 
     /// Get `DatatypeBuilder` to create a `Datatype` identified by `key`.
     ///
     /// The `Datatype` built by this builder will be marked
-    /// with [`DatatypeState::DueToCreate`].
+    /// with [`DatatypeState::Creating`].
     pub fn create_datatype(&self, key: impl IntoString) -> DatatypeBuilder<'_> {
-        DatatypeBuilder::new(self, key.into(), DatatypeState::DueToCreate)
+        DatatypeBuilder::new(self, key.into(), DatatypeState::Creating)
     }
 
     /// Get `DatatypeBuilder` to subscribe or create a `Datatype` identified by `key`.
     ///
     /// The `Datatype` built by this builder will be marked
-    /// with [`DatatypeState::DueToSubscribeOrCreate`].
+    /// with [`DatatypeState::SubscribingOrCreating`].
     pub fn subscribe_or_create_datatype(&self, key: impl IntoString) -> DatatypeBuilder<'_> {
-        DatatypeBuilder::new(self, key.into(), DatatypeState::DueToSubscribeOrCreate)
+        DatatypeBuilder::new(self, key.into(), DatatypeState::SubscribingOrCreating)
     }
 
     #[cfg(test)]
@@ -234,14 +234,14 @@ mod tests_client {
 
         assert!(client1.get_datatype("k1").is_none());
         let counter1 = client1.subscribe_datatype("k1").build_counter().unwrap();
-        assert_eq!(DatatypeState::DueToSubscribe, counter1.get_state());
+        assert_eq!(DatatypeState::Subscribing, counter1.get_state());
         assert!(client1.get_datatype("k1").is_some());
 
         let client2 = Client::builder(get_test_collection_name!(), get_test_collection_name!())
             .build()
             .unwrap();
         let counter2 = client2.create_datatype("k1").build_counter().unwrap();
-        assert_eq!(DatatypeState::DueToCreate, counter2.get_state());
+        assert_eq!(DatatypeState::Creating, counter2.get_state());
 
         let client3 = Client::builder(get_test_collection_name!(), get_test_collection_name!())
             .build()
@@ -250,7 +250,7 @@ mod tests_client {
             .subscribe_or_create_datatype("k1")
             .build_counter()
             .unwrap();
-        assert_eq!(counter3.get_state(), DatatypeState::DueToSubscribeOrCreate);
+        assert_eq!(counter3.get_state(), DatatypeState::SubscribingOrCreating);
     }
 
     #[test]
@@ -297,9 +297,17 @@ mod tests_client {
             .build()
             .unwrap();
 
-        client1.create_datatype(key.clone()).build_counter().unwrap().sync().unwrap();
+        client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap()
+            .sync()
+            .unwrap();
 
-        let counter = client2.create_datatype(key.clone()).build_counter().unwrap();
+        let counter = client2
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
         assert!(client2.get_datatype(&key).is_some());
         assert!(matches!(
             counter.sync().unwrap_err(),
@@ -321,7 +329,10 @@ mod tests_client {
             .unwrap();
         let key = get_test_func_name!();
 
-        let counter = client.subscribe_datatype(key.clone()).build_counter().unwrap();
+        let counter = client
+            .subscribe_datatype(key.clone())
+            .build_counter()
+            .unwrap();
         assert!(client.get_datatype(&key).is_some());
         assert!(matches!(
             counter.sync().unwrap_err(),
@@ -350,7 +361,7 @@ mod tests_client {
         let old_core = counter.get_core() as *const _;
 
         let removed = client.unsubscribe_datatype(counter.get_key()).unwrap();
-        assert_eq!(removed.get_state(), DatatypeState::DueToUnsubscribe);
+        assert_eq!(removed.get_state(), DatatypeState::Unsubscribing);
         assert!(client.get_datatype(counter.get_key()).is_some());
 
         counter.sync().unwrap();
@@ -441,7 +452,7 @@ mod tests_client {
             .until(|| counter.get_state() == DatatypeState::Subscribed);
 
         let removed = client.unsubscribe_datatype(counter.get_key()).unwrap();
-        assert_eq!(removed.get_state(), DatatypeState::DueToUnsubscribe);
+        assert_eq!(removed.get_state(), DatatypeState::Unsubscribing);
         assert!(client.get_datatype(counter.get_key()).is_some());
 
         awaitility::at_most(std::time::Duration::from_secs(1))

--- a/src/clients/common.rs
+++ b/src/clients/common.rs
@@ -1,11 +1,13 @@
 use std::{
     fmt::{Debug, Display, Formatter},
-    sync::Arc,
+    sync::{Arc, Weak},
 };
 
+use parking_lot::RwLock;
 use tokio::runtime::Handle;
 
 use crate::{
+    clients::datatype_manager::DatatypeManager,
     connectivity::Connectivity,
     types::{common::ArcStr, uid::Cuid},
     utils::runtime::{get_or_init_runtime_handle, reserve_to_shutdown_runtime},
@@ -17,6 +19,7 @@ pub struct ClientCommon {
     pub alias: ArcStr,
     pub handle: Handle,
     pub connectivity: Arc<dyn Connectivity>,
+    datatype_manager: RwLock<Weak<RwLock<DatatypeManager>>>,
 }
 
 impl ClientCommon {
@@ -33,7 +36,18 @@ impl ClientCommon {
             alias,
             cuid,
             connectivity,
+            datatype_manager: RwLock::new(Weak::new()),
         })
+    }
+
+    pub(crate) fn set_datatype_manager(&self, manager: Weak<RwLock<DatatypeManager>>) {
+        *self.datatype_manager.write() = manager;
+    }
+
+    pub(crate) fn detach_datatype_if_same_instance(&self, key: &str, core_id: usize) {
+        if let Some(manager) = self.datatype_manager.read().upgrade() {
+            manager.write().remove_if_same_instance(key, core_id);
+        }
     }
 
     #[cfg(test)]

--- a/src/clients/datatype_manager.rs
+++ b/src/clients/datatype_manager.rs
@@ -94,20 +94,20 @@ mod tests_datatype_manager {
         let res1 = dm.subscribe_or_create_datatype(
             "k1",
             DataType::Counter,
-            DatatypeState::DueToCreate,
+            DatatypeState::Creating,
             Default::default(),
             false,
             Default::default(),
         );
         assert!(res1.is_ok());
         let dt1 = res1.unwrap();
-        assert_eq!(dt1.get_state(), DatatypeState::DueToCreate);
+        assert_eq!(dt1.get_state(), DatatypeState::Creating);
         assert_eq!(dt1.get_type(), DataType::Counter);
 
         let res2 = dm.subscribe_or_create_datatype(
             "k1",
             DataType::Map,
-            DatatypeState::DueToCreate,
+            DatatypeState::Creating,
             Default::default(),
             false,
             Default::default(),
@@ -120,7 +120,7 @@ mod tests_datatype_manager {
         let res3 = dm.subscribe_or_create_datatype(
             "k1",
             DataType::Counter,
-            DatatypeState::DueToSubscribeOrCreate,
+            DatatypeState::SubscribingOrCreating,
             Default::default(),
             false,
             Default::default(),

--- a/src/clients/datatype_manager.rs
+++ b/src/clients/datatype_manager.rs
@@ -28,6 +28,18 @@ impl DatatypeManager {
         self.datatypes.get(key).cloned()
     }
 
+    pub fn remove_if_same_instance(&mut self, key: &str, core_id: usize) -> Option<DatatypeSet> {
+        if self
+            .datatypes
+            .get(key)
+            .is_some_and(|dt| dt.get_core_id() == core_id)
+        {
+            self.datatypes.remove(key)
+        } else {
+            None
+        }
+    }
+
     pub fn subscribe_or_create_datatype(
         &mut self,
         key: &str,

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -169,27 +169,42 @@ impl Connectivity for LocalConnectivity {
     fn push_pull(&self, pushed: &PushPullPack) -> Result<PushPullPack, ConnectivityError> {
         let resource_id = pushed.resource_id();
 
-        let local_datatype_server_with_lock = self
+        let server_with_lock = self
             .get_local_datatype_server(&resource_id)
             .ok_or_else(|| ConnectivityError::ResourceNotFound(resource_id.clone()))?;
-        let mut local_datatype_server = local_datatype_server_with_lock.write();
-        let pulled = match pushed.state {
-            DatatypeState::DueToCreate => local_datatype_server.process_due_to_create(pushed)?,
-            DatatypeState::DueToSubscribe => {
-                local_datatype_server.process_due_to_subscribe(pushed)?
-            }
-            DatatypeState::DueToSubscribeOrCreate => {
-                local_datatype_server.process_due_to_subscribe_or_create(pushed)?
-            }
-            DatatypeState::Subscribed => {
-                local_datatype_server.process_subscribed(pushed, self.is_realtime())?
-            }
-            DatatypeState::DueToUnsubscribe => {
-                local_datatype_server.process_due_to_unsubscribe(pushed, self.is_realtime())?
-            }
-            DatatypeState::DueToDelete => local_datatype_server.process_due_to_delete(pushed)?,
-            DatatypeState::Disabled => local_datatype_server.process_disabled(pushed)?,
+        let (pulled, should_remove_server) = {
+            let mut server = server_with_lock.write();
+            let pulled = match pushed.state {
+                DatatypeState::DueToCreate => server.process_due_to_create(pushed)?,
+                DatatypeState::DueToSubscribe => server.process_due_to_subscribe(pushed)?,
+                DatatypeState::DueToSubscribeOrCreate => {
+                    server.process_due_to_subscribe_or_create(pushed)?
+                }
+                DatatypeState::Subscribed => {
+                    server.process_subscribed(pushed, self.is_realtime())?
+                }
+                DatatypeState::DueToUnsubscribe => {
+                    server.process_due_to_unsubscribe(pushed, self.is_realtime())?
+                }
+                DatatypeState::DueToDelete => server.process_due_to_delete(pushed)?,
+                DatatypeState::Disabled => server.process_disabled(pushed)?,
+            };
+            (
+                pulled,
+                pushed.state == DatatypeState::DueToUnsubscribe && server.is_empty(),
+            )
         };
+
+        if should_remove_server {
+            let mut datatypes = self.datatype_servers.write();
+            if datatypes
+                .get(&resource_id)
+                .is_some_and(|server| Arc::ptr_eq(server, &server_with_lock))
+            {
+                datatypes.remove(&resource_id);
+            }
+        }
+
         Ok(pulled)
     }
 
@@ -310,5 +325,91 @@ mod tests_local_connectivity {
 
         counter2.sync().unwrap();
         assert_eq!(counter2.get_value(), 7);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_promote_remaining_client_when_creator_unsubscribes() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+        let client1 = Client::builder(collection.clone(), "client1")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let client2 = Client::builder(collection.clone(), "client2")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let client3 = Client::builder(collection, "client3")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+
+        let counter1 = client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+        counter1.increase_by(7).unwrap();
+        counter1.sync().unwrap();
+
+        let counter2 = client2
+            .subscribe_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+        counter2.sync().unwrap();
+        assert_eq!(counter2.get_value(), 7);
+
+        counter1.unsubscribe().unwrap();
+        counter1.sync().unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::Disabled);
+
+        let server = connectivity
+            .get_local_datatype_server(&resource_id)
+            .unwrap();
+        assert_eq!(server.read().creator(), &client2.get_cuid());
+
+        counter2.increase_by(5).unwrap();
+        counter2.sync().unwrap();
+
+        let counter3 = client3.subscribe_datatype(key).build_counter().unwrap();
+        counter3.sync().unwrap();
+        assert_eq!(counter3.get_value(), 12);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_remove_server_when_last_client_unsubscribes() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+        let client1 = Client::builder(collection.clone(), "client1")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let client2 = Client::builder(collection, "client2")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+
+        let counter1 = client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+        counter1.increase_by(7).unwrap();
+        counter1.sync().unwrap();
+
+        counter1.unsubscribe().unwrap();
+        counter1.sync().unwrap();
+        assert!(
+            connectivity
+                .get_local_datatype_server(&resource_id)
+                .is_none()
+        );
+
+        let counter2 = client2.create_datatype(key).build_counter().unwrap();
+        counter2.sync().unwrap();
+        assert_eq!(counter2.get_value(), 0);
+        assert_eq!(counter2.get_state(), DatatypeState::Subscribed);
     }
 }

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -185,7 +185,7 @@ impl Connectivity for LocalConnectivity {
                 local_datatype_server.process_subscribed(pushed, self.is_realtime())?
             }
             DatatypeState::DueToUnsubscribe => {
-                local_datatype_server.process_due_to_unsubscribe(pushed)?
+                local_datatype_server.process_due_to_unsubscribe(pushed, self.is_realtime())?
             }
             DatatypeState::DueToDelete => local_datatype_server.process_due_to_delete(pushed)?,
             DatatypeState::Disabled => local_datatype_server.process_disabled(pushed)?,

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -175,23 +175,23 @@ impl Connectivity for LocalConnectivity {
         let (pulled, should_remove_server) = {
             let mut server = server_with_lock.write();
             let pulled = match pushed.state {
-                DatatypeState::DueToCreate => server.process_due_to_create(pushed)?,
-                DatatypeState::DueToSubscribe => server.process_due_to_subscribe(pushed)?,
-                DatatypeState::DueToSubscribeOrCreate => {
-                    server.process_due_to_subscribe_or_create(pushed)?
+                DatatypeState::Creating => server.process_creating(pushed)?,
+                DatatypeState::Subscribing => server.process_subscribing(pushed)?,
+                DatatypeState::SubscribingOrCreating => {
+                    server.process_subscribing_or_creating(pushed)?
                 }
                 DatatypeState::Subscribed => {
                     server.process_subscribed(pushed, self.is_realtime())?
                 }
-                DatatypeState::DueToUnsubscribe => {
-                    server.process_due_to_unsubscribe(pushed, self.is_realtime())?
+                DatatypeState::Unsubscribing => {
+                    server.process_unsubscribing(pushed, self.is_realtime())?
                 }
-                DatatypeState::DueToDelete => server.process_due_to_delete(pushed)?,
+                DatatypeState::Deleting => server.process_deleting(pushed)?,
                 DatatypeState::Disabled => server.process_disabled(pushed)?,
             };
             (
                 pulled,
-                pushed.state == DatatypeState::DueToUnsubscribe && server.is_empty(),
+                pushed.state == DatatypeState::Unsubscribing && server.is_empty(),
             )
         };
 

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -83,6 +83,10 @@ impl LocalDatatypeServer {
         self.sender_map.insert(wired.cuid(), sender);
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.wired_map.is_empty()
+    }
+
     pub fn push_transactions(&mut self, pushed: &PushPullPack) -> (u64, bool) {
         let client_cp = self
             .cseq_map
@@ -304,6 +308,11 @@ impl LocalDatatypeServer {
     #[cfg(test)]
     pub fn get_wired_datatype(&self, cuid: &Cuid) -> Option<Arc<WiredDatatype>> {
         self.wired_map.get(cuid).cloned()
+    }
+
+    #[cfg(test)]
+    pub fn creator(&self) -> &Cuid {
+        &self.creator
     }
 }
 
@@ -598,13 +607,9 @@ mod tests_local_datatype_server {
             DatatypeError::FailedByServerPushPullError(_)
         ));
         assert_eq!(counter.get_state(), DatatypeState::Disabled);
-        let server = connectivity
-            .get_local_datatype_server(&resource_id)
-            .unwrap();
         assert!(
-            server
-                .read()
-                .get_wired_datatype(&client.get_cuid())
+            connectivity
+                .get_local_datatype_server(&resource_id)
                 .is_none()
         );
         assert!(client.get_datatype(counter.get_key()).is_none());

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -210,10 +210,9 @@ impl LocalDatatypeServer {
         is_realtime: bool,
     ) -> Result<PushPullPack, ConnectivityError> {
         let pulled = self.process_client_push(pushed, DatatypeState::Disabled, is_realtime);
-        if pulled.error.is_some() {
-            return Ok(pulled);
-        }
 
+        // Always clean up client registration regardless of error: the client will be Disabled
+        // either way, and leaving stale entries would cause infinite unsubscribe retry loops.
         self.wired_map.remove(&pushed.cuid);
         self.sender_map.remove(&pushed.cuid);
 
@@ -598,6 +597,7 @@ mod tests_local_datatype_server {
             counter.sync().unwrap_err(),
             DatatypeError::FailedByServerPushPullError(_)
         ));
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
         let server = connectivity
             .get_local_datatype_server(&resource_id)
             .unwrap();
@@ -605,9 +605,9 @@ mod tests_local_datatype_server {
             server
                 .read()
                 .get_wired_datatype(&client.get_cuid())
-                .is_some()
+                .is_none()
         );
-        assert!(client.get_datatype(counter.get_key()).is_some());
+        assert!(client.get_datatype(counter.get_key()).is_none());
     }
 
     #[rstest]

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -155,25 +155,34 @@ impl LocalDatatypeServer {
         pushed: &PushPullPack,
         is_realtime: bool,
     ) -> Result<PushPullPack, ConnectivityError> {
+        Ok(self.process_client_push(pushed, DatatypeState::Subscribed, is_realtime))
+    }}
+
+    fn process_client_push(
+        &mut self,
+        pushed: &PushPullPack,
+        success_state: DatatypeState,
+        is_realtime: bool,
+    ) -> PushPullPack {
         let mut pulled = pushed.get_pulled_stub();
         if pulled.is_readonly && !pushed.transactions.is_empty() {
             pulled.error = Some(ServerPushPullError::IllegalPushRequest(
                 "readonly client cannot push transactions".to_string(),
             ));
             pulled.state = DatatypeState::Disabled;
-            return Ok(pulled);
+            return pulled;
         }
         let (cseq, pushed_any) = self.push_transactions(pushed);
         pulled.checkpoint.sseq = pushed.checkpoint.sseq;
         pulled.checkpoint.cseq = cseq;
         self.pull_transactions(&mut pulled);
-        pulled.state = DatatypeState::Subscribed;
+        pulled.state = success_state;
         if is_realtime && pushed_any {
             self.notify_pushed(&pushed.cuid);
         }
 
-        Ok(pulled)
-    }}
+        pulled
+    }
 
     #[instrument(skip_all)]
     fn notify_pushed(&self, cuid: &Cuid) {
@@ -198,8 +207,21 @@ impl LocalDatatypeServer {
     pub fn process_due_to_unsubscribe(
         &mut self,
         pushed: &PushPullPack,
+        is_realtime: bool,
     ) -> Result<PushPullPack, ConnectivityError> {
-        let pulled = pushed.get_pulled_stub();
+        let pulled = self.process_client_push(pushed, DatatypeState::Disabled, is_realtime);
+        if pulled.error.is_some() {
+            return Ok(pulled);
+        }
+
+        self.wired_map.remove(&pushed.cuid);
+        self.sender_map.remove(&pushed.cuid);
+
+        if self.creator == pushed.cuid {
+            if let Some(next_creator) = self.wired_map.keys().next() {
+                self.creator = next_creator.clone();
+            }
+        }
         Ok(pulled)
     }}
 
@@ -540,6 +562,52 @@ mod tests_local_datatype_server {
                 counter2.get_attr().get_duid()
             );
         }
+    }
+
+    #[test]
+    #[instrument]
+    fn can_reject_readonly_due_to_unsubscribe_with_transactions() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+
+        let client = Client::builder(collection, "client")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype(key).build_counter().unwrap();
+        counter.sync().unwrap();
+        counter.increase().unwrap();
+        counter.unsubscribe().unwrap();
+
+        let interceptor = connectivity
+            .get_wired_interceptor(&resource_id, &client.get_cuid())
+            .unwrap();
+        interceptor
+            .set_before_push(push_set_readonly)
+            .set_after_pull(|pull| {
+                assert_eq!(pull.state, DatatypeState::Disabled);
+                assert_eq!(
+                    pull.error,
+                    Some(ServerPushPullError::IllegalPushRequest(String::new()))
+                );
+                Ok(())
+            });
+
+        assert!(matches!(
+            counter.sync().unwrap_err(),
+            DatatypeError::FailedByServerPushPullError(_)
+        ));
+        let server = connectivity
+            .get_local_datatype_server(&resource_id)
+            .unwrap();
+        assert!(
+            server
+                .read()
+                .get_wired_datatype(&client.get_cuid())
+                .is_some()
+        );
+        assert!(client.get_datatype(counter.get_key()).is_some());
     }
 
     #[rstest]

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -110,7 +110,7 @@ impl LocalDatatypeServer {
     }
 
     datatype_server_instrument! {
-    pub fn process_due_to_create(
+    pub fn process_creating(
         &mut self,
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
@@ -142,14 +142,14 @@ impl LocalDatatypeServer {
     }}
 
     datatype_server_instrument! {
-    pub fn process_due_to_subscribe_or_create(
+    pub fn process_subscribing_or_creating(
         &mut self,
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
         if self.created {
-            self.process_due_to_subscribe(pushed)
+            self.process_subscribing(pushed)
         } else {
-            self.process_due_to_create(pushed)
+            self.process_creating(pushed)
         }
     }}
 
@@ -208,7 +208,7 @@ impl LocalDatatypeServer {
     }
 
     datatype_server_instrument! {
-    pub fn process_due_to_unsubscribe(
+    pub fn process_unsubscribing(
         &mut self,
         pushed: &PushPullPack,
         is_realtime: bool,
@@ -229,7 +229,7 @@ impl LocalDatatypeServer {
     }}
 
     datatype_server_instrument! {
-    pub fn process_due_to_delete(
+    pub fn process_deleting(
         &mut self,
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
@@ -247,7 +247,7 @@ impl LocalDatatypeServer {
     }}
 
     datatype_server_instrument! {
-    pub fn process_due_to_subscribe(
+    pub fn process_subscribing(
         &mut self,
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
@@ -398,7 +398,7 @@ mod tests_local_datatype_server {
         10,
     )]
     #[instrument]
-    fn can_process_due_to_create(
+    fn can_process_creating(
         #[case] pre_create: bool,
         #[case] modify_push: fn(&mut PushPullPack),
         #[case] expected_is_readonly: bool,
@@ -496,7 +496,7 @@ mod tests_local_datatype_server {
         CheckPoint::new(0, 0),
     )]
     #[instrument]
-    fn can_process_due_to_subscribe(
+    fn can_process_subscribing(
         #[case] creator_sync: bool,
         #[case] modify_push: fn(&mut PushPullPack),
         #[case] expected_error: Option<ServerPushPullError>,
@@ -574,7 +574,7 @@ mod tests_local_datatype_server {
 
     #[test]
     #[instrument]
-    fn can_reject_readonly_due_to_unsubscribe_with_transactions() {
+    fn can_reject_readonly_unsubscribing_with_transactions() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
         let (collection, key, resource_id) = get_test_ids!();

--- a/src/connectivity/null_connectivity.rs
+++ b/src/connectivity/null_connectivity.rs
@@ -64,7 +64,8 @@ impl Connectivity for NullConnectivity {
                 self.push_transaction(pushed, &mut pulled);
             }
             DatatypeState::DueToUnsubscribe => {
-                todo!()
+                pulled.state = DatatypeState::Disabled;
+                self.push_transaction(pushed, &mut pulled);
             }
             DatatypeState::DueToDelete => {
                 todo!()
@@ -122,5 +123,16 @@ mod tests_null_connectivity {
             pulled2.error.unwrap(),
             ServerPushPullError::IllegalPushRequest(String::new())
         );
+
+        let mut pushed3 = PushPullPack::new(&attr, DatatypeState::DueToUnsubscribe);
+        let cseq = op_id.next_cseq();
+        pushed3
+            .transactions
+            .push(Arc::new(Transaction::new(&op_id.cuid, cseq)));
+        let res3 = null_connectivity.push_pull(&pushed3);
+        assert!(res3.is_ok());
+        let pulled3 = res3.unwrap();
+        assert_eq!(pulled3.state, DatatypeState::Disabled);
+        assert_eq!(pulled3.checkpoint.cseq, pushed3.checkpoint.cseq);
     }
 }

--- a/src/connectivity/null_connectivity.rs
+++ b/src/connectivity/null_connectivity.rs
@@ -38,7 +38,7 @@ impl Connectivity for NullConnectivity {
         let mut pulled = pushed.get_pulled_stub();
 
         match pushed.state {
-            DatatypeState::DueToCreate | DatatypeState::DueToSubscribeOrCreate => {
+            DatatypeState::Creating | DatatypeState::SubscribingOrCreating => {
                 if pushed.is_readonly {
                     self.set_illegal_push_request(
                         &mut pulled,
@@ -49,7 +49,7 @@ impl Connectivity for NullConnectivity {
                 pulled.state = DatatypeState::Subscribed;
                 self.push_transaction(pushed, &mut pulled);
             }
-            DatatypeState::DueToSubscribe => {
+            DatatypeState::Subscribing => {
                 if !pushed.transactions.is_empty() {
                     self.set_illegal_push_request(
                         &mut pulled,
@@ -63,11 +63,11 @@ impl Connectivity for NullConnectivity {
                 pulled.state = DatatypeState::Subscribed;
                 self.push_transaction(pushed, &mut pulled);
             }
-            DatatypeState::DueToUnsubscribe => {
+            DatatypeState::Unsubscribing => {
                 pulled.state = DatatypeState::Disabled;
                 self.push_transaction(pushed, &mut pulled);
             }
-            DatatypeState::DueToDelete => {
+            DatatypeState::Deleting => {
                 todo!()
             }
             DatatypeState::Disabled => {
@@ -100,7 +100,7 @@ mod tests_null_connectivity {
         let null_connectivity = NullConnectivity {};
         let attr = new_attribute!(DataType::Counter);
 
-        let mut pushed1 = PushPullPack::new(&attr, DatatypeState::DueToCreate);
+        let mut pushed1 = PushPullPack::new(&attr, DatatypeState::Creating);
         pushed1.is_readonly = true;
         let res1 = null_connectivity.push_pull(&pushed1);
         assert!(res1.is_ok());
@@ -110,7 +110,7 @@ mod tests_null_connectivity {
             ServerPushPullError::IllegalPushRequest(String::new())
         );
 
-        let mut pushed2 = PushPullPack::new(&attr, DatatypeState::DueToSubscribe);
+        let mut pushed2 = PushPullPack::new(&attr, DatatypeState::Subscribing);
         let mut op_id = OperationId::new();
         let cseq = op_id.next_cseq();
         pushed2
@@ -124,7 +124,7 @@ mod tests_null_connectivity {
             ServerPushPullError::IllegalPushRequest(String::new())
         );
 
-        let mut pushed3 = PushPullPack::new(&attr, DatatypeState::DueToUnsubscribe);
+        let mut pushed3 = PushPullPack::new(&attr, DatatypeState::Unsubscribing);
         let cseq = op_id.next_cseq();
         pushed3
             .transactions

--- a/src/datatypes/builder.rs
+++ b/src/datatypes/builder.rs
@@ -29,11 +29,11 @@ use crate::{
 /// let client = Client::builder("docs-example", "DatatypeBuilder-test").build().unwrap();
 /// assert_eq!(
 ///     client.subscribe_datatype("k1").build_counter().unwrap().get_state(),
-///     DatatypeState::DueToSubscribe
+///     DatatypeState::Subscribing
 /// );
 /// assert_eq!(
 ///     client.create_datatype("k2").build_counter().unwrap().get_state(),
-///     DatatypeState::DueToCreate
+///     DatatypeState::Creating
 /// );
 /// assert_eq!(
 ///     client
@@ -41,7 +41,7 @@ use crate::{
 ///         .build_counter()
 ///         .unwrap()
 ///         .get_state(),
-///     DatatypeState::DueToSubscribeOrCreate
+///     DatatypeState::SubscribingOrCreating
 /// );
 /// ```
 pub struct DatatypeBuilder<'c> {
@@ -249,7 +249,7 @@ mod tests_datatype_builder {
             .subscribe_datatype("subscribe_dt")
             .build_counter()
             .unwrap();
-        assert_eq!(counter.get_state(), DatatypeState::DueToSubscribe);
+        assert_eq!(counter.get_state(), DatatypeState::Subscribing);
         assert!(matches!(
             counter.increase().unwrap_err(),
             DatatypeError::Disallowed(_)
@@ -259,7 +259,7 @@ mod tests_datatype_builder {
             .subscribe_or_create_datatype("subscribe_or_create_dt")
             .build_counter()
             .unwrap();
-        assert_eq!(counter.get_state(), DatatypeState::DueToSubscribeOrCreate);
+        assert_eq!(counter.get_state(), DatatypeState::SubscribingOrCreating);
         assert!(counter.increase().is_ok());
     }
 

--- a/src/datatypes/common.rs
+++ b/src/datatypes/common.rs
@@ -151,6 +151,20 @@ impl Attribute {
             _ => return None,
         })
     }
+
+    pub(crate) fn detach_datatype_if_same_instance(&self) {
+        let Some(transactional) = self
+            .weak_transactional
+            .read()
+            .as_ref()
+            .and_then(Weak::upgrade)
+        else {
+            return;
+        };
+        let core_id = Arc::as_ptr(&transactional) as usize;
+        self.client_common
+            .detach_datatype_if_same_instance(&self.key, core_id);
+    }
 }
 
 #[cfg(test)]

--- a/src/datatypes/counter.rs
+++ b/src/datatypes/counter.rs
@@ -214,7 +214,7 @@ mod tests_counter {
     #[test]
     #[instrument]
     fn can_use_counter_operations() {
-        let counter = Counter::new_for_test(DatatypeState::DueToCreate);
+        let counter = Counter::new_for_test(DatatypeState::Creating);
         assert_eq!(1, counter.increase().unwrap());
         assert_eq!(11, counter.increase_by(10).unwrap());
         assert_eq!(11, counter.get_value());
@@ -244,7 +244,7 @@ mod tests_counter {
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     #[instrument]
     async fn can_run_transactions_concurrently() {
-        let counter = Counter::new_for_test(DatatypeState::DueToCreate);
+        let counter = Counter::new_for_test(DatatypeState::Creating);
         let mut join_handles = vec![];
         let parent_span = Span::current();
 

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -21,7 +21,7 @@ use crate::{
 /// let counter = client.create_datatype("test-counter".to_string()).build_counter().unwrap();
 /// assert_eq!(counter.get_key(), "test-counter");
 /// assert_eq!(counter.get_type(), DataType::Counter);
-/// assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
+/// assert_eq!(counter.get_state(), DatatypeState::Creating);
 /// ```
 pub trait Datatype {
     /// Returns a unique identifier used to distinguish instances in a collection.
@@ -76,8 +76,14 @@ pub trait Datatype {
 
     /// Unsubscribes this datatype from the connectivity backend.
     ///
-    /// After a successful unsubscribe, the datatype transitions to
-    /// [`DatatypeState::Disabled`] and should no longer be used for writes or sync.
+    /// This records local intent by transitioning the datatype to
+    /// [`DatatypeState::Unsubscribing`]. Backend acknowledgement happens on the
+    /// next push/pull: realtime connectivity can trigger it automatically, while
+    /// manual connectivity requires an explicit [`sync()`](Self::sync).
+    ///
+    /// Once the backend confirms unsubscribe, the datatype transitions to
+    /// [`DatatypeState::Disabled`] and client-managed datatypes are detached from
+    /// their owning client.
     fn unsubscribe(&self) -> Result<(), DatatypeError>;
 
     fn set_handler(&self, id: usize, handler: DatatypeHandler);
@@ -168,12 +174,12 @@ mod tests_datatype_trait {
         let key = attr.key.as_ref();
         let data = TransactionalDatatype::new_arc(
             attr.clone(),
-            DatatypeState::DueToCreate,
+            DatatypeState::Creating,
             Default::default(),
         );
         assert_eq!(data.get_key(), key);
         assert_eq!(data.get_type(), DataType::Counter);
-        assert_eq!(data.get_state(), DatatypeState::DueToCreate);
+        assert_eq!(data.get_state(), DatatypeState::Creating);
         assert_eq!(data.get_server_version(), 0);
         assert_eq!(data.get_client_version(), 0);
         assert_eq!(data.get_synced_client_version(), 0);
@@ -209,7 +215,7 @@ mod tests_datatype_trait {
             counter1.sync().unwrap_err(),
             DatatypeError::FailedByClientPushPullError(ClientPushPullError::ExceedMaxMemSize)
         );
-        assert_eq!(counter1.get_state(), DatatypeState::DueToCreate);
+        assert_eq!(counter1.get_state(), DatatypeState::Creating);
 
         // make a success case
         interceptor1.set_after_pull(|_pull| Ok(()));
@@ -235,12 +241,12 @@ mod tests_datatype_trait {
             counter.unsubscribe().unwrap_err(),
             DatatypeError::Disallowed(_)
         ));
-        assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
+        assert_eq!(counter.get_state(), DatatypeState::Creating);
     }
 
     #[test]
     #[instrument]
-    fn can_mark_due_to_unsubscribe() {
+    fn can_mark_unsubscribing() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
         let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
@@ -256,12 +262,12 @@ mod tests_datatype_trait {
 
         counter.unsubscribe().unwrap();
 
-        assert_eq!(counter.get_state(), DatatypeState::DueToUnsubscribe);
+        assert_eq!(counter.get_state(), DatatypeState::Unsubscribing);
     }
 
     #[test]
     #[instrument]
-    fn can_reject_write_and_repeated_unsubscribe_while_due_to_unsubscribe() {
+    fn can_reject_write_and_repeated_unsubscribe_while_unsubscribing() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
         let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
@@ -276,7 +282,7 @@ mod tests_datatype_trait {
 
         counter.unsubscribe().unwrap();
 
-        assert_eq!(counter.get_state(), DatatypeState::DueToUnsubscribe);
+        assert_eq!(counter.get_state(), DatatypeState::Unsubscribing);
         assert!(matches!(
             counter.increase().unwrap_err(),
             DatatypeError::Disallowed(_)
@@ -301,7 +307,7 @@ mod tests_datatype_trait {
         counter.sync().unwrap();
 
         counter.unsubscribe().unwrap();
-        assert_eq!(counter.get_state(), DatatypeState::DueToUnsubscribe);
+        assert_eq!(counter.get_state(), DatatypeState::Unsubscribing);
         counter.sync().unwrap();
 
         assert_eq!(counter.get_state(), DatatypeState::Disabled);
@@ -314,7 +320,7 @@ mod tests_datatype_trait {
 
     #[test]
     #[instrument]
-    fn can_disable_due_to_unsubscribe_on_protocol_violation() {
+    fn can_disable_unsubscribing_on_protocol_violation() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
         let (collection, key, resource_id) = get_test_ids!();

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -261,6 +261,34 @@ mod tests_datatype_trait {
 
     #[test]
     #[instrument]
+    fn can_reject_write_and_repeated_unsubscribe_while_due_to_unsubscribe() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+        let counter = client
+            .create_datatype(get_test_func_name!())
+            .build_counter()
+            .unwrap();
+        counter.sync().unwrap();
+
+        counter.unsubscribe().unwrap();
+
+        assert_eq!(counter.get_state(), DatatypeState::DueToUnsubscribe);
+        assert!(matches!(
+            counter.increase().unwrap_err(),
+            DatatypeError::Disallowed(_)
+        ));
+        assert!(matches!(
+            counter.unsubscribe().unwrap_err(),
+            DatatypeError::Disallowed(_)
+        ));
+    }
+
+    #[test]
+    #[instrument]
     fn can_sync_unsubscribe_to_disabled() {
         let connectivity = LocalConnectivity::new_arc();
         connectivity.set_realtime(false);
@@ -286,6 +314,36 @@ mod tests_datatype_trait {
                 .get_wired_datatype(&client.get_cuid())
                 .is_none()
         );
+    }
+
+    #[test]
+    #[instrument]
+    fn can_disable_due_to_unsubscribe_on_protocol_violation() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+        let client = Client::builder(collection, get_test_func_name!())
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype(key).build_counter().unwrap();
+        counter.sync().unwrap();
+        counter.unsubscribe().unwrap();
+
+        let interceptor = connectivity
+            .get_wired_interceptor(&resource_id, &client.get_cuid())
+            .unwrap();
+        interceptor.set_after_pull(|pull| {
+            pull.state = DatatypeState::Subscribed;
+            Ok(())
+        });
+
+        assert!(matches!(
+            counter.sync().unwrap_err(),
+            DatatypeError::FailedByProtocolViolation(_)
+        ));
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+        assert!(client.get_datatype(counter.get_key()).is_none());
     }
 
     #[test]

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -74,6 +74,12 @@ pub trait Datatype {
     /// ```
     fn sync(&self) -> Result<(), DatatypeError>;
 
+    /// Unsubscribes this datatype from the connectivity backend.
+    ///
+    /// After a successful unsubscribe, the datatype transitions to
+    /// [`DatatypeState::Disabled`] and should no longer be used for writes or sync.
+    fn unsubscribe(&self) -> Result<(), DatatypeError>;
+
     fn set_handler(&self, id: usize, handler: DatatypeHandler);
 
     fn unset_handler(&self, id: usize) -> Option<DatatypeHandler>;
@@ -118,6 +124,10 @@ where
         self.get_core().sync()
     }
 
+    fn unsubscribe(&self) -> Result<(), DatatypeError> {
+        self.get_core().unsubscribe()
+    }
+
     fn set_handler(&self, id: usize, handler: DatatypeHandler) {
         self.get_core().set_handler(id, handler)
     }
@@ -134,6 +144,8 @@ where
 
 #[cfg(test)]
 mod tests_datatype_trait {
+    use std::time::Duration;
+
     use tracing::instrument;
 
     use crate::{
@@ -203,5 +215,134 @@ mod tests_datatype_trait {
         interceptor1.set_after_pull(|_pull| Ok(()));
         assert!(counter1.sync().is_ok());
         assert_eq!(counter1.get_state(), DatatypeState::Subscribed);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_reject_unsubscribe_before_subscribed() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+        let counter = client
+            .create_datatype(get_test_func_name!())
+            .build_counter()
+            .unwrap();
+
+        assert!(matches!(
+            counter.unsubscribe().unwrap_err(),
+            DatatypeError::Disallowed(_)
+        ));
+        assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_mark_due_to_unsubscribe() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+        let counter = client
+            .create_datatype(get_test_func_name!())
+            .build_counter()
+            .unwrap();
+        counter.sync().unwrap();
+        assert_eq!(counter.get_state(), DatatypeState::Subscribed);
+
+        counter.unsubscribe().unwrap();
+
+        assert_eq!(counter.get_state(), DatatypeState::DueToUnsubscribe);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_sync_unsubscribe_to_disabled() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+        let client = Client::builder(collection, get_test_func_name!())
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype(key).build_counter().unwrap();
+        counter.sync().unwrap();
+
+        counter.unsubscribe().unwrap();
+        assert_eq!(counter.get_state(), DatatypeState::DueToUnsubscribe);
+        counter.sync().unwrap();
+
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+        let server = connectivity
+            .get_local_datatype_server(&resource_id)
+            .unwrap();
+        assert!(
+            server
+                .read()
+                .get_wired_datatype(&client.get_cuid())
+                .is_none()
+        );
+    }
+
+    #[test]
+    #[instrument]
+    fn can_unsubscribe_with_pending_transactions() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, _) = get_test_ids!();
+        let client1 = Client::builder(collection.clone(), "client1")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let client2 = Client::builder(collection, "client2")
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+
+        let counter1 = client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+        counter1.sync().unwrap();
+
+        let counter2 = client2.subscribe_datatype(key).build_counter().unwrap();
+        counter2.sync().unwrap();
+        assert_eq!(counter2.get_value(), 0);
+
+        counter1.increase_by(7).unwrap();
+        counter1.unsubscribe().unwrap();
+        counter1.sync().unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::Disabled);
+
+        counter2.sync().unwrap();
+        assert_eq!(counter2.get_value(), 7);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_auto_sync_unsubscribe_in_realtime() {
+        let connectivity = LocalConnectivity::new_arc();
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .with_connectivity(connectivity)
+            .build()
+            .unwrap();
+        let counter = client
+            .create_datatype(get_test_func_name!())
+            .build_counter()
+            .unwrap();
+
+        awaitility::at_most(Duration::from_secs(1))
+            .poll_interval(Duration::from_micros(100))
+            .until(|| counter.get_state() == DatatypeState::Subscribed);
+
+        counter.unsubscribe().unwrap();
+
+        awaitility::at_most(Duration::from_secs(1))
+            .poll_interval(Duration::from_micros(100))
+            .until(|| counter.get_state() == DatatypeState::Disabled);
     }
 }

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -305,13 +305,9 @@ mod tests_datatype_trait {
         counter.sync().unwrap();
 
         assert_eq!(counter.get_state(), DatatypeState::Disabled);
-        let server = connectivity
-            .get_local_datatype_server(&resource_id)
-            .unwrap();
         assert!(
-            server
-                .read()
-                .get_wired_datatype(&client.get_cuid())
+            connectivity
+                .get_local_datatype_server(&resource_id)
                 .is_none()
         );
     }

--- a/src/datatypes/datatype_set.rs
+++ b/src/datatypes/datatype_set.rs
@@ -3,7 +3,10 @@ use std::{collections::BTreeMap, sync::Arc};
 use crate::{
     Counter, DataType, Datatype, DatatypeState,
     clients::common::ClientCommon,
-    datatypes::{common::Attribute, option::DatatypeOption, transactional::TransactionalDatatype},
+    datatypes::{
+        common::Attribute, datatype::DatatypeBlanket, option::DatatypeOption,
+        transactional::TransactionalDatatype,
+    },
     types::common::ArcStr,
 };
 
@@ -29,6 +32,18 @@ impl DatatypeSet {
     pub fn get_state(&self) -> DatatypeState {
         match self {
             DatatypeSet::Counter(cnt) => cnt.get_state(),
+        }
+    }
+
+    pub(crate) fn get_core_id(&self) -> usize {
+        match self {
+            DatatypeSet::Counter(cnt) => cnt.get_core() as *const TransactionalDatatype as usize,
+        }
+    }
+
+    pub(crate) fn unsubscribe(&self) -> Result<(), crate::DatatypeError> {
+        match self {
+            DatatypeSet::Counter(cnt) => cnt.unsubscribe(),
         }
     }
 

--- a/src/datatypes/datatype_set.rs
+++ b/src/datatypes/datatype_set.rs
@@ -28,7 +28,7 @@ impl DatatypeSet {
     }
 
     /// Returns [`DatatypeState`] of the internal datatype in this wrapper,
-    /// e.g., `DatatypeState::DueToCreate`
+    /// e.g., `DatatypeState::Creating`
     pub fn get_state(&self) -> DatatypeState {
         match self {
             DatatypeSet::Counter(cnt) => cnt.get_state(),
@@ -102,7 +102,7 @@ mod tests_datatype_set {
         let ds1 = DatatypeSet::new(
             DataType::Counter,
             "k1".into(),
-            DatatypeState::DueToCreate,
+            DatatypeState::Creating,
             new_client_common!(),
             Default::default(),
             false,

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -318,7 +318,7 @@ mod tests_event_loop {
         let err = counter.sync().unwrap_err();
         assert!(matches!(err, DatatypeError::FailedByClientPushPullError(_)));
         // DatatypeAction::Normal → no state change
-        assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
+        assert_eq!(counter.get_state(), DatatypeState::Creating);
 
         // explicit sync() sends to unbounded channel → bypasses 500ms BackOff wait
         interceptor.set_after_pull(|_| Ok(()));
@@ -356,7 +356,7 @@ mod tests_event_loop {
             }
         });
 
-        assert_eq!(counter.get_state(), DatatypeState::DueToCreate);
+        assert_eq!(counter.get_state(), DatatypeState::Creating);
 
         awaitility::at_most(Duration::from_secs(10))
             .poll_interval(Duration::from_millis(100))

--- a/src/datatypes/handler.rs
+++ b/src/datatypes/handler.rs
@@ -180,7 +180,7 @@ mod tests_handers_manager {
             DatatypeHandler::new().set_on_state_change(move |_ds, old_state, new_state| {
                 let a = count_for_h1.fetch_add(1, Ordering::Relaxed);
                 assert_eq!(a, 0);
-                assert_eq!(old_state, DatatypeState::DueToCreate);
+                assert_eq!(old_state, DatatypeState::Creating);
                 assert_eq!(new_state, DatatypeState::Subscribed);
             });
 
@@ -188,7 +188,7 @@ mod tests_handers_manager {
             DatatypeHandler::new().set_on_state_change(move |_ds, old_state, new_state| {
                 let a = count_for_h2.fetch_add(1, Ordering::Relaxed);
                 assert_eq!(a, 1);
-                assert_eq!(old_state, DatatypeState::DueToCreate);
+                assert_eq!(old_state, DatatypeState::Creating);
                 assert_eq!(new_state, DatatypeState::Subscribed);
             });
 
@@ -241,7 +241,7 @@ mod tests_handers_manager {
             .with_handler(0, handler2)
             .build_counter()
             .unwrap();
-        assert_eq!(counter1.get_state(), DatatypeState::DueToSubscribe);
+        assert_eq!(counter1.get_state(), DatatypeState::Subscribing);
         assert!(matches!(
             counter1.sync().unwrap_err(),
             DatatypeError::FailedToSubscribe(_)

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -170,6 +170,9 @@ impl MutableDatatype {
             self.state = new_state;
             self.handlers_manager
                 .notify_state_change(old_state, new_state);
+            if new_state == DatatypeState::Disabled {
+                self.attr.detach_datatype_if_same_instance();
+            }
         }
     }
 

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -43,7 +43,10 @@ impl<'a> PullHandler<'a> {
             self.enqueue_step(Self::sync_checkpoint);
             Ok(())
         })();
-        self.commit()?;
+        let should_detach = result.is_ok()
+            && self.old_state == DatatypeState::DueToUnsubscribe
+            && self.new_state == DatatypeState::Disabled;
+        self.commit(should_detach)?;
         result
     }
 
@@ -96,7 +99,9 @@ impl<'a> PullHandler<'a> {
                 }
             }
             DatatypeState::DueToUnsubscribe => {
-                todo!()
+                if self.pulled_ppp.state != DatatypeState::Disabled {
+                    self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
+                }
             }
             DatatypeState::DueToDelete => {
                 todo!()
@@ -158,12 +163,15 @@ impl<'a> PullHandler<'a> {
         Ok(())
     }
 
-    fn commit(&mut self) -> Result<(), DatatypeErrorWithActions> {
+    fn commit(&mut self, should_detach: bool) -> Result<(), DatatypeErrorWithActions> {
         let steps = std::mem::take(&mut self.pending_steps);
         for step in steps {
             step(self)?;
         }
         self.mutable.set_state(self.new_state);
+        if should_detach {
+            self.mutable.attr.detach_datatype_if_same_instance();
+        }
         Ok(())
     }
 }

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -43,10 +43,7 @@ impl<'a> PullHandler<'a> {
             self.enqueue_step(Self::sync_checkpoint);
             Ok(())
         })();
-        let should_detach = result.is_ok()
-            && self.old_state == DatatypeState::DueToUnsubscribe
-            && self.new_state == DatatypeState::Disabled;
-        self.commit(should_detach)?;
+        self.commit()?;
         result
     }
 
@@ -73,18 +70,21 @@ impl<'a> PullHandler<'a> {
         match self.old_state {
             DatatypeState::DueToCreate => {
                 if self.pulled_ppp.state != DatatypeState::Subscribed {
+                    self.new_state = DatatypeState::Disabled;
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
                 self.is_created = true;
             }
             DatatypeState::DueToSubscribe => {
                 if self.pulled_ppp.state != DatatypeState::Subscribed {
+                    self.new_state = DatatypeState::Disabled;
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
                 self.enqueue_step(Self::apply_subscribe_response);
             }
             DatatypeState::DueToSubscribeOrCreate => {
                 if self.pulled_ppp.state != DatatypeState::Subscribed {
+                    self.new_state = DatatypeState::Disabled;
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
                 if self.pulled_ppp.duid == self.mutable.attr.get_duid() {
@@ -95,11 +95,13 @@ impl<'a> PullHandler<'a> {
             }
             DatatypeState::Subscribed => {
                 if self.pulled_ppp.state != DatatypeState::Subscribed {
+                    self.new_state = DatatypeState::Disabled;
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
             }
             DatatypeState::DueToUnsubscribe => {
                 if self.pulled_ppp.state != DatatypeState::Disabled {
+                    self.new_state = DatatypeState::Disabled;
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
             }
@@ -163,15 +165,12 @@ impl<'a> PullHandler<'a> {
         Ok(())
     }
 
-    fn commit(&mut self, should_detach: bool) -> Result<(), DatatypeErrorWithActions> {
+    fn commit(&mut self) -> Result<(), DatatypeErrorWithActions> {
         let steps = std::mem::take(&mut self.pending_steps);
         for step in steps {
             step(self)?;
         }
         self.mutable.set_state(self.new_state);
-        if should_detach {
-            self.mutable.attr.detach_datatype_if_same_instance();
-        }
         Ok(())
     }
 }

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -68,21 +68,21 @@ impl<'a> PullHandler<'a> {
         }
 
         match self.old_state {
-            DatatypeState::DueToCreate => {
+            DatatypeState::Creating => {
                 if self.pulled_ppp.state != DatatypeState::Subscribed {
                     self.new_state = DatatypeState::Disabled;
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
                 self.is_created = true;
             }
-            DatatypeState::DueToSubscribe => {
+            DatatypeState::Subscribing => {
                 if self.pulled_ppp.state != DatatypeState::Subscribed {
                     self.new_state = DatatypeState::Disabled;
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
                 self.enqueue_step(Self::apply_subscribe_response);
             }
-            DatatypeState::DueToSubscribeOrCreate => {
+            DatatypeState::SubscribingOrCreating => {
                 if self.pulled_ppp.state != DatatypeState::Subscribed {
                     self.new_state = DatatypeState::Disabled;
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
@@ -99,13 +99,13 @@ impl<'a> PullHandler<'a> {
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
             }
-            DatatypeState::DueToUnsubscribe => {
+            DatatypeState::Unsubscribing => {
                 if self.pulled_ppp.state != DatatypeState::Disabled {
                     self.new_state = DatatypeState::Disabled;
                     self.process_illegal_state_response(self.old_state, self.pulled_ppp.state)?;
                 }
             }
-            DatatypeState::DueToDelete => {
+            DatatypeState::Deleting => {
                 todo!()
             }
             DatatypeState::Disabled => {

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -12,7 +12,7 @@ use crate::{
         mutable::MutableDatatype,
         wired::WiredDatatype,
     },
-    errors::datatypes::DatatypeError,
+    errors::{datatypes::DatatypeError, with_err_out},
     observability::trace::add_span_event,
     operations::Operation,
     utils::{defer_guard::DeferGuard, no_guard_mutex::NoGuardMutex},
@@ -111,6 +111,15 @@ impl Datatype for TransactionalDatatype {
         self.event_loop.send_push_transaction_with_guarantee()
     }
 
+    fn unsubscribe(&self) -> Result<(), DatatypeError> {
+        self.check_subscribed("unsubscribe")?;
+        self.mutable
+            .write()
+            .set_state(DatatypeState::DueToUnsubscribe);
+        self.event_loop.send_push_transaction_with_best_effort();
+        Ok(())
+    }
+
     fn set_handler(&self, id: usize, handler: DatatypeHandler) {
         self.mutable.write().set_handler(id, handler)
     }
@@ -189,6 +198,17 @@ impl TransactionalDatatype {
                 "{} is not allowed in Disabled state",
                 op
             )));
+        }
+        Ok(())
+    }
+
+    fn check_subscribed(&self, op: &str) -> Result<(), DatatypeError> {
+        let state = self.mutable.read().get_state();
+        if state != DatatypeState::Subscribed {
+            return Err(with_err_out!(DatatypeError::Disallowed(format!(
+                "{} is only allowed in Subscribed state, current state is {:?}",
+                op, state
+            ))));
         }
         Ok(())
     }

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -113,9 +113,7 @@ impl Datatype for TransactionalDatatype {
 
     fn unsubscribe(&self) -> Result<(), DatatypeError> {
         self.check_subscribed("unsubscribe")?;
-        self.mutable
-            .write()
-            .set_state(DatatypeState::DueToUnsubscribe);
+        self.mutable.write().set_state(DatatypeState::Unsubscribing);
         self.event_loop.send_push_transaction_with_best_effort();
         Ok(())
     }

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -181,6 +181,29 @@ impl MutableDatatype {
         state == DatatypeState::DueToCreate
             || state == DatatypeState::DueToSubscribe
             || state == DatatypeState::DueToSubscribeOrCreate
+            || state == DatatypeState::DueToUnsubscribe
             || self.push_buffer.last_cseq > self.checkpoint.cseq
+    }
+}
+
+#[cfg(test)]
+mod tests_wired {
+    use crate::{
+        DataType, DatatypeState,
+        datatypes::{
+            common::new_attribute, wired::WiredDatatype, wired_interceptor::WiredInterceptor,
+        },
+    };
+
+    #[test]
+    fn can_push_due_to_unsubscribe() {
+        let attr = new_attribute!(DataType::Counter);
+        let wired = WiredDatatype::new_arc_for_test(
+            attr,
+            DatatypeState::DueToUnsubscribe,
+            WiredInterceptor::new_arc(),
+        );
+
+        assert!(wired.push_if_needed());
     }
 }

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -73,7 +73,7 @@ impl WiredDatatype {
             DatatypeAction::Restart => {
                 let mut mutable = self.mutable.write();
                 mutable.reset();
-                mutable.set_state(DatatypeState::DueToSubscribeOrCreate);
+                mutable.set_state(DatatypeState::SubscribingOrCreating);
             }
             DatatypeAction::Disable => self.mutable.write().disable(),
             DatatypeAction::Reset => {
@@ -178,10 +178,10 @@ impl MutableDatatype {
 
     fn need_push(&self) -> bool {
         let state = self.get_state();
-        state == DatatypeState::DueToCreate
-            || state == DatatypeState::DueToSubscribe
-            || state == DatatypeState::DueToSubscribeOrCreate
-            || state == DatatypeState::DueToUnsubscribe
+        state == DatatypeState::Creating
+            || state == DatatypeState::Subscribing
+            || state == DatatypeState::SubscribingOrCreating
+            || state == DatatypeState::Unsubscribing
             || self.push_buffer.last_cseq > self.checkpoint.cseq
     }
 }
@@ -196,11 +196,11 @@ mod tests_wired {
     };
 
     #[test]
-    fn can_push_due_to_unsubscribe() {
+    fn can_push_unsubscribing() {
         let attr = new_attribute!(DataType::Counter);
         let wired = WiredDatatype::new_arc_for_test(
             attr,
-            DatatypeState::DueToUnsubscribe,
+            DatatypeState::Unsubscribing,
             WiredInterceptor::new_arc(),
         );
 

--- a/src/datatypes/wired_interceptor.rs
+++ b/src/datatypes/wired_interceptor.rs
@@ -85,11 +85,8 @@ mod tests_wired_interceptor {
                 Ok(())
             });
 
-        let wd = WiredDatatype::new_arc_for_test(
-            attr,
-            DatatypeState::DueToCreate,
-            wd_interceptor.clone(),
-        );
+        let wd =
+            WiredDatatype::new_arc_for_test(attr, DatatypeState::Creating, wd_interceptor.clone());
 
         let _ = wd.push_pull();
         let _ = rx.recv();

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -85,12 +85,12 @@ pub enum DatatypeAction {
 impl From<DatatypeState> for DatatypeAction {
     fn from(value: DatatypeState) -> Self {
         match value {
-            DatatypeState::DueToCreate => DatatypeAction::Restart,
-            DatatypeState::DueToSubscribe => DatatypeAction::Restart,
-            DatatypeState::DueToSubscribeOrCreate => DatatypeAction::Restart,
+            DatatypeState::Creating => DatatypeAction::Restart,
+            DatatypeState::Subscribing => DatatypeAction::Restart,
+            DatatypeState::SubscribingOrCreating => DatatypeAction::Restart,
             DatatypeState::Subscribed => DatatypeAction::Normal,
-            DatatypeState::DueToUnsubscribe => DatatypeAction::Normal,
-            DatatypeState::DueToDelete => DatatypeAction::Normal,
+            DatatypeState::Unsubscribing => DatatypeAction::Normal,
+            DatatypeState::Deleting => DatatypeAction::Normal,
             DatatypeState::Disabled => DatatypeAction::Disable,
         }
     }
@@ -123,12 +123,12 @@ mod tests_datatypes {
     use crate::{DatatypeState, errors::datatypes::DatatypeAction};
 
     #[rstest]
-    #[case(DatatypeState::DueToCreate, DatatypeAction::Restart)]
-    #[case(DatatypeState::DueToSubscribe, DatatypeAction::Restart)]
-    #[case(DatatypeState::DueToSubscribeOrCreate, DatatypeAction::Restart)]
+    #[case(DatatypeState::Creating, DatatypeAction::Restart)]
+    #[case(DatatypeState::Subscribing, DatatypeAction::Restart)]
+    #[case(DatatypeState::SubscribingOrCreating, DatatypeAction::Restart)]
     #[case(DatatypeState::Subscribed, DatatypeAction::Normal)]
-    #[case(DatatypeState::DueToUnsubscribe, DatatypeAction::Normal)]
-    #[case(DatatypeState::DueToDelete, DatatypeAction::Normal)]
+    #[case(DatatypeState::Unsubscribing, DatatypeAction::Normal)]
+    #[case(DatatypeState::Deleting, DatatypeAction::Normal)]
     #[case(DatatypeState::Disabled, DatatypeAction::Disable)]
     fn can_convert_datatype_state_into_action(
         #[case] state: DatatypeState,

--- a/src/errors/push_pull.rs
+++ b/src/errors/push_pull.rs
@@ -28,10 +28,8 @@ impl ServerPushPullError {
         match self {
             ServerPushPullError::IllegalPushRequest(msg) => {
                 let data_err = match old_state {
-                    DatatypeState::DueToCreate => DatatypeError::FailedToCreate(msg.to_owned()),
-                    DatatypeState::DueToSubscribe => {
-                        DatatypeError::FailedToSubscribe(msg.to_owned())
-                    }
+                    DatatypeState::Creating => DatatypeError::FailedToCreate(msg.to_owned()),
+                    DatatypeState::Subscribing => DatatypeError::FailedToSubscribe(msg.to_owned()),
                     _ => DatatypeError::FailedByServerPushPullError(self.clone()),
                 };
                 DatatypeErrorWithActions::new(

--- a/src/types/datatype.rs
+++ b/src/types/datatype.rs
@@ -46,37 +46,37 @@ pub enum DataType {
 ///
 /// let client = Client::builder("doc-example", "state-test").build().unwrap();
 ///
-/// // DueToCreate state allows writing
+/// // Creating state allows writing
 /// let counter1 = client.create_datatype("c1").build_counter().unwrap();
-/// assert_eq!(counter1.get_state(), DatatypeState::DueToCreate);
+/// assert_eq!(counter1.get_state(), DatatypeState::Creating);
 /// assert!(counter1.increase().is_ok());
 ///
-/// // DueToSubscribe state prevents writing (state-based)
+/// // Subscribing state prevents writing (state-based)
 /// let counter2 = client.subscribe_datatype("c2").build_counter().unwrap();
-/// assert_eq!(counter2.get_state(), DatatypeState::DueToSubscribe);
+/// assert_eq!(counter2.get_state(), DatatypeState::Subscribing);
 /// assert!(counter2.increase().is_err());
 ///
 /// // Explicit read-only flag prevents writing (flag-based)
 /// let counter3 = client.create_datatype("c3").with_readonly().build_counter().unwrap();
-/// assert_eq!(counter3.get_state(), DatatypeState::DueToCreate);
+/// assert_eq!(counter3.get_state(), DatatypeState::Creating);
 /// assert!(counter3.increase().is_err()); // read-only despite writable state
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum_macros::Display)]
 #[repr(i32)]
 pub enum DatatypeState {
-    /// The datatype is scheduled to be created on the server (writable).
+    /// The datatype is scheduled to be created and subscribed on the server (writable).
     #[default]
-    DueToCreate = 0,
+    Creating = 0,
     /// The datatype is scheduled to be subscribed on the server (read-only).
-    DueToSubscribe = 1,
+    Subscribing = 1,
     /// The datatype is scheduled to be subscribed or created if it doesn't exist (writable).
-    DueToSubscribeOrCreate = 2,
+    SubscribingOrCreating = 2,
     /// The datatype has been successfully subscribed on the server (writable).
     Subscribed = 3,
     /// The datatype is scheduled to be unsubscribed from the server (read-only).
-    DueToUnsubscribe = 4,
+    Unsubscribing = 4,
     /// The datatype is scheduled to be deleted from the server (read-only).
-    DueToDelete = 5,
+    Deleting = 5,
     /// The datatype is neither enabled nor synchronized with the server (read-only).
     Disabled = 6,
 }
@@ -85,8 +85,8 @@ impl DatatypeState {
     /// Returns whether this state allows write operations.
     ///
     /// A datatype is writable when it is in one of these states:
-    /// - `DueToCreate` - scheduled for creation
-    /// - `DueToSubscribeOrCreate` - scheduled for subscription or creation
+    /// - `Creating` - scheduled for creation
+    /// - `SubscribingOrCreating` - scheduled for subscription or creation
     /// - `Subscribed` - actively subscribed
     ///
     /// **Important:** This method only checks the lifecycle state. The actual
@@ -97,16 +97,16 @@ impl DatatypeState {
     ///
     /// ```
     /// # use qortoo::DatatypeState;
-    /// assert!(DatatypeState::DueToCreate.is_read_writable());
+    /// assert!(DatatypeState::Creating.is_read_writable());
     /// assert!(DatatypeState::Subscribed.is_read_writable());
-    /// assert!(!DatatypeState::DueToSubscribe.is_read_writable());
+    /// assert!(!DatatypeState::Subscribing.is_read_writable());
     /// assert!(!DatatypeState::Disabled.is_read_writable());
     /// ```
     pub fn is_read_writable(&self) -> bool {
         matches!(
             self,
-            DatatypeState::DueToCreate
-                | DatatypeState::DueToSubscribeOrCreate
+            DatatypeState::Creating
+                | DatatypeState::SubscribingOrCreating
                 | DatatypeState::Subscribed
         )
     }
@@ -119,8 +119,8 @@ impl DatatypeState {
     ///
     /// ```
     /// # use qortoo::DatatypeState;
-    /// assert!(!DatatypeState::DueToCreate.is_readonly());
-    /// assert!(DatatypeState::DueToSubscribe.is_readonly());
+    /// assert!(!DatatypeState::Creating.is_readonly());
+    /// assert!(DatatypeState::Subscribing.is_readonly());
     /// assert!(DatatypeState::Disabled.is_readonly());
     /// ```
     pub fn is_readonly(&self) -> bool {
@@ -147,10 +147,10 @@ mod tests_datatype {
     }
 
     #[rstest]
-    #[case::due_to_create(DatatypeState::DueToCreate, true)]
+    #[case::creating(DatatypeState::Creating, true)]
     #[case::subscribed(DatatypeState::Subscribed, true)]
-    #[case::due_to_subscribe_or_create(DatatypeState::DueToSubscribeOrCreate, true)]
-    #[case::due_to_subscribe(DatatypeState::DueToSubscribe, false)]
+    #[case::subscribing_or_creating(DatatypeState::SubscribingOrCreating, true)]
+    #[case::subscribing(DatatypeState::Subscribing, false)]
     #[case::disabled(DatatypeState::Disabled, false)]
     fn can_check_accessibility_of_datatype_state(
         #[case] state: DatatypeState,
@@ -167,14 +167,14 @@ mod tests_datatype {
             .build()
             .unwrap();
 
-        // DueToCreate state allows writing
+        // Creating state allows writing
         let counter1 = client.create_datatype("c1").build_counter().unwrap();
-        assert_eq!(counter1.get_state(), DatatypeState::DueToCreate);
+        assert_eq!(counter1.get_state(), DatatypeState::Creating);
         assert!(counter1.increase().is_ok());
 
-        // DueToSubscribe state prevents writing (state-based)
+        // Subscribing state prevents writing (state-based)
         let counter2 = client.subscribe_datatype("c2").build_counter().unwrap();
-        assert_eq!(counter2.get_state(), DatatypeState::DueToSubscribe);
+        assert_eq!(counter2.get_state(), DatatypeState::Subscribing);
         assert!(counter2.increase().is_err());
 
         // Explicit read-only flag prevents writing (flag-based)
@@ -183,7 +183,7 @@ mod tests_datatype {
             .with_readonly()
             .build_counter()
             .unwrap();
-        assert_eq!(counter3.get_state(), DatatypeState::DueToCreate);
+        assert_eq!(counter3.get_state(), DatatypeState::Creating);
         assert!(counter3.increase().is_err()); // read-only despite writable state
     }
 }

--- a/src/types/push_pull_pack.rs
+++ b/src/types/push_pull_pack.rs
@@ -135,7 +135,7 @@ mod tests_push_pull_pack {
     #[test]
     fn can_use_push_pull_pack() {
         let attr = new_attribute!(DataType::Counter);
-        let mut ppp = PushPullPack::new(&attr, DatatypeState::DueToCreate);
+        let mut ppp = PushPullPack::new(&attr, DatatypeState::Creating);
         info!("{}", ppp.resource_id());
         assert_eq!(
             ppp.resource_id(),

--- a/tests/datatype_builder.rs
+++ b/tests/datatype_builder.rs
@@ -18,7 +18,7 @@ mod tests_datatype_builder {
         assert_eq!(DataType::Counter, counter.get_type());
         assert!(matches!(
             counter.get_state(),
-            DatatypeState::DueToCreate | DatatypeState::Subscribed
+            DatatypeState::Creating | DatatypeState::Subscribed
         ));
         assert_eq!(counter.get_value(), 42);
     }


### PR DESCRIPTION
- Add `Datatype::unsubscribe()` to transition a datatype to `DueToUnsubscribe` and fire a best-effort push.
- Add `Client::unsubscribe_datatype()` as a key-based convenience wrapper over the trait method.
- Auto-remove datatypes from `DatatypeManager` when `PullHandler` commits a `DueToUnsubscribe → Disabled` transition.
- Store `DatatypeManager` as `Arc<RwLock>` in `Client` so `ClientCommon` can hold a `Weak` back-reference for detach.
- Implement `DueToUnsubscribe` handling in `LocalDatatypeServer`, `NullConnectivity`, and `WiredDatatype`.
- Extract `process_client_push()` in `LocalDatatypeServer` to share push logic between subscribe and unsubscribe flows.

## Commits included
- 🧬feat(datatypes): implement unsubscribe lifecycle and disabled detach
- 🧬feat(connectivity): remove local server after final unsubscribe
- 📜docs(datatypes): add DatatypeState lifecycle reference document