### PR TITLE
💄refactor(errors): replace push-pull error taxonomy with RecoveryAction-based routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,12 +330,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_more"
@@ -1274,7 +1271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdc38a304f59a03e6efa3876766a48c70a766a93f88341c3fff4212834b8e327"
 dependencies = [
  "prost 0.13.5",
- "prost-types",
+ "prost-types 0.13.5",
 ]
 
 [[package]]
@@ -1342,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -1375,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "aho-corasick",
  "crossbeam-epoch",
@@ -1490,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1583,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1597,22 +1594,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.23",
+ "reqwest 0.13.3",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1620,18 +1617,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.1",
- "reqwest 0.12.23",
+ "reqwest 0.13.3",
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1642,15 +1639,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror",
 ]
@@ -1873,6 +1871,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -2175,9 +2182,7 @@ checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2424,15 +2429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,12 +2448,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -2544,24 +2534,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2779,12 +2768,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "libc 0.2.184",
  "num-conv",
  "num_threads",
@@ -2796,15 +2784,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2962,6 +2950,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost 0.14.1",
+ "prost-types 0.14.1",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,9 +3075,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,27 +22,27 @@ tracing-subscriber = { version = "^0.3.23", features = [
 
 tracing = "^0.1.44"
 nanoid = "^0.5.0"
-tokio = { version = "^1.52.2", features = ["full"] }
-parking_lot = "^0.12.5"
-time = { version = "^0.3.47", features = [
+tokio = { version = "^1.52", features = ["full"] }
+parking_lot = "^0.12"
+time = { version = "^0.3", features = [
     "formatting",
     "local-offset",
     "macros",
 ] }
-itoa = "^1.0.18"
-derive_more = { version = "^2.1.1", features = ["display", "debug"] }
-chrono = "^0.4.44"
-thiserror = "^2.0.18"
-opentelemetry = { version = "^0.31.0" }
-tracing-opentelemetry = { version = "^0.32.1" }
-ubyte = "^0.10.4"
-crossbeam-channel = "^0.5.15"
-futures = "^0.3.32"
-btparse = "^0.2.0"
-strum_macros = "^0.28.0"
-regex = "^1.12.3"
-dyn-fmt = "^0.4.3"
-backon = { version = "^1.6.0", default-features = false, features = ["tokio-sleep"] }
+itoa = "^1.0"
+derive_more = { version = "^2.1", features = ["display", "debug"] }
+chrono = "^0.4"
+thiserror = "^2.0"
+opentelemetry = { version = "^0.32" }
+tracing-opentelemetry = { version = "^0.33" }
+ubyte = "^0.10"
+crossbeam-channel = "^0.5"
+futures = "^0.3"
+btparse = "^0.2"
+strum_macros = "^0.28"
+regex = "^1.12"
+dyn-fmt = "^0.4"
+backon = { version = "^1.6", default-features = false, features = ["tokio-sleep"] }
 metrics = "^0.24"
 
 [[example]]
@@ -62,24 +62,24 @@ name = "trace"
 path = "examples/observability/trace.rs"
 
 [dev-dependencies]
-rstest = "^0.26.1"
-awaitility = "^0.4.1"
-tokio = { version = "^1.52.2", features = ["full", "test-util"] }
-metrics-util = { version = "^0.20.3", features = ["debugging"] }
-serial_test = "^3.4"
-tracing-subscriber = { version = "^0.3.23", features = [
+rstest = "^0.26"
+awaitility = "^0.4"
+tokio = { version = "^1.52", features = ["full", "test-util"] }
+metrics-util = { version = "^0.20", features = ["debugging"] }
+serial_test = "^3.5"
+tracing-subscriber = { version = "^0.3", features = [
     "json",
     "fmt",
     "env-filter",
 ] }
-ctor = "^1.0.1"
+ctor = "^1.0"
 tracing-loki = "^0.2"
 url = "^2.5"
-metrics-exporter-prometheus = "^0.18.3"
+metrics-exporter-prometheus = "^0.18"
 libc = { version = "^1.0.0-alpha.3"}
-once_cell = { version = "^1.21.4"}
-opentelemetry_sdk = { version = "^0.31"}
-opentelemetry-otlp = { version = "^0.31", features = [
+once_cell = { version = "^1.21"}
+opentelemetry_sdk = { version = "0.32" }
+opentelemetry-otlp = { version = "0.32", features = [
     "grpc-tonic",
 ]}
-pyroscope = { version = "^2.0.3", features = ["backend-pprof-rs"] }
+pyroscope = { version = "^2.0", features = ["backend-pprof-rs"] }

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ Each datatype is composed of five layers stacked vertically. A user operation pa
 | [Datatype State](datatype-state.md) | `DatatypeState` lifecycle, write access, sync intent states, and unsubscribe cleanup |
 | [Transaction and Rollback](transaction-and-rollback.md) | `TxRecord` structure, transaction lifecycle, and inverse-operation rollback |
 | [Event Loop](event-loop.md) | Priority-based event processing, channel types, and exponential backoff behavior |
+| [Error Handling](error-handling.md) | Error taxonomy, `RecoveryAction` routing, and sync-path vs commit-path recovery |
 | [Observability](observability.md) | Tracing, log layer, Prometheus metrics, and Pyroscope profiling integration |
 
 ## Usage Guides
@@ -46,7 +47,6 @@ Each datatype is composed of five layers stacked vertically. A user operation pa
 | Client and DatatypeBuilder | TBD — `Client` builder pattern, collection scoping, and datatype registration |
 | Datatypes Reference | TBD — Counter API; planned `Variable` and `Map` types |
 | Connectivity Backends | TBD — `NullConnectivity`, `LocalConnectivity`, and implementing a custom backend |
-| Error Handling | TBD — Error types, `DatatypeErrorWithActions`, `EventLoopAction`, and recovery strategies |
 | Handler System | TBD — `DatatypeHandler`, `HandlersManager`, priority-based callback dispatch |
 | Testing Guide | TBD — Test macros, `LocalConnectivity` realtime pitfall, and async test patterns |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ flowchart TD
 
 > For datatype lifecycle states and write-access rules see [`docs/datatype-state.md`](datatype-state.md).
 > For event loop internals (channel architecture, BackOff, Notify flow) see [`docs/event-loop.md`](event-loop.md).
-> For error taxonomy, `DatatypeErrorWithActions`, and recovery action enums see [`docs/error-handling.md`](error-handling.md).
+> For error taxonomy and `RecoveryAction` routing see [`docs/error-handling.md`](error-handling.md).
 
 ### Layer Responsibilities
 

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,280 @@
+# Error Handling
+
+Qortoo separates *what went wrong* (a typed error) from *how the SDK recovers* (a single
+`RecoveryAction`). Wire-level and connectivity errors are translated into a
+`DatatypeError`, and `mapping()` pairs that error with the one recovery policy that
+applies — the pair travels as `DatatypeErrorWithAction`.
+
+## Overview
+
+```mermaid
+flowchart TD
+    PPE["PushPullError\n(wire-level, in PushPullPack.error)\nsrc/errors/push_pull.rs"]
+    CNE["ConnectivityError\n(crate-internal)\nsrc/errors/connectivity.rs"]
+    IR["InternalReason\n(crate-private)\nsrc/errors/datatypes.rs"]
+
+    DE["DatatypeError\nsrc/errors/datatypes.rs"]
+    MAP["mapping()"]
+    DEWA["DatatypeErrorWithAction\n{ error, recovery }"]
+    RA["RecoveryAction"]
+
+    EL["EventLoop\n(sync-path errors)"]
+    TX["TransactionalDatatype::end_transaction\n(commit-path errors)"]
+    CLIENT["ClientError\nsrc/errors/clients.rs"]
+
+    PPE -->|"to_datatype_error()"| DE
+    CNE -->|"to_datatype_error()"| DE
+    IR -->|"into_error()"| DE
+    DE --> MAP --> DEWA --> RA
+    IR -.->|"mapping() creation-site override"| DEWA
+
+    RA --> EL
+    RA --> TX
+    CLIENT -->|"returned directly to caller"| API["Public API caller"]
+```
+
+---
+
+## Core Types
+
+| Type | File | Purpose |
+|------|------|---------|
+| `BoxedError` | `src/errors/mod.rs` | `Box<dyn Error + Send + Sync>` — thread-safe opaque error |
+| `ClientError` | `src/errors/clients.rs` | Client-side errors (name validation, datatype registration); returned directly to callers |
+| `DatatypeError` | `src/errors/datatypes.rs` | User-visible errors surfaced by all datatype operations |
+| `ServerRejectReason` | `src/errors/datatypes.rs` | Why the server permanently rejected an operation; carried by `DatatypeError::ServerRejected` |
+| `InternalReason` | `src/errors/datatypes.rs` | Crate-private reasons behind `DatatypeError::Internal` |
+| `ConnectivityError` | `src/errors/connectivity.rs` | Crate-internal errors from the connectivity backend (not re-exported) |
+| `PushPullError` | `src/errors/push_pull.rs` | Wire-level error set by the responder in `PushPullPack.error` |
+| `DatatypeErrorWithAction` | `src/errors/datatypes.rs` | `DatatypeError` + its `RecoveryAction` |
+| `RecoveryAction` | `src/errors/datatypes.rs` | The single recovery policy applied after a routed error |
+
+---
+
+## Error Taxonomy
+
+### ClientError (codes 100–)
+
+Returned directly to API callers. Never routed through the event loop.
+
+| Variant | Code | Trigger |
+|---------|------|---------|
+| `InvalidCollectionName` | 100 | Collection name fails naming validation |
+| `FailedToSubscribeOrCreateDatatype` | 101 | Re-registering a key on the same client, or type mismatch |
+
+### DatatypeError (codes 200–)
+
+The public-facing error type for all datatype operations, surfaced via API return values
+and `on_error` handlers. Variants split into two groups:
+
+**Caller-facing — returned directly, never routed through `mapping()`:**
+
+| Variant | Code | Meaning |
+|---------|------|---------|
+| `TransactionFailed` | 201 | Transaction closure returned an error or commit failed |
+| `Disallowed` | 205 | Access denied for a reason other than state/readonly (e.g., key not managed by this client) |
+| `NotWritable` | 206 | Write rejected because the datatype state does not allow writes |
+
+**Routed — carry a `RecoveryAction` via `mapping()`:**
+
+| Variant | Code | Meaning | RecoveryAction |
+|---------|------|---------|----------------|
+| `Internal` | 202 | Internal SDK fault (see `InternalReason`); not user-actionable | `Disable`* |
+| `ReadonlyViolation` | 207 | Write from a client configured as readonly | `Disable` |
+| `SyncFailed` | 210 | Transient sync failure (connectivity timeout, server internal error) | `RetryWithBackOff` |
+| `PushBufferExceededMaxMemSize` | 211 | Transaction cannot be buffered for pushing | `RollbackTransaction` |
+| `ServerRejected(ServerRejectReason)` | 213 | Server permanently rejected the operation | `Disable` |
+
+\* except `InternalReason::NonSequentialCseq`, which is routed to `RollbackTransaction`
+at its creation site — see [InternalReason](#3-internalreason--creation-site-routing).
+
+`ReadonlyViolation` appears on both sides: locally it is returned directly to the caller
+of a write API; when the *server* reports it (`PushPullError::ReadonlyViolation`), it is
+routed through `mapping()` and disables the datatype.
+
+### ServerRejectReason
+
+Carried by `DatatypeError::ServerRejected`. New lifecycle operations (e.g., delete,
+merge) add variants here without touching `DatatypeError` itself.
+
+| Variant | Trigger |
+|---------|---------|
+| `CreateFailed` | Server refused to create the datatype (e.g., already exists) |
+| `ResourceNotFound` | Requested resource does not exist or has an incompatible type |
+| `MissingSubscription` | Server-side subscription entry is missing (e.g., server restarted) |
+| `ProtocolViolation` | Push violated the wire protocol (unexpected state transition, type mismatch) |
+
+### ConnectivityError (crate-internal)
+
+Not re-exported at the crate root; it stays internal until custom connectivity backends
+become a public extension point.
+
+| Variant | Trigger | Converts to |
+|---------|---------|-------------|
+| `TimedOut` | Backend did not respond in time | `DatatypeError::SyncFailed` |
+
+### PushPullError (codes 300–)
+
+The wire-level error set by the responder (the server side) in `PushPullPack.error`.
+The client converts it via `to_datatype_error()`; variant names mirror
+`ServerRejectReason` where a counterpart exists.
+
+| Variant | Code | Converts to |
+|---------|------|-------------|
+| `ProtocolViolation` | 301 | `ServerRejected(ProtocolViolation)` |
+| `ReadonlyViolation` | 302 | `ReadonlyViolation` |
+| `CreateFailed` | 303 | `ServerRejected(CreateFailed)` |
+| `ResourceNotFound` | 304 | `ServerRejected(ResourceNotFound)` |
+| `MissingSubscription` | 305 | `ServerRejected(MissingSubscription)` |
+| `ServerInternalError` | 306 | `SyncFailed` (transient — retry with backoff) |
+
+---
+
+## RecoveryAction
+
+Each variant is a self-consistent recovery policy: it bundles the event-loop scheduling
+effect and the datatype-lifecycle side effect that must occur together. Contradictory
+pairings (e.g., disabling the datatype while keeping sync scheduled) are unrepresentable
+by construction.
+
+| Variant | Lifecycle effect (`MutableDatatype::apply_action`) | Loop effect (`LoopMode`) | Producers |
+|---------|-----------------------------------------------------|--------------------------|-----------|
+| `NotifyOnly` | none — `on_error` only | `Normal` | *reserved* |
+| `RetryWithBackOff` | none | `BackOff` | `SyncFailed` |
+| `RollbackTransaction` | `do_rollback()` on the pending transaction | — (never reaches the loop) | `PushBufferExceededMaxMemSize`, `InternalReason::NonSequentialCseq` |
+| `Resubscribe` | `reset()` + state → `SubscribingOrCreating` | `Normal` | *reserved* |
+| `ResubscribeWithBackOff` | same as `Resubscribe` | `BackOff` | *reserved* |
+| `Disable` | `disable()` — state → `Disabled` | `Stopped` | `Internal`, `ServerRejected`, `ReadonlyViolation` |
+
+> **WARNING (reserved variants)**: `Resubscribe` / `ResubscribeWithBackOff` reset local
+> state, which discards unpushed transactions in the push buffer. A local data-loss
+> policy must be decided before wiring a producer.
+
+`MutableDatatype::apply_action()` is the single dispatch point for the lifecycle side
+effect, shared by both consumer paths below.
+
+---
+
+## How It Works
+
+### 1. Sync path — errors routed through the event loop
+
+When `push_pull()` fails, the raw error is converted to a `DatatypeError`
+(`to_datatype_error()`), then routed (`mapping()`):
+
+```mermaid
+flowchart TD
+    PP["wired.push_pull()"]
+    ERR["Err(DatatypeErrorWithAction)"]
+    LM["loop_mode = LoopMode::from(recovery)"]
+    HE["wired.handle_error(error, recovery)"]
+    AA["mutable.write().apply_action(recovery)"]
+    CB["mutable.read().call_error_handler(error)\n(on_error handlers, after lock release)"]
+
+    PP -->|"failure"| ERR
+    ERR --> LM
+    ERR --> HE
+    HE --> AA --> CB
+```
+
+The event loop derives its scheduling mode from the action
+(`impl From<RecoveryAction> for LoopMode` in `event_loop.rs`):
+
+| RecoveryAction | LoopMode |
+|----------------|----------|
+| `NotifyOnly`, `Resubscribe` | `Normal` |
+| `RetryWithBackOff`, `ResubscribeWithBackOff` | `BackOff` — exponential backoff (500ms–30s, unlimited retries) |
+| `Disable` | `Stopped` — further `PushTransaction` events are rejected |
+| `RollbackTransaction` | `debug_assert` — must never reach the loop |
+
+See [`docs/event-loop.md`](event-loop.md) for the full BackOff and Stopped flow.
+
+### 2. Commit path — errors consumed on the user thread
+
+`RollbackTransaction` never travels through the event loop. When
+`MutableDatatype::end_transaction()` fails to enqueue the committed transaction into the
+push buffer, the pending transaction is restored and the routed error is returned to
+`TransactionalDatatype::end_transaction()`, which handles it synchronously:
+
+```mermaid
+flowchart TD
+    ET["mutable.end_transaction()"]
+    ENQ["push_buffer.enqueue(tx)"]
+    RESTORE["restore tx_record.pending\n(Arc::try_unwrap)"]
+    APPLY["mutable.apply_action(RollbackTransaction)\n→ do_rollback()"]
+    NOTIFY["call_error_handler(error)\n(after write-lock release)"]
+
+    ET --> ENQ
+    ENQ -->|"Err(DatatypeErrorWithAction)"| RESTORE
+    RESTORE --> APPLY --> NOTIFY
+```
+
+This path runs in a defer guard after the write API has already returned, so the
+`on_error` handler is the only way the user learns about the rollback. See
+[`docs/transaction-and-rollback.md`](transaction-and-rollback.md) for the rollback
+mechanics.
+
+### 3. InternalReason — creation-site routing
+
+`InternalReason` names the crate-private causes of `DatatypeError::Internal`:
+`Deserialize`, `ExecuteOperation`, `EventLoop`, `NonSequentialCseq`,
+`GetPushingTransactions`. `into_error()` erases the reason into `Internal(String)`, so a
+reason that needs a routing other than the `Internal` default (`Disable`) must be mapped
+**before** the erasure, at its creation site, via `InternalReason::mapping()`:
+
+- `NonSequentialCseq` → `RollbackTransaction` (mapped inside `push_buffer.enqueue()`)
+- all other reasons → delegate to `DatatypeError::mapping()`, which stays the single
+  source of truth per error variant
+
+### 4. with_err_out! Macro
+
+All internal error paths use the `with_err_out!` macro (`src/errors/mod.rs`) to log an
+ANSI-colored error message plus a filtered stack trace showing only frames within the
+Qortoo SDK:
+
+```rust
+let err = with_err_out!(InternalReason::EventLoop(err_msg).into_error());
+```
+
+The macro captures `Backtrace::force_capture()` and `Location::caller()`, then calls
+`with_stack_trace` which filters frames by `SDK_NAME` and formats them with `↘︎` arrows.
+
+---
+
+## Key Design Decisions
+
+- **Single `RecoveryAction` enum instead of two action axes**: an earlier design paired
+  an event-loop action with a lifecycle action, but only three of the twelve
+  combinations were ever produced and several were contradictory (e.g., disable the
+  datatype but keep syncing). Encoding only the valid policies makes invalid states
+  unrepresentable and gives each consumer an exhaustive match.
+
+- **`mapping()` as the translation boundary**: `DatatypeError::mapping()` owns the
+  error→action table rather than a central match in the event loop. Adding a routed
+  variant means updating one method next to the error definition (Open/Closed
+  Principle). Caller-facing variants hitting `mapping()` is a bug and panics via
+  `unreachable!`.
+
+- **Names mirror across layers**: `PushPullError` variants align with
+  `ServerRejectReason` variants (`CreateFailed`, `ResourceNotFound`,
+  `MissingSubscription`, `ProtocolViolation`), so `to_datatype_error()` is
+  self-documenting.
+
+- **Variant equality by discriminant**: `ClientError`, `DatatypeError`, and
+  `PushPullError` use `mem::discriminant`-based `PartialEq`, not payload equality. Test
+  code can assert two errors are the *same kind* without caring about message strings.
+
+- **`#[non_exhaustive]` on all public enums**: adding new variants is not a breaking API
+  change for downstream crates.
+
+- **`#[repr(i32)]` numeric codes**: `DatatypeError` (200–) and `PushPullError` (300–)
+  assign explicit integer discriminants to support wire-level error code mapping without
+  relying on Rust's unstable discriminant values.
+
+---
+
+## Related Concepts
+
+- [`docs/event-loop.md`](event-loop.md) — how `LoopMode` (derived from `RecoveryAction`) drives BackOff and Stopped scheduling
+- [`docs/architecture.md`](architecture.md) — overall layer stack; errors surface from the Wired layer upward
+- [`docs/transaction-and-rollback.md`](transaction-and-rollback.md) — the rollback that `RecoveryAction::RollbackTransaction` triggers

--- a/docs/event-loop.md
+++ b/docs/event-loop.md
@@ -63,26 +63,29 @@ pub enum Event {
 
 ---
 
-## EventLoopAction States
+## LoopMode States
 
-The event loop tracks its current sync policy via `EventLoopAction`.
+The event loop tracks its scheduling mode via `LoopMode`, a loop-private enum derived
+from the routed `RecoveryAction` (`impl From<RecoveryAction> for LoopMode`). The routing
+decision lives in `RecoveryAction` (see [`docs/error-handling.md`](error-handling.md));
+`LoopMode` only tracks how the loop schedules the next sync attempt.
 
 ```mermaid
 flowchart LR
     N(["Normal"])
     B(["BackOff"])
-    P(["PauseSync"])
+    S(["Stopped"])
 
-    N -->|"error: BackOff"| B
-    N -->|"error: PauseSync"| P
+    N -->|"error: RetryWithBackOff"| B
+    N -->|"error: Disable"| S
     B -->|"timer expires or\nexplicit sync() succeeds"| N
 ```
 
-| State | Behavior |
-|-------|----------|
+| Mode | Behavior |
+|------|----------|
 | `Normal` | Auto-push allowed; both channels polled |
 | `BackOff` | Auto-push blocked; only `unbounded_rx` polled; retries after timeout |
-| `PauseSync` | Auto-push blocked; any `PushTransaction` immediately returns an error |
+| `Stopped` | Auto-push blocked; any `PushTransaction` immediately returns an error |
 
 ---
 
@@ -93,22 +96,22 @@ flowchart LR
 ```mermaid
 flowchart TD
     RE["receive_event()"]
-    State{"EventLoopAction?"}
+    State{"LoopMode?"}
 
     AutoPush["[Normal] push_if_needed &&\nwired.push_if_needed()\n→ return Ok(Event::PushTransaction(None))"]
 
     BOSelect["[BackOff]\ncompute next backoff duration\ncrossbeam select!"]
     BOUnbounded["recv(unbounded_rx)\n→ handle immediately\n(Stop, explicit sync, Notify)"]
-    BOTimer["default(duration)\n→ timer expired\n→ return Ok(Event::BackOff)"]
+    BOTimer["default(duration)\n→ timer expired\n→ loop_mode = Normal\n→ return Ok(Event::BackOff)"]
 
-    NPSelect["[Normal / PauseSync]\ncrossbeam select!"]
+    NPSelect["[Normal / Stopped]\ncrossbeam select!"]
     NPUnbounded["recv(unbounded_rx) → handle"]
     NPBounded["recv(bounded_rx) → handle"]
 
     RE --> State
     State -->|"Normal (push needed)"| AutoPush
     State -->|"BackOff"| BOSelect
-    State -->|"Normal / PauseSync\n(no push needed)"| NPSelect
+    State -->|"Normal / Stopped\n(no push needed)"| NPSelect
     BOSelect --> BOUnbounded
     BOSelect --> BOTimer
     NPSelect --> NPUnbounded
@@ -126,11 +129,11 @@ flowchart TD
 ```mermaid
 flowchart TD
     PT["PushTransaction(resp_tx)"]
-    Pause{"[PauseSync]?"}
+    Pause{"[Stopped]?"}
     PauseErr["immediately return error\n→ process_blocking_resp()"]
     PushPull["wired.push_pull()"]
-    Ok["Ok\nevent_loop_action = Normal\nbackoff = None\nprocess_blocking_resp(None)"]
-    Err["Err(DatatypeErrorWithActions)\nevent_loop_action = dewa.event_loop_action\nwired.handle_error(error, datatype_action)\nprocess_blocking_resp(Some(error))"]
+    Ok["Ok\nloop_mode = Normal\nbackoff = None\nprocess_blocking_resp(None)"]
+    Err["Err(DatatypeErrorWithAction)\nloop_mode = LoopMode::from(dewa.recovery)\nwired.handle_error(error, recovery)\nprocess_blocking_resp(Some(error))"]
 
     PT --> Pause
     Pause -->|"Yes"| PauseErr
@@ -185,7 +188,7 @@ Exponential backoff is implemented via `backon::ExponentialBuilder`.
 | Max retry count | Unlimited |
 | Growth factor | Exponential (×2) |
 
-**BackOff entry**: Transient errors such as `ClientPushPullError::FailedInConnectivity` map to `EventLoopAction::BackOff` via `.mapping()`.
+**BackOff entry**: Transient errors such as `DatatypeError::SyncFailed` (connectivity timeout, server internal error) map to `RecoveryAction::RetryWithBackOff` via `.mapping()`, which the loop derives into `LoopMode::BackOff`.
 
 **BackOff exit**:
 - Explicit `sync()` succeeds (via unbounded channel, bypasses wait)
@@ -193,18 +196,25 @@ Exponential backoff is implemented via `backon::ExponentialBuilder`.
 
 ---
 
-## DatatypeAction — Post-Error State Transitions
+## RecoveryAction — Post-Error Side Effects
 
-On push_pull failure, `DatatypeErrorWithActions.datatype_action` determines the datatype state change.
+On push_pull failure, `DatatypeErrorWithAction.recovery` determines both the loop's next
+scheduling mode (`LoopMode::from(recovery)`) and the datatype state change
+(`wired.handle_error` → `MutableDatatype::apply_action`). The full routing table lives
+in [`docs/error-handling.md`](error-handling.md); for the datatype lifecycle and
+write-access rules, see [`docs/datatype-state.md`](datatype-state.md).
 
-For the full datatype lifecycle and write-access rules, see [`docs/datatype-state.md`](datatype-state.md).
+| RecoveryAction | Lifecycle effect | LoopMode |
+|----------------|------------------|----------|
+| `NotifyOnly` *(reserved)* | None — `on_error` only | `Normal` |
+| `RetryWithBackOff` | No state change | `BackOff` |
+| `Resubscribe` *(reserved)* | `reset()` + transition to `SubscribingOrCreating` | `Normal` |
+| `ResubscribeWithBackOff` *(reserved)* | Same as `Resubscribe` | `BackOff` |
+| `Disable` | Transition to `Disabled` (sync permanently stopped) | `Stopped` |
 
-| Action | Effect |
-|--------|--------|
-| `Normal` | No state change |
-| `Restart` | Transition to `SubscribingOrCreating` (reconnect attempt) |
-| `Disable` | Transition to `Disabled` (sync permanently stopped) |
-| `Reset` | Call `do_rollback()` to undo the pending local transaction; the next sync cycle re-fetches state from the server |
+`RecoveryAction::RollbackTransaction` never reaches the event loop — it is consumed on
+the user thread by `TransactionalDatatype::end_transaction()` (guarded by a
+`debug_assert` in `LoopMode::from`).
 
 ## Unsubscribe Lifecycle
 

--- a/src/clients/client.rs
+++ b/src/clients/client.rs
@@ -311,7 +311,7 @@ mod tests_client {
         assert!(client2.get_datatype(&key).is_some());
         assert!(matches!(
             counter.sync().unwrap_err(),
-            crate::DatatypeError::FailedToCreate(_)
+            crate::DatatypeError::ServerRejected(_)
         ));
 
         assert_eq!(counter.get_state(), DatatypeState::Disabled);
@@ -336,7 +336,7 @@ mod tests_client {
         assert!(client.get_datatype(&key).is_some());
         assert!(matches!(
             counter.sync().unwrap_err(),
-            crate::DatatypeError::FailedToSubscribe(_)
+            crate::DatatypeError::ServerRejected(_)
         ));
 
         assert_eq!(counter.get_state(), DatatypeState::Disabled);

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -11,10 +11,10 @@ use crossbeam_channel::Sender;
 use parking_lot::RwLock;
 
 use crate::{
-    ConnectivityError, DatatypeState,
+    DatatypeState,
     connectivity::{Connectivity, local_datatype_server::LocalDatatypeServer},
     datatypes::{event_loop::Event, wired::WiredDatatype},
-    errors::push_pull::ServerPushPullError,
+    errors::{connectivity::ConnectivityError, push_pull::PushPullError},
     types::{common::ResourceID, push_pull_pack::PushPullPack},
 };
 
@@ -183,7 +183,7 @@ impl Connectivity for LocalConnectivity {
 
         let Some(server_with_lock) = self.get_local_datatype_server(&resource_id) else {
             let mut pulled = pushed.get_pulled_stub();
-            pulled.error = Some(ServerPushPullError::FailedByResourceNotFound(resource_id.clone()));
+            pulled.error = Some(PushPullError::ResourceNotFound(resource_id.clone()));
             pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         };

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -14,6 +14,7 @@ use crate::{
     ConnectivityError, DatatypeState,
     connectivity::{Connectivity, local_datatype_server::LocalDatatypeServer},
     datatypes::{event_loop::Event, wired::WiredDatatype},
+    errors::push_pull::ServerPushPullError,
     types::{common::ResourceID, push_pull_pack::PushPullPack},
 };
 
@@ -180,9 +181,12 @@ impl Connectivity for LocalConnectivity {
     fn push_pull(&self, pushed: &PushPullPack) -> Result<PushPullPack, ConnectivityError> {
         let resource_id = pushed.resource_id();
 
-        let server_with_lock = self
-            .get_local_datatype_server(&resource_id)
-            .ok_or_else(|| ConnectivityError::ResourceNotFound(resource_id.clone()))?;
+        let Some(server_with_lock) = self.get_local_datatype_server(&resource_id) else {
+            let mut pulled = pushed.get_pulled_stub();
+            pulled.error = Some(ServerPushPullError::FailedByResourceNotFound(resource_id.clone()));
+            pulled.state = DatatypeState::Disabled;
+            return Ok(pulled);
+        };
         let (pulled, should_remove_server) = {
             let mut server = server_with_lock.write();
             let pulled = match pushed.state {

--- a/src/connectivity/local_connectivity.rs
+++ b/src/connectivity/local_connectivity.rs
@@ -134,6 +134,17 @@ impl LocalConnectivity {
         let wired_datatype = server.read().get_wired_datatype(cuid)?;
         Some(wired_datatype.get_wired_interceptor())
     }
+
+    #[cfg(test)]
+    pub fn remove_client_subscription(
+        &self,
+        resource_id: &ResourceID,
+        cuid: &crate::types::uid::Cuid,
+    ) {
+        if let Some(server) = self.get_local_datatype_server(resource_id) {
+            server.write().remove_client_subscription(cuid);
+        }
+    }
 }
 
 impl Debug for LocalConnectivity {

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -4,9 +4,9 @@ use crossbeam_channel::Sender;
 use tracing::{instrument, trace};
 
 use crate::{
-    ConnectivityError, DataType, DatatypeState,
+    DataType, DatatypeState,
     datatypes::{common::Attribute, event_loop::Event, wired::WiredDatatype},
-    errors::push_pull::ServerPushPullError,
+    errors::{connectivity::ConnectivityError, push_pull::PushPullError},
     operations::transaction::Transaction,
     types::{
         checkpoint::CheckPoint,
@@ -124,14 +124,14 @@ impl LocalDatatypeServer {
         // If already created, an error should occur,
         // but if the DUID is the same, it is considered a duplicate transmission case and is allowed.
         if self.created && self.duid != pushed.duid {
-            pulled.error = Some(ServerPushPullError::FailedToCreate(
+            pulled.error = Some(PushPullError::CreateFailed(
                 "already exist".to_string(),
             ));
             pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         }
         if pulled.is_readonly {
-            pulled.error = Some(ServerPushPullError::FailedByReadonlyRestriction);
+            pulled.error = Some(PushPullError::ReadonlyViolation);
             pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         }
@@ -165,7 +165,7 @@ impl LocalDatatypeServer {
     ) -> Result<PushPullPack, ConnectivityError> {
         let mut pulled = pushed.get_pulled_stub();
         if !self.wired_map.contains_key(&pushed.cuid) {
-            pulled.error = Some(ServerPushPullError::FailedByMissingSubscription(
+            pulled.error = Some(PushPullError::MissingSubscription(
                 format!(
                     "cuid '{}' has no active datatype subscription on this server",
                     pushed.cuid
@@ -175,7 +175,7 @@ impl LocalDatatypeServer {
             return Ok(pulled);
         }
         if self.r#type != pushed.r#type {
-            pulled.error = Some(ServerPushPullError::FailedByIllegalRequest(format!(
+            pulled.error = Some(PushPullError::ProtocolViolation(format!(
                 "type mismatch for '{}': expected {} but got {}",
                 pushed.resource_id(),
                 self.r#type,
@@ -195,7 +195,7 @@ impl LocalDatatypeServer {
     ) -> PushPullPack {
         let mut pulled = pushed.get_pulled_stub();
         if pulled.is_readonly && !pushed.transactions.is_empty() {
-            pulled.error = Some(ServerPushPullError::FailedByReadonlyRestriction);
+            pulled.error = Some(PushPullError::ReadonlyViolation);
             pulled.state = DatatypeState::Disabled;
             return pulled;
         }
@@ -274,7 +274,7 @@ impl LocalDatatypeServer {
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
         let mut pulled = pushed.get_pulled_stub();
-        pulled.error = Some(ServerPushPullError::FailedByIllegalRequest(
+        pulled.error = Some(PushPullError::ProtocolViolation(
             "disabled client attempted push".to_string(),
         ));
         pulled.state = DatatypeState::Disabled;
@@ -288,7 +288,7 @@ impl LocalDatatypeServer {
     ) -> Result<PushPullPack, ConnectivityError> {
         let mut pulled = pushed.get_pulled_stub();
         if !self.created {
-            pulled.error = Some(ServerPushPullError::FailedByResourceNotFound(format!(
+            pulled.error = Some(PushPullError::ResourceNotFound(format!(
                 "{} '{}' not exists",
                 pushed.r#type,
                 pushed.resource_id(),
@@ -297,7 +297,7 @@ impl LocalDatatypeServer {
             return Ok(pulled);
         }
         if self.r#type != pushed.r#type {
-            pulled.error = Some(ServerPushPullError::FailedByResourceNotFound(format!(
+            pulled.error = Some(PushPullError::ResourceNotFound(format!(
                 "mismatched types for '{}': pushed type-{} but existed type {}",
                 pushed.resource_id(),
                 pushed.r#type,
@@ -307,7 +307,7 @@ impl LocalDatatypeServer {
             return Ok(pulled);
         }
         if !pushed.transactions.is_empty() {
-            pulled.error = Some(ServerPushPullError::FailedByIllegalRequest(
+            pulled.error = Some(PushPullError::ProtocolViolation(
                 "cannot push transactions when subscribing".to_string(),
             ));
             pulled.state = DatatypeState::Disabled;
@@ -318,7 +318,7 @@ impl LocalDatatypeServer {
         let wired_of_creator = match self.get_creator_wired_datatype() {
             Some(w) => w,
             None => {
-                pulled.error = Some(ServerPushPullError::FailedByServerInternalError(format!(
+                pulled.error = Some(PushPullError::ServerInternalError(format!(
                     "creator unavailable for '{}'",
                     pushed.resource_id()
                 )));
@@ -365,7 +365,14 @@ mod tests_local_datatype_server {
     use rstest::rstest;
     use tracing::{info, instrument};
 
-    use crate::{Client, Counter, DataType, Datatype, DatatypeError, DatatypeState, connectivity::local_connectivity::LocalConnectivity, errors::push_pull::ServerPushPullError, operations::transaction::Transaction, types::{checkpoint::CheckPoint, push_pull_pack::PushPullPack, uid::Duid}, utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids}, ConnectivityError};
+    use crate::{
+        Client, Counter, DataType, Datatype, DatatypeError, DatatypeState,
+        connectivity::local_connectivity::LocalConnectivity,
+        errors::{connectivity::ConnectivityError, push_pull::PushPullError},
+        operations::transaction::Transaction,
+        types::{checkpoint::CheckPoint, push_pull_pack::PushPullPack, uid::Duid},
+        utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
+    };
 
     fn push_no_change(_push: &mut PushPullPack) {}
     fn push_set_readonly(push: &mut PushPullPack) {
@@ -388,7 +395,7 @@ mod tests_local_datatype_server {
         pulled: &PushPullPack,
         is_readonly: bool,
         cp: CheckPoint,
-        error: Option<ServerPushPullError>,
+        error: Option<PushPullError>,
         tx_len: usize,
     ) {
         assert_eq!(pulled.is_readonly, is_readonly);
@@ -408,10 +415,10 @@ mod tests_local_datatype_server {
         false,
         push_set_readonly,
         true,
-        Some(ServerPushPullError::FailedByReadonlyRestriction),
+        Some(PushPullError::ReadonlyViolation),
         CheckPoint::new(0, 0),
         false,
-        0,
+        0
     )]
     #[case::normal(false, push_no_change, false, None, CheckPoint::new(10, 10), true, 10)]
     #[case::duplicate(true, push_no_change, false, None, CheckPoint::new(10, 10), true, 10)]
@@ -419,7 +426,7 @@ mod tests_local_datatype_server {
         true,
         push_set_new_duid,
         false,
-        Some(ServerPushPullError::FailedToCreate("already exist".to_string())),
+        Some(PushPullError::CreateFailed("already exist".to_string())),
         CheckPoint::new(0, 0),
         true,
         10,
@@ -429,7 +436,7 @@ mod tests_local_datatype_server {
         #[case] pre_create: bool,
         #[case] modify_push: fn(&mut PushPullPack),
         #[case] expected_is_readonly: bool,
-        #[case] expected_error: Option<ServerPushPullError>,
+        #[case] expected_error: Option<PushPullError>,
         #[case] expected_cp: CheckPoint,
         #[case] expected_created: bool,
         #[case] expected_history_len: usize,
@@ -458,8 +465,11 @@ mod tests_local_datatype_server {
             .unwrap();
 
         if pre_create {
-            wired_interceptor1
-                .set_after_pull(|_pull| Err(ConnectivityError::TimedOut("".to_owned()).to_datatype_error().mapping()));
+            wired_interceptor1.set_after_pull(|_pull| {
+                Err(ConnectivityError::TimedOut("".to_owned())
+                    .to_datatype_error()
+                    .mapping())
+            });
             let _ = counter1.sync();
             assert!(server.read().created);
         }
@@ -487,7 +497,7 @@ mod tests_local_datatype_server {
         let sync_result = counter1.sync();
         if let Some(ref sppe) = *expected_error {
             let err = sync_result.unwrap_err();
-            if matches!(sppe, ServerPushPullError::FailedByReadonlyRestriction) {
+            if matches!(sppe, PushPullError::ReadonlyViolation) {
                 assert!(matches!(err, DatatypeError::ReadonlyViolation));
             } else {
                 assert!(matches!(err, DatatypeError::ServerRejected(_)));
@@ -507,26 +517,26 @@ mod tests_local_datatype_server {
     #[case::not_created(
         false,
         push_no_change,
-        Some(ServerPushPullError::FailedByResourceNotFound("".to_string())),
+        Some(PushPullError::ResourceNotFound("".to_string())),
         CheckPoint::new(0, 0),
     )]
     #[case::type_mismatch(
         true,
         push_set_variable_type,
-        Some(ServerPushPullError::FailedByResourceNotFound("".to_string())),
+        Some(PushPullError::ResourceNotFound("".to_string())),
         CheckPoint::new(0, 0),
     )]
     #[case::with_transactions(
         true,
         push_add_transaction,
-        Some(ServerPushPullError::FailedByIllegalRequest("".to_string())),
+        Some(PushPullError::ProtocolViolation("".to_string())),
         CheckPoint::new(0, 0),
     )]
     #[instrument]
     fn can_process_subscribing(
         #[case] creator_sync: bool,
         #[case] modify_push: fn(&mut PushPullPack),
-        #[case] expected_error: Option<ServerPushPullError>,
+        #[case] expected_error: Option<PushPullError>,
         #[case] expected_cp: CheckPoint,
     ) {
         let connectivity = LocalConnectivity::new_arc();
@@ -578,13 +588,9 @@ mod tests_local_datatype_server {
             });
 
         let sync_result = counter2.sync();
-        if let Some(ref sppe) = *expected_error {
+        if expected_error.is_some() {
             let err = sync_result.unwrap_err();
-            if matches!(sppe, ServerPushPullError::FailedByIllegalRequest(_)) {
-                assert!(matches!(err, DatatypeError::ServerRejected(_)));
-            } else {
-                assert!(matches!(err, DatatypeError::ServerRejected(_)));
-            }
+            assert!(matches!(err, DatatypeError::ServerRejected(_)));
             assert_eq!(counter2.get_state(), DatatypeState::Disabled);
         } else {
             assert!(sync_result.is_ok());
@@ -624,7 +630,7 @@ mod tests_local_datatype_server {
             .set_before_push(push_set_readonly)
             .set_after_pull(|pull| {
                 assert_eq!(pull.state, DatatypeState::Disabled);
-                assert_eq!(pull.error, Some(ServerPushPullError::FailedByReadonlyRestriction));
+                assert_eq!(pull.error, Some(PushPullError::ReadonlyViolation));
                 Ok(())
             });
 
@@ -648,9 +654,9 @@ mod tests_local_datatype_server {
         false,
         push_set_readonly,
         true,
-        Some(ServerPushPullError::FailedByReadonlyRestriction),
+        Some(PushPullError::ReadonlyViolation),
         CheckPoint::new(0, 0),
-        0,
+        0
     )]
     #[case::readonly_no_transactions(
         0,
@@ -676,7 +682,7 @@ mod tests_local_datatype_server {
         #[case] use_subscriber: bool,
         #[case] modify_push: fn(&mut PushPullPack),
         #[case] expected_is_readonly: bool,
-        #[case] expected_error: Option<ServerPushPullError>,
+        #[case] expected_error: Option<PushPullError>,
         #[case] expected_cp: CheckPoint,
         #[case] expected_tx_len: usize,
     ) {
@@ -761,10 +767,13 @@ mod tests_local_datatype_server {
         }
     }
 
-    fn check_error(expected_error: Arc<Option<ServerPushPullError>>, counter: &Counter) {
+    fn check_error(expected_error: Arc<Option<PushPullError>>, counter: &Counter) {
         let sync_result = counter.sync();
         if expected_error.is_some() {
-            assert!(matches!(sync_result.unwrap_err(), DatatypeError::ReadonlyViolation));
+            assert!(matches!(
+                sync_result.unwrap_err(),
+                DatatypeError::ReadonlyViolation
+            ));
             assert_eq!(counter.get_state(), DatatypeState::Disabled);
         } else {
             assert!(sync_result.is_ok());
@@ -911,7 +920,10 @@ mod tests_local_datatype_server {
 
         // The next sync must fail with ServerRejected and disable the datatype.
         let result = counter1.sync();
-        assert!(matches!(result.unwrap_err(), DatatypeError::ServerRejected(_)));
+        assert!(matches!(
+            result.unwrap_err(),
+            DatatypeError::ServerRejected(_)
+        ));
         awaitility::at_most(Duration::from_secs(1))
             .poll_interval(Duration::from_micros(100))
             .until(|| counter1.get_state() == DatatypeState::Disabled);
@@ -1021,7 +1033,10 @@ mod tests_local_datatype_server {
             .with_connectivity(connectivity.clone())
             .build()
             .unwrap();
-        let counter1 = client1.create_datatype(key.clone()).build_counter().unwrap();
+        let counter1 = client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
         counter1.sync().unwrap();
         assert_eq!(counter1.get_state(), DatatypeState::Subscribed);
 
@@ -1030,7 +1045,10 @@ mod tests_local_datatype_server {
             .with_connectivity(connectivity.clone())
             .build()
             .unwrap();
-        let counter2 = client2.subscribe_datatype(key.clone()).build_counter().unwrap();
+        let counter2 = client2
+            .subscribe_datatype(key.clone())
+            .build_counter()
+            .unwrap();
         counter2.sync().unwrap();
         assert_eq!(counter2.get_state(), DatatypeState::Subscribed);
 
@@ -1044,14 +1062,17 @@ mod tests_local_datatype_server {
             .clone();
         connectivity.remove_client_subscription(&resource_id, &creator_cuid);
 
-        // A new subscriber receives FailedByServerInternalError → SyncFailed (BackOff + Normal).
+        // A new subscriber receives ServerInternalError → SyncFailed (RetryWithBackOff).
         // The server does not override the state, so the client remains in Subscribing and
         // retries with exponential backoff.
         let client3 = Client::builder(collection.clone(), "new-subscriber")
             .with_connectivity(connectivity.clone())
             .build()
             .unwrap();
-        let counter3 = client3.subscribe_datatype(key.clone()).build_counter().unwrap();
+        let counter3 = client3
+            .subscribe_datatype(key.clone())
+            .build_counter()
+            .unwrap();
         let result = counter3.sync();
         assert!(matches!(result.unwrap_err(), DatatypeError::SyncFailed(_)));
         assert_eq!(counter3.get_state(), DatatypeState::Subscribing);

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -87,7 +87,13 @@ impl LocalDatatypeServer {
         self.wired_map.is_empty()
     }
 
-    pub fn push_transactions(&mut self, pushed: &PushPullPack) -> (u64, bool) {
+    #[cfg(test)]
+    pub fn remove_client_subscription(&mut self, cuid: &Cuid) {
+        self.wired_map.remove(cuid);
+        self.sender_map.remove(cuid);
+    }
+
+    fn push_transactions(&mut self, pushed: &PushPullPack) -> (u64, bool) {
         let client_cp = self
             .cseq_map
             .entry(pushed.cuid.clone())
@@ -125,9 +131,7 @@ impl LocalDatatypeServer {
             return Ok(pulled);
         }
         if pulled.is_readonly {
-            pulled.error = Some(ServerPushPullError::IllegalPushRequest(
-                "readonly client cannot create datatype".to_string(),
-            ));
+            pulled.error = Some(ServerPushPullError::FailedByReadonlyRestriction);
             pulled.state = DatatypeState::Disabled;
             return Ok(pulled);
         }
@@ -159,6 +163,27 @@ impl LocalDatatypeServer {
         pushed: &PushPullPack,
         is_realtime: bool,
     ) -> Result<PushPullPack, ConnectivityError> {
+        let mut pulled = pushed.get_pulled_stub();
+        if !self.wired_map.contains_key(&pushed.cuid) {
+            pulled.error = Some(ServerPushPullError::FailedByMissingSubscription(
+                format!(
+                    "cuid '{}' has no active datatype subscription on this server",
+                    pushed.cuid
+                ),
+            ));
+            pulled.state = DatatypeState::Disabled;
+            return Ok(pulled);
+        }
+        if self.r#type != pushed.r#type {
+            pulled.error = Some(ServerPushPullError::FailedByIllegalRequest(format!(
+                "type mismatch for '{}': expected {} but got {}",
+                pushed.resource_id(),
+                self.r#type,
+                pushed.r#type,
+            )));
+            pulled.state = DatatypeState::Disabled;
+            return Ok(pulled);
+        }
         Ok(self.process_client_push(pushed, DatatypeState::Subscribed, is_realtime))
     }}
 
@@ -170,9 +195,7 @@ impl LocalDatatypeServer {
     ) -> PushPullPack {
         let mut pulled = pushed.get_pulled_stub();
         if pulled.is_readonly && !pushed.transactions.is_empty() {
-            pulled.error = Some(ServerPushPullError::IllegalPushRequest(
-                "readonly client cannot push transactions".to_string(),
-            ));
+            pulled.error = Some(ServerPushPullError::FailedByReadonlyRestriction);
             pulled.state = DatatypeState::Disabled;
             return pulled;
         }
@@ -213,9 +236,17 @@ impl LocalDatatypeServer {
         pushed: &PushPullPack,
         is_realtime: bool,
     ) -> Result<PushPullPack, ConnectivityError> {
+        // If the client's datatype is not subscribed on this server, skip push processing to avoid
+        // polluting cseq_map, and return Disabled directly since that is the desired state.
+        if !self.wired_map.contains_key(&pushed.cuid) {
+            let mut pulled = pushed.get_pulled_stub();
+            pulled.state = DatatypeState::Disabled;
+            return Ok(pulled);
+        }
+
         let pulled = self.process_client_push(pushed, DatatypeState::Disabled, is_realtime);
 
-        // Always clean up client registration regardless of error: the client will be Disabled
+        // Always clean up client subscription regardless of error: the client will be Disabled
         // either way, and leaving stale entries would cause infinite unsubscribe retry loops.
         self.wired_map.remove(&pushed.cuid);
         self.sender_map.remove(&pushed.cuid);
@@ -242,7 +273,11 @@ impl LocalDatatypeServer {
         &mut self,
         pushed: &PushPullPack,
     ) -> Result<PushPullPack, ConnectivityError> {
-        let pulled = pushed.get_pulled_stub();
+        let mut pulled = pushed.get_pulled_stub();
+        pulled.error = Some(ServerPushPullError::FailedByIllegalRequest(
+            "disabled client attempted push".to_string(),
+        ));
+        pulled.state = DatatypeState::Disabled;
         Ok(pulled)
     }}
 
@@ -272,7 +307,7 @@ impl LocalDatatypeServer {
             return Ok(pulled);
         }
         if !pushed.transactions.is_empty() {
-            pulled.error = Some(ServerPushPullError::IllegalPushRequest(
+            pulled.error = Some(ServerPushPullError::FailedByIllegalRequest(
                 "cannot push transactions when subscribing".to_string(),
             ));
             pulled.state = DatatypeState::Disabled;
@@ -280,9 +315,17 @@ impl LocalDatatypeServer {
         }
 
         pulled.duid = self.duid.clone();
-        let wired_of_creator = self
-            .get_creator_wired_datatype()
-            .ok_or(ConnectivityError::ResourceNotFound(pushed.resource_id()))?;
+        let wired_of_creator = match self.get_creator_wired_datatype() {
+            Some(w) => w,
+            None => {
+                pulled.error = Some(ServerPushPullError::FailedToSubscribe(format!(
+                    "internal server error for '{}'",
+                    pushed.resource_id()
+                )));
+                pulled.state = DatatypeState::Disabled;
+                return Ok(pulled);
+            }
+        };
         let tx = wired_of_creator.get_subscribe_snapshot();
         pulled.checkpoint.sseq = tx.sseq;
         pulled.snapshot_transaction = Some(Arc::new(tx));
@@ -345,6 +388,9 @@ mod tests_local_datatype_server {
     fn push_set_variable_type(push: &mut PushPullPack) {
         push.r#type = DataType::Variable;
     }
+    fn push_set_disabled_state(push: &mut PushPullPack) {
+        push.state = DatatypeState::Disabled;
+    }
     fn push_add_transaction(push: &mut PushPullPack) {
         push.transactions.push(Arc::new(Transaction::default()));
     }
@@ -381,7 +427,7 @@ mod tests_local_datatype_server {
         false,
         push_set_readonly,
         true,
-        Some(ServerPushPullError::IllegalPushRequest("".to_string())),
+        Some(ServerPushPullError::FailedByReadonlyRestriction),
         CheckPoint::new(0, 0),
         false,
         0,
@@ -459,12 +505,13 @@ mod tests_local_datatype_server {
             });
 
         let sync_result = counter1.sync();
-        if expected_error.is_some() {
-            assert!(matches!(
-                sync_result.unwrap_err(),
-                DatatypeError::FailedToCreate(_)
-            ));
-            // assert!(equal_errors!(&sync_result.unwrap_err(), &expected_error.unwrap()));
+        if let Some(ref sppe) = *expected_error {
+            let err = sync_result.unwrap_err();
+            if matches!(sppe, ServerPushPullError::FailedByReadonlyRestriction) {
+                assert!(matches!(err, DatatypeError::Disallowed(_)));
+            } else {
+                assert!(matches!(err, DatatypeError::FailedToCreate(_)));
+            }
             assert_eq!(counter1.get_state(), DatatypeState::Disabled);
         } else {
             assert!(sync_result.is_ok());
@@ -492,7 +539,7 @@ mod tests_local_datatype_server {
     #[case::with_transactions(
         true,
         push_add_transaction,
-        Some(ServerPushPullError::IllegalPushRequest("".to_string())),
+        Some(ServerPushPullError::FailedByIllegalRequest("".to_string())),
         CheckPoint::new(0, 0),
     )]
     #[instrument]
@@ -551,11 +598,13 @@ mod tests_local_datatype_server {
             });
 
         let sync_result = counter2.sync();
-        if expected_error.is_some() {
-            assert!(matches!(
-                sync_result.unwrap_err(),
-                DatatypeError::FailedToSubscribe(_)
-            ));
+        if let Some(ref sppe) = *expected_error {
+            let err = sync_result.unwrap_err();
+            if matches!(sppe, ServerPushPullError::FailedByIllegalRequest(_)) {
+                assert!(matches!(err, DatatypeError::FailedByProtocolViolation(_)));
+            } else {
+                assert!(matches!(err, DatatypeError::FailedToSubscribe(_)));
+            }
             assert_eq!(counter2.get_state(), DatatypeState::Disabled);
         } else {
             assert!(sync_result.is_ok());
@@ -595,16 +644,13 @@ mod tests_local_datatype_server {
             .set_before_push(push_set_readonly)
             .set_after_pull(|pull| {
                 assert_eq!(pull.state, DatatypeState::Disabled);
-                assert_eq!(
-                    pull.error,
-                    Some(ServerPushPullError::IllegalPushRequest(String::new()))
-                );
+                assert_eq!(pull.error, Some(ServerPushPullError::FailedByReadonlyRestriction));
                 Ok(())
             });
 
         assert!(matches!(
             counter.sync().unwrap_err(),
-            DatatypeError::FailedByServerPushPullError(_)
+            DatatypeError::Disallowed(_)
         ));
         assert_eq!(counter.get_state(), DatatypeState::Disabled);
         assert!(
@@ -622,7 +668,7 @@ mod tests_local_datatype_server {
         false,
         push_set_readonly,
         true,
-        Some(ServerPushPullError::IllegalPushRequest("".to_string())),
+        Some(ServerPushPullError::FailedByReadonlyRestriction),
         CheckPoint::new(0, 0),
         0,
     )]
@@ -738,12 +784,7 @@ mod tests_local_datatype_server {
     fn check_error(expected_error: Arc<Option<ServerPushPullError>>, counter: &Counter) {
         let sync_result = counter.sync();
         if expected_error.is_some() {
-            assert_eq!(
-                sync_result.unwrap_err(),
-                DatatypeError::FailedByServerPushPullError(
-                    ServerPushPullError::IllegalPushRequest("".to_string())
-                )
-            );
+            assert!(matches!(sync_result.unwrap_err(), DatatypeError::Disallowed(_)));
             assert_eq!(counter.get_state(), DatatypeState::Disabled);
         } else {
             assert!(sync_result.is_ok());
@@ -861,5 +902,177 @@ mod tests_local_datatype_server {
         counter2.sync().unwrap();
         assert_eq!(counter1.get_value(), value_before);
         assert_eq!(counter2.get_value(), value_before);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_reject_subscribed_push_from_unsubscribed_client() {
+        use std::time::Duration;
+
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+
+        let client1 = Client::builder(collection.clone(), get_test_func_name!())
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+
+        let counter1 = client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+
+        counter1.sync().unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::Subscribed);
+
+        // Simulate the server losing the client's subscription (e.g., after a server restart).
+        connectivity.remove_client_subscription(&resource_id, &client1.get_cuid());
+
+        // The next sync must fail with FailedToSubscribe and trigger a Restart action.
+        let result = counter1.sync();
+        assert!(matches!(result.unwrap_err(), DatatypeError::FailedToSubscribe(_)));
+        awaitility::at_most(Duration::from_secs(1))
+            .poll_interval(Duration::from_micros(100))
+            .until(|| counter1.get_state() == DatatypeState::SubscribingOrCreating);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_unsubscribe_not_subscribed_client_gracefully() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+
+        let client1 = Client::builder(collection.clone(), get_test_func_name!())
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+
+        let counter1 = client1
+            .create_datatype(key.clone())
+            .build_counter()
+            .unwrap();
+
+        counter1.sync().unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::Subscribed);
+
+        // Simulate the server losing the client's subscription.
+        connectivity.remove_client_subscription(&resource_id, &client1.get_cuid());
+
+        // Unsubscribing a client whose server-side subscription is gone must complete
+        // gracefully: no error, and the datatype reaches Disabled.
+        // Manual mode: send_push_transaction_with_best_effort skips the event, so call
+        // sync() explicitly to drive the Unsubscribing → Disabled transition.
+        counter1.unsubscribe().unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::Unsubscribing);
+        counter1.sync().unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::Disabled);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_reject_type_mismatch_in_subscribed_push() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+
+        let client = Client::builder(collection.clone(), get_test_func_name!())
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter = client.create_datatype(key.clone()).build_counter().unwrap();
+        counter.sync().unwrap();
+        assert_eq!(counter.get_state(), DatatypeState::Subscribed);
+
+        // Simulate a client sending a push with a different DataType after subscription.
+        let interceptor = connectivity
+            .get_wired_interceptor(&resource_id, &client.get_cuid())
+            .unwrap();
+        interceptor.set_before_push(push_set_variable_type);
+
+        let result = counter.sync();
+        assert!(matches!(
+            result.unwrap_err(),
+            DatatypeError::FailedByProtocolViolation(_)
+        ));
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_reject_push_from_disabled_client() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+
+        let client = Client::builder(collection.clone(), get_test_func_name!())
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+
+        let counter = client.create_datatype(key.clone()).build_counter().unwrap();
+        counter.sync().unwrap();
+        assert_eq!(counter.get_state(), DatatypeState::Subscribed);
+
+        // Simulate a buggy or malicious client sending a push with Disabled state.
+        let interceptor = connectivity
+            .get_wired_interceptor(&resource_id, &client.get_cuid())
+            .unwrap();
+        interceptor.set_before_push(push_set_disabled_state);
+
+        let result = counter.sync();
+        assert!(matches!(
+            result.unwrap_err(),
+            DatatypeError::FailedByProtocolViolation(_)
+        ));
+        assert_eq!(counter.get_state(), DatatypeState::Disabled);
+    }
+
+    #[test]
+    #[instrument]
+    fn can_fail_subscribe_when_creator_is_unavailable() {
+        let connectivity = LocalConnectivity::new_arc();
+        connectivity.set_realtime(false);
+        let (collection, key, resource_id) = get_test_ids!();
+
+        // client1 creates the datatype and becomes the creator.
+        let client1 = Client::builder(collection.clone(), "creator")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter1 = client1.create_datatype(key.clone()).build_counter().unwrap();
+        counter1.sync().unwrap();
+        assert_eq!(counter1.get_state(), DatatypeState::Subscribed);
+
+        // client2 subscribes so the server is not empty after the creator is removed.
+        let client2 = Client::builder(collection.clone(), "subscriber")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter2 = client2.subscribe_datatype(key.clone()).build_counter().unwrap();
+        counter2.sync().unwrap();
+        assert_eq!(counter2.get_state(), DatatypeState::Subscribed);
+
+        // Remove creator from wired_map without going through the normal unsubscribe flow,
+        // leaving server.creator pointing to a stale cuid.
+        let creator_cuid = connectivity
+            .get_local_datatype_server(&resource_id)
+            .unwrap()
+            .read()
+            .creator()
+            .clone();
+        connectivity.remove_client_subscription(&resource_id, &creator_cuid);
+
+        // A new subscriber must receive FailedToSubscribe (PauseSync + Disable),
+        // not ConnectivityError (which would cause infinite BackOff retries).
+        let client3 = Client::builder(collection.clone(), "new-subscriber")
+            .with_connectivity(connectivity.clone())
+            .build()
+            .unwrap();
+        let counter3 = client3.subscribe_datatype(key.clone()).build_counter().unwrap();
+        let result = counter3.sync();
+        assert!(matches!(result.unwrap_err(), DatatypeError::FailedToSubscribe(_)));
+        assert_eq!(counter3.get_state(), DatatypeState::Disabled);
     }
 }

--- a/src/connectivity/local_datatype_server.rs
+++ b/src/connectivity/local_datatype_server.rs
@@ -288,7 +288,7 @@ impl LocalDatatypeServer {
     ) -> Result<PushPullPack, ConnectivityError> {
         let mut pulled = pushed.get_pulled_stub();
         if !self.created {
-            pulled.error = Some(ServerPushPullError::FailedToSubscribe(format!(
+            pulled.error = Some(ServerPushPullError::FailedByResourceNotFound(format!(
                 "{} '{}' not exists",
                 pushed.r#type,
                 pushed.resource_id(),
@@ -297,7 +297,7 @@ impl LocalDatatypeServer {
             return Ok(pulled);
         }
         if self.r#type != pushed.r#type {
-            pulled.error = Some(ServerPushPullError::FailedToSubscribe(format!(
+            pulled.error = Some(ServerPushPullError::FailedByResourceNotFound(format!(
                 "mismatched types for '{}': pushed type-{} but existed type {}",
                 pushed.resource_id(),
                 pushed.r#type,
@@ -318,11 +318,10 @@ impl LocalDatatypeServer {
         let wired_of_creator = match self.get_creator_wired_datatype() {
             Some(w) => w,
             None => {
-                pulled.error = Some(ServerPushPullError::FailedToSubscribe(format!(
-                    "internal server error for '{}'",
+                pulled.error = Some(ServerPushPullError::FailedByServerInternalError(format!(
+                    "creator unavailable for '{}'",
                     pushed.resource_id()
                 )));
-                pulled.state = DatatypeState::Disabled;
                 return Ok(pulled);
             }
         };
@@ -366,17 +365,7 @@ mod tests_local_datatype_server {
     use rstest::rstest;
     use tracing::{info, instrument};
 
-    use crate::{
-        Client, Counter, DataType, Datatype, DatatypeError, DatatypeState,
-        connectivity::local_connectivity::LocalConnectivity,
-        errors::{
-            datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
-            push_pull::ServerPushPullError,
-        },
-        operations::transaction::Transaction,
-        types::{checkpoint::CheckPoint, push_pull_pack::PushPullPack, uid::Duid},
-        utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
-    };
+    use crate::{Client, Counter, DataType, Datatype, DatatypeError, DatatypeState, connectivity::local_connectivity::LocalConnectivity, errors::push_pull::ServerPushPullError, operations::transaction::Transaction, types::{checkpoint::CheckPoint, push_pull_pack::PushPullPack, uid::Duid}, utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids}, ConnectivityError};
 
     fn push_no_change(_push: &mut PushPullPack) {}
     fn push_set_readonly(push: &mut PushPullPack) {
@@ -412,14 +401,6 @@ mod tests_local_datatype_server {
 
         assert_eq!(pulled.error, error);
         assert_eq!(pulled.transactions.len(), tx_len);
-    }
-
-    fn make_create_error() -> DatatypeErrorWithActions {
-        DatatypeErrorWithActions::new(
-            DatatypeError::FailedToCreate("".to_owned()),
-            EventLoopAction::Normal,
-            DatatypeAction::Normal,
-        )
     }
 
     #[rstest]
@@ -478,8 +459,7 @@ mod tests_local_datatype_server {
 
         if pre_create {
             wired_interceptor1
-                .set_before_push(|_push| {})
-                .set_after_pull(|_pull| Err(make_create_error()));
+                .set_after_pull(|_pull| Err(ConnectivityError::TimedOut("".to_owned()).to_datatype_error().mapping()));
             let _ = counter1.sync();
             assert!(server.read().created);
         }
@@ -508,9 +488,9 @@ mod tests_local_datatype_server {
         if let Some(ref sppe) = *expected_error {
             let err = sync_result.unwrap_err();
             if matches!(sppe, ServerPushPullError::FailedByReadonlyRestriction) {
-                assert!(matches!(err, DatatypeError::Disallowed(_)));
+                assert!(matches!(err, DatatypeError::ReadonlyViolation));
             } else {
-                assert!(matches!(err, DatatypeError::FailedToCreate(_)));
+                assert!(matches!(err, DatatypeError::ServerRejected(_)));
             }
             assert_eq!(counter1.get_state(), DatatypeState::Disabled);
         } else {
@@ -527,13 +507,13 @@ mod tests_local_datatype_server {
     #[case::not_created(
         false,
         push_no_change,
-        Some(ServerPushPullError::FailedToSubscribe("".to_string())),
+        Some(ServerPushPullError::FailedByResourceNotFound("".to_string())),
         CheckPoint::new(0, 0),
     )]
     #[case::type_mismatch(
         true,
         push_set_variable_type,
-        Some(ServerPushPullError::FailedToSubscribe("".to_string())),
+        Some(ServerPushPullError::FailedByResourceNotFound("".to_string())),
         CheckPoint::new(0, 0),
     )]
     #[case::with_transactions(
@@ -601,9 +581,9 @@ mod tests_local_datatype_server {
         if let Some(ref sppe) = *expected_error {
             let err = sync_result.unwrap_err();
             if matches!(sppe, ServerPushPullError::FailedByIllegalRequest(_)) {
-                assert!(matches!(err, DatatypeError::FailedByProtocolViolation(_)));
+                assert!(matches!(err, DatatypeError::ServerRejected(_)));
             } else {
-                assert!(matches!(err, DatatypeError::FailedToSubscribe(_)));
+                assert!(matches!(err, DatatypeError::ServerRejected(_)));
             }
             assert_eq!(counter2.get_state(), DatatypeState::Disabled);
         } else {
@@ -650,7 +630,7 @@ mod tests_local_datatype_server {
 
         assert!(matches!(
             counter.sync().unwrap_err(),
-            DatatypeError::Disallowed(_)
+            DatatypeError::ReadonlyViolation
         ));
         assert_eq!(counter.get_state(), DatatypeState::Disabled);
         assert!(
@@ -784,7 +764,7 @@ mod tests_local_datatype_server {
     fn check_error(expected_error: Arc<Option<ServerPushPullError>>, counter: &Counter) {
         let sync_result = counter.sync();
         if expected_error.is_some() {
-            assert!(matches!(sync_result.unwrap_err(), DatatypeError::Disallowed(_)));
+            assert!(matches!(sync_result.unwrap_err(), DatatypeError::ReadonlyViolation));
             assert_eq!(counter.get_state(), DatatypeState::Disabled);
         } else {
             assert!(sync_result.is_ok());
@@ -929,12 +909,12 @@ mod tests_local_datatype_server {
         // Simulate the server losing the client's subscription (e.g., after a server restart).
         connectivity.remove_client_subscription(&resource_id, &client1.get_cuid());
 
-        // The next sync must fail with FailedToSubscribe and trigger a Restart action.
+        // The next sync must fail with ServerRejected and disable the datatype.
         let result = counter1.sync();
-        assert!(matches!(result.unwrap_err(), DatatypeError::FailedToSubscribe(_)));
+        assert!(matches!(result.unwrap_err(), DatatypeError::ServerRejected(_)));
         awaitility::at_most(Duration::from_secs(1))
             .poll_interval(Duration::from_micros(100))
-            .until(|| counter1.get_state() == DatatypeState::SubscribingOrCreating);
+            .until(|| counter1.get_state() == DatatypeState::Disabled);
     }
 
     #[test]
@@ -994,7 +974,7 @@ mod tests_local_datatype_server {
         let result = counter.sync();
         assert!(matches!(
             result.unwrap_err(),
-            DatatypeError::FailedByProtocolViolation(_)
+            DatatypeError::ServerRejected(_)
         ));
         assert_eq!(counter.get_state(), DatatypeState::Disabled);
     }
@@ -1024,7 +1004,7 @@ mod tests_local_datatype_server {
         let result = counter.sync();
         assert!(matches!(
             result.unwrap_err(),
-            DatatypeError::FailedByProtocolViolation(_)
+            DatatypeError::ServerRejected(_)
         ));
         assert_eq!(counter.get_state(), DatatypeState::Disabled);
     }
@@ -1064,15 +1044,16 @@ mod tests_local_datatype_server {
             .clone();
         connectivity.remove_client_subscription(&resource_id, &creator_cuid);
 
-        // A new subscriber must receive FailedToSubscribe (PauseSync + Disable),
-        // not ConnectivityError (which would cause infinite BackOff retries).
+        // A new subscriber receives FailedByServerInternalError → SyncFailed (BackOff + Normal).
+        // The server does not override the state, so the client remains in Subscribing and
+        // retries with exponential backoff.
         let client3 = Client::builder(collection.clone(), "new-subscriber")
             .with_connectivity(connectivity.clone())
             .build()
             .unwrap();
         let counter3 = client3.subscribe_datatype(key.clone()).build_counter().unwrap();
         let result = counter3.sync();
-        assert!(matches!(result.unwrap_err(), DatatypeError::FailedToSubscribe(_)));
-        assert_eq!(counter3.get_state(), DatatypeState::Disabled);
+        assert!(matches!(result.unwrap_err(), DatatypeError::SyncFailed(_)));
+        assert_eq!(counter3.get_state(), DatatypeState::Subscribing);
     }
 }

--- a/src/connectivity/mod.rs
+++ b/src/connectivity/mod.rs
@@ -3,8 +3,8 @@ use std::{fmt::Debug, sync::Arc};
 use crossbeam_channel::Sender;
 
 use crate::{
-    ConnectivityError,
     datatypes::{event_loop::Event, wired::WiredDatatype},
+    errors::connectivity::ConnectivityError,
     types::push_pull_pack::PushPullPack,
 };
 

--- a/src/connectivity/null_connectivity.rs
+++ b/src/connectivity/null_connectivity.rs
@@ -24,7 +24,7 @@ impl NullConnectivity {
     }
 
     fn set_illegal_push_request(&self, pulled: &mut PushPullPack, reason: &str) {
-        pulled.error = Some(ServerPushPullError::IllegalPushRequest(reason.to_owned()));
+        pulled.error = Some(ServerPushPullError::FailedByIllegalRequest(reason.to_owned()));
         pulled.state = DatatypeState::Disabled;
     }
 }
@@ -40,10 +40,8 @@ impl Connectivity for NullConnectivity {
         match pushed.state {
             DatatypeState::Creating | DatatypeState::SubscribingOrCreating => {
                 if pushed.is_readonly {
-                    self.set_illegal_push_request(
-                        &mut pulled,
-                        "readonly client cannot create datatype",
-                    );
+                    pulled.error = Some(ServerPushPullError::FailedByReadonlyRestriction);
+                    pulled.state = DatatypeState::Disabled;
                     return Ok(pulled);
                 }
                 pulled.state = DatatypeState::Subscribed;
@@ -105,10 +103,7 @@ mod tests_null_connectivity {
         let res1 = null_connectivity.push_pull(&pushed1);
         assert!(res1.is_ok());
         let pulled1 = res1.unwrap();
-        assert_eq!(
-            pulled1.error.unwrap(),
-            ServerPushPullError::IllegalPushRequest(String::new())
-        );
+        assert_eq!(pulled1.error.unwrap(), ServerPushPullError::FailedByReadonlyRestriction);
 
         let mut pushed2 = PushPullPack::new(&attr, DatatypeState::Subscribing);
         let mut op_id = OperationId::new();
@@ -121,7 +116,7 @@ mod tests_null_connectivity {
         let pulled2 = res2.unwrap();
         assert_eq!(
             pulled2.error.unwrap(),
-            ServerPushPullError::IllegalPushRequest(String::new())
+            ServerPushPullError::FailedByIllegalRequest(String::new())
         );
 
         let mut pushed3 = PushPullPack::new(&attr, DatatypeState::Unsubscribing);

--- a/src/connectivity/null_connectivity.rs
+++ b/src/connectivity/null_connectivity.rs
@@ -6,7 +6,7 @@ use crate::{
     DatatypeState,
     connectivity::Connectivity,
     datatypes::{event_loop::Event, wired::WiredDatatype},
-    errors::{connectivity::ConnectivityError, push_pull::ServerPushPullError},
+    errors::{connectivity::ConnectivityError, push_pull::PushPullError},
     types::push_pull_pack::PushPullPack,
 };
 
@@ -24,7 +24,7 @@ impl NullConnectivity {
     }
 
     fn set_illegal_push_request(&self, pulled: &mut PushPullPack, reason: &str) {
-        pulled.error = Some(ServerPushPullError::FailedByIllegalRequest(reason.to_owned()));
+        pulled.error = Some(PushPullError::ProtocolViolation(reason.to_owned()));
         pulled.state = DatatypeState::Disabled;
     }
 }
@@ -40,7 +40,7 @@ impl Connectivity for NullConnectivity {
         match pushed.state {
             DatatypeState::Creating | DatatypeState::SubscribingOrCreating => {
                 if pushed.is_readonly {
-                    pulled.error = Some(ServerPushPullError::FailedByReadonlyRestriction);
+                    pulled.error = Some(PushPullError::ReadonlyViolation);
                     pulled.state = DatatypeState::Disabled;
                     return Ok(pulled);
                 }
@@ -88,7 +88,7 @@ mod tests_null_connectivity {
         DataType, DatatypeState,
         connectivity::{Connectivity, null_connectivity::NullConnectivity},
         datatypes::common::new_attribute,
-        errors::push_pull::ServerPushPullError,
+        errors::push_pull::PushPullError,
         operations::transaction::Transaction,
         types::{operation_id::OperationId, push_pull_pack::PushPullPack},
     };
@@ -103,7 +103,7 @@ mod tests_null_connectivity {
         let res1 = null_connectivity.push_pull(&pushed1);
         assert!(res1.is_ok());
         let pulled1 = res1.unwrap();
-        assert_eq!(pulled1.error.unwrap(), ServerPushPullError::FailedByReadonlyRestriction);
+        assert_eq!(pulled1.error.unwrap(), PushPullError::ReadonlyViolation);
 
         let mut pushed2 = PushPullPack::new(&attr, DatatypeState::Subscribing);
         let mut op_id = OperationId::new();
@@ -116,7 +116,7 @@ mod tests_null_connectivity {
         let pulled2 = res2.unwrap();
         assert_eq!(
             pulled2.error.unwrap(),
-            ServerPushPullError::FailedByIllegalRequest(String::new())
+            PushPullError::ProtocolViolation(String::new())
         );
 
         let mut pushed3 = PushPullPack::new(&attr, DatatypeState::Unsubscribing);

--- a/src/datatypes/builder.rs
+++ b/src/datatypes/builder.rs
@@ -219,7 +219,7 @@ mod tests_datatype_builder {
         // Write operations should fail
         assert!(matches!(
             counter.increase().unwrap_err(),
-            DatatypeError::NotWritable(_) 
+            DatatypeError::NotWritable(_)
         ));
 
         // Transaction should fail — either NotWritable (state not yet synced) or

--- a/src/datatypes/builder.rs
+++ b/src/datatypes/builder.rs
@@ -219,17 +219,18 @@ mod tests_datatype_builder {
         // Write operations should fail
         assert!(matches!(
             counter.increase().unwrap_err(),
-            DatatypeError::Disallowed(_)
+            DatatypeError::NotWritable(_) 
         ));
 
-        // Transaction should fail
+        // Transaction should fail — either NotWritable (state not yet synced) or
+        // ReadonlyViolation (state already synced to Subscribed by the time this runs)
         let tx_result = counter.transaction("test-tx", |c| {
             c.increase().unwrap();
             Ok(())
         });
         assert!(matches!(
             tx_result.unwrap_err(),
-            DatatypeError::Disallowed(_)
+            DatatypeError::NotWritable(_) | DatatypeError::ReadonlyViolation
         ));
         assert_eq!(counter.get_value(), 0);
     }
@@ -252,7 +253,7 @@ mod tests_datatype_builder {
         assert_eq!(counter.get_state(), DatatypeState::Subscribing);
         assert!(matches!(
             counter.increase().unwrap_err(),
-            DatatypeError::Disallowed(_)
+            DatatypeError::NotWritable(_)
         ));
 
         let counter = client

--- a/src/datatypes/counter.rs
+++ b/src/datatypes/counter.rs
@@ -10,7 +10,7 @@ use crate::{
         datatype::DatatypeBlanket,
         transactional::{TransactionContext, TransactionalDatatype},
     },
-    errors::BoxedError,
+    errors::{BoxedError, datatypes::InternalReason},
     operations::Operation,
 };
 
@@ -70,7 +70,7 @@ impl Counter {
         trace!("increased by {delta} -> {ret:?}");
         match ret {
             ReturnType::Counter(cv) => Ok(cv),
-            _ => Err(DatatypeError::FailedToExecuteOperation("unexpected return type".into()))
+            _ => Err(InternalReason::ExecuteOperation("unexpected return type".into()).into_error())
         }
     }}
 
@@ -172,7 +172,7 @@ impl Counter {
             counter_clone.tx_ctx = this_tx_ctx_clone.clone();
             match tx_func(counter_clone) {
                 Ok(_) => Ok(()),
-                Err(e) => Err(DatatypeError::FailedTransaction(e.to_string())),
+                Err(e) => Err(DatatypeError::TransactionFailed(e.to_string())),
             }
         };
         self.datatype.do_transaction(this_tx_ctx, do_tx_func)

--- a/src/datatypes/counter.rs
+++ b/src/datatypes/counter.rs
@@ -187,14 +187,64 @@ impl DatatypeBlanket for Counter {
 
 #[cfg(test)]
 mod tests_counter {
+    use std::{sync::Arc, time::Duration};
+
+    use parking_lot::Mutex;
     use tracing::{Span, info_span, instrument};
     use tracing_opentelemetry::OpenTelemetrySpanExt;
 
     use crate::{
-        DataType, DatatypeState,
-        datatypes::{counter::Counter, datatype::Datatype},
-        utils::test_utils::get_test_func_name,
+        Client, DataType, DatatypeError, DatatypeHandler, DatatypeState,
+        datatypes::{counter::Counter, datatype::Datatype, option::DatatypeOption},
+        utils::test_utils::{get_test_collection_name, get_test_func_name},
     };
+
+    #[test]
+    #[instrument]
+    fn can_notify_on_error_when_enqueue_fails() {
+        let client = Client::builder(get_test_collection_name!(), get_test_func_name!())
+            .build()
+            .unwrap();
+        let counter = client
+            .create_datatype(get_test_func_name!())
+            .build_counter()
+            .unwrap();
+        counter.increase_by(3).unwrap();
+
+        let received = Arc::new(Mutex::new(None));
+        let received_in_handler = received.clone();
+        counter.set_handler(
+            1,
+            DatatypeHandler::new().set_on_error(move |_ds, err| {
+                *received_in_handler.lock() = Some(err);
+            }),
+        );
+
+        let result = counter.transaction("oversize", |c| {
+            c.increase_by(100).unwrap();
+            // Shrink the buffer limit so the commit-time enqueue fails with
+            // PushBufferExceededMaxMemSize (bypassing the clamp in DatatypeOption::new).
+            c.datatype.mutable.write().push_buffer.option = Arc::new(DatatypeOption {
+                max_mem_size_of_push_buffer: 0,
+            });
+            Ok(())
+        });
+        // tx_func itself succeeded; the enqueue failure is routed to Normal + Rollback.
+        assert!(result.is_ok());
+
+        // The failed transaction was rolled back and the datatype stays alive.
+        assert_eq!(counter.get_value(), 3);
+        assert_ne!(counter.get_state(), DatatypeState::Disabled);
+
+        awaitility::at_most(Duration::from_secs(1))
+            .poll_interval(Duration::from_millis(1))
+            .until(|| {
+                matches!(
+                    *received.lock(),
+                    Some(DatatypeError::PushBufferExceededMaxMemSize)
+                )
+            });
+    }
 
     #[test]
     fn can_assert_send_and_sync_traits() {

--- a/src/datatypes/crdts/mod.rs
+++ b/src/datatypes/crdts/mod.rs
@@ -5,7 +5,7 @@ use crate::operations::body::OperationBody;
 use crate::{
     DataType, DatatypeError,
     datatypes::{common::ReturnType, crdts::counter_crdt::CounterCrdt},
-    errors::{datatypes::InternalReason, with_err_out},
+    errors::datatypes::InternalReason,
     operations::Operation,
 };
 
@@ -72,19 +72,20 @@ impl Crdt {
         }
     }
 
-    pub fn deserialize(&mut self, serialized: &[u8]) {
+    pub fn deserialize(&mut self, serialized: &[u8]) -> Result<(), DatatypeError> {
         match self {
             Self::Counter(c) => {
                 if serialized.len() != 8 {
-                    with_err_out!(InternalReason::Deserialize(format!(
-                        "counter crdt: {serialized:?}, and will recover to counter value 0"
-                    )).into_error());
-                    *c = CounterCrdt::default();
-                    return;
+                    return Err(InternalReason::Deserialize(format!(
+                        "counter crdt: expected 8 bytes, got {}",
+                        serialized.len()
+                    ))
+                    .into_error());
                 }
                 let mut array = [0u8; 8];
                 array.copy_from_slice(serialized);
-                *c = CounterCrdt::from_bytes(&array)
+                *c = CounterCrdt::from_bytes(&array);
+                Ok(())
             }
         }
     }
@@ -93,7 +94,7 @@ impl Crdt {
 #[cfg(test)]
 mod tests_crdts {
     use crate::{
-        DataType,
+        DataType, DatatypeError,
         datatypes::crdts::{Crdt, counter_crdt::CounterCrdt},
     };
 
@@ -105,13 +106,17 @@ mod tests_crdts {
 
         let mut crdt2 = Crdt::new(DataType::Counter);
         let serialized = crdt1.serialize();
-        crdt2.deserialize(&serialized);
+        crdt2.deserialize(&serialized).unwrap();
 
         let Crdt::Counter(c) = &crdt2;
         assert_eq!(c.value(), 100);
-        crdt2.deserialize("{}".as_bytes());
 
+        // Invalid input returns Err; counter value must not change.
+        assert!(matches!(
+            crdt2.deserialize("{}".as_bytes()),
+            Err(DatatypeError::Internal(_))
+        ));
         let Crdt::Counter(c) = &crdt2;
-        assert_eq!(c.value(), 0);
+        assert_eq!(c.value(), 100);
     }
 }

--- a/src/datatypes/crdts/mod.rs
+++ b/src/datatypes/crdts/mod.rs
@@ -5,7 +5,7 @@ use crate::operations::body::OperationBody;
 use crate::{
     DataType, DatatypeError,
     datatypes::{common::ReturnType, crdts::counter_crdt::CounterCrdt},
-    errors::with_err_out,
+    errors::{datatypes::InternalReason, with_err_out},
     operations::Operation,
 };
 
@@ -30,7 +30,7 @@ impl Crdt {
             if let OperationBody::Delay4Test(body) = &op.body {
                 return match body.run() {
                     Ok(_) => Ok(ReturnType::None),
-                    Err(_) => Err(DatatypeError::FailedToExecuteOperation(format!("{body}"))),
+                    Err(_) => Err(InternalReason::ExecuteOperation(format!("{body}")).into_error()),
                 };
             }
         }
@@ -48,7 +48,7 @@ impl Crdt {
             if let OperationBody::Delay4Test(body) = &op.body {
                 return match body.run() {
                     Ok(_) => Ok(ReturnType::None),
-                    Err(_) => Err(DatatypeError::FailedToExecuteOperation(format!("{body}"))),
+                    Err(_) => Err(InternalReason::ExecuteOperation(format!("{body}")).into_error()),
                 };
             }
         }
@@ -76,9 +76,9 @@ impl Crdt {
         match self {
             Self::Counter(c) => {
                 if serialized.len() != 8 {
-                    with_err_out!(DatatypeError::FailedToDeserialize(format!(
+                    with_err_out!(InternalReason::Deserialize(format!(
                         "counter crdt: {serialized:?}, and will recover to counter value 0"
-                    )));
+                    )).into_error());
                     *c = CounterCrdt::default();
                     return;
                 }

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -199,9 +199,8 @@ mod tests_datatype_trait {
             .unwrap();
 
         // produce push_pull error
-        interceptor1.set_after_pull(|_pull| {
-            Err(DatatypeError::SyncFailed("injected".into()).mapping())
-        });
+        interceptor1
+            .set_after_pull(|_pull| Err(DatatypeError::SyncFailed("injected".into()).mapping()));
 
         assert!(matches!(
             counter1.sync().unwrap_err(),

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -160,7 +160,6 @@ mod tests_datatype_trait {
         datatypes::{
             common::new_attribute, datatype::Datatype, transactional::TransactionalDatatype,
         },
-        errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
         utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
     };
 
@@ -201,17 +200,13 @@ mod tests_datatype_trait {
 
         // produce push_pull error
         interceptor1.set_after_pull(|_pull| {
-            Err(DatatypeErrorWithActions::new(
-                DatatypeError::PushBufferExceededMaxMemSize,
-                EventLoopAction::BackOff,
-                DatatypeAction::Reset,
-            ))
+            Err(DatatypeError::SyncFailed("injected".into()).mapping())
         });
 
-        assert_eq!(
+        assert!(matches!(
             counter1.sync().unwrap_err(),
-            DatatypeError::PushBufferExceededMaxMemSize
-        );
+            DatatypeError::SyncFailed(_)
+        ));
         assert_eq!(counter1.get_state(), DatatypeState::Creating);
 
         // make a success case
@@ -236,7 +231,7 @@ mod tests_datatype_trait {
 
         assert!(matches!(
             counter.unsubscribe().unwrap_err(),
-            DatatypeError::Disallowed(_)
+            DatatypeError::NotWritable(_)
         ));
         assert_eq!(counter.get_state(), DatatypeState::Creating);
     }
@@ -282,11 +277,11 @@ mod tests_datatype_trait {
         assert_eq!(counter.get_state(), DatatypeState::Unsubscribing);
         assert!(matches!(
             counter.increase().unwrap_err(),
-            DatatypeError::Disallowed(_)
+            DatatypeError::NotWritable(_)
         ));
         assert!(matches!(
             counter.unsubscribe().unwrap_err(),
-            DatatypeError::Disallowed(_)
+            DatatypeError::NotWritable(_)
         ));
     }
 
@@ -339,7 +334,7 @@ mod tests_datatype_trait {
 
         assert!(matches!(
             counter.sync().unwrap_err(),
-            DatatypeError::FailedByProtocolViolation(_)
+            DatatypeError::ServerRejected(_)
         ));
         assert_eq!(counter.get_state(), DatatypeState::Disabled);
         assert!(client.get_datatype(counter.get_key()).is_none());

--- a/src/datatypes/datatype.rs
+++ b/src/datatypes/datatype.rs
@@ -54,7 +54,7 @@ pub trait Datatype {
     ///
     /// # Errors
     ///
-    /// Returns [`DatatypeError::FailedByClientPushPullError`] if the synchronization fails.
+    /// Returns [`DatatypeError`] if the synchronization fails.
     ///
     /// # Examples
     ///
@@ -160,10 +160,7 @@ mod tests_datatype_trait {
         datatypes::{
             common::new_attribute, datatype::Datatype, transactional::TransactionalDatatype,
         },
-        errors::{
-            datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
-            push_pull::ClientPushPullError,
-        },
+        errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
         utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
     };
 
@@ -205,7 +202,7 @@ mod tests_datatype_trait {
         // produce push_pull error
         interceptor1.set_after_pull(|_pull| {
             Err(DatatypeErrorWithActions::new(
-                DatatypeError::FailedByClientPushPullError(ClientPushPullError::ExceedMaxMemSize),
+                DatatypeError::PushBufferExceededMaxMemSize,
                 EventLoopAction::BackOff,
                 DatatypeAction::Reset,
             ))
@@ -213,7 +210,7 @@ mod tests_datatype_trait {
 
         assert_eq!(
             counter1.sync().unwrap_err(),
-            DatatypeError::FailedByClientPushPullError(ClientPushPullError::ExceedMaxMemSize)
+            DatatypeError::PushBufferExceededMaxMemSize
         );
         assert_eq!(counter1.get_state(), DatatypeState::Creating);
 

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -12,7 +12,7 @@ use crate::{
     datatypes::wired::WiredDatatype,
     defaults::DEFAULT_EVENT_LOOP_TIMEOUT_MS,
     errors::{
-        datatypes::{DatatypeAction, EventLoopAction},
+        datatypes::{DatatypeAction, EventLoopAction, InternalReason},
         with_err_out,
     },
     observability::{metrics, trace::add_span_event},
@@ -104,12 +104,10 @@ impl EventLoop {
                                 break;
                             }
                             Event::PushTransaction(resp_tx) => {
-                                if matches!(event_loop_action, EventLoopAction::PauseSync) {
+                                if matches!(event_loop_action, EventLoopAction::StopSync) {
                                     Self::process_blocking_resp(
                                         resp_tx,
-                                        Some(DatatypeError::FailedInEventLoop(
-                                            "event loop paused".into(),
-                                        )),
+                                        Some(InternalReason::EventLoop("event loop stopped".into()).into_error()),
                                     );
                                     continue;
                                 }
@@ -172,7 +170,7 @@ impl EventLoop {
     ) -> Result<Event, DatatypeError> {
         let (push_if_needed, backoff_duration) = match event_loop_action {
             EventLoopAction::Normal => (true, None),
-            EventLoopAction::PauseSync => (false, None),
+            EventLoopAction::StopSync => (false, None),
             EventLoopAction::BackOff => {
                 let backoff_iter = backoff.get_or_insert_with(Self::build_backoff);
                 let d = backoff_iter.next().unwrap_or(BACKOFF_MAX_DELAY);
@@ -186,7 +184,7 @@ impl EventLoop {
 
         let map_err = |e, ch: &str| {
             let err_msg = format!("{ch} channel error {e:?}; stopping event loop");
-            with_err_out!(DatatypeError::FailedInEventLoop(err_msg))
+            with_err_out!(InternalReason::EventLoop(err_msg).into_error())
         };
 
         if let Some(duration) = backoff_duration {
@@ -226,14 +224,14 @@ impl EventLoop {
     fn send_to_unbounded(&self, ev: Event) -> Result<(), DatatypeError> {
         self.unbounded_tx
             .try_send(ev)
-            .map_err(|e| with_err_out!(DatatypeError::FailedInEventLoop(format!("{e:?}"))))
+            .map_err(|e| with_err_out!(InternalReason::EventLoop(format!("{e:?}")).into_error()))
     }
 
     fn send_to_bounded(&self, ev: Event) -> Result<(), DatatypeError> {
         let ev_str = format!("{ev}");
         self.bounded_tx.try_send(ev).map_err(|e| {
             add_span_event!(ev_str, "result"=>"fail");
-            DatatypeError::FailedInEventLoop(format!("{e:?}"))
+            InternalReason::EventLoop(format!("{e:?}")).into_error()
         })?;
         add_span_event!(ev_str, "result"=>"succeed");
         Ok(())
@@ -254,9 +252,9 @@ impl EventLoop {
             match rx.await {
                 Ok(Some(err)) => Err(err),
                 Ok(None) => Ok(()),
-                Err(e) => Err(DatatypeError::FailedInEventLoop(format!(
+                Err(e) => Err(InternalReason::EventLoop(format!(
                     "failed to receive response of sync(): {e}"
-                ))),
+                )).into_error()),
             }
         })
     }
@@ -275,7 +273,7 @@ mod tests_event_loop {
     use tracing::instrument;
 
     use crate::{
-        Client, ConnectivityError, DatatypeError, DatatypeState,
+        Client, DatatypeError, DatatypeState, ServerRejectReason,
         connectivity::local_connectivity::LocalConnectivity,
         datatypes::datatype::Datatype,
         errors::datatypes::DatatypeErrorWithActions,
@@ -283,18 +281,18 @@ mod tests_event_loop {
     };
 
     fn make_backoff_error() -> DatatypeErrorWithActions {
-        DatatypeError::FailedInConnectivity(ConnectivityError::ResourceNotFound(
+        DatatypeError::SyncFailed("injected".to_string()).mapping()
+    }
+
+    fn make_pause_sync_error() -> DatatypeErrorWithActions {
+        DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(
             "injected".to_string(),
         ))
         .mapping()
     }
 
-    fn make_pause_sync_error() -> DatatypeErrorWithActions {
-        DatatypeError::FailedByProtocolViolation("injected".to_string()).mapping()
-    }
-
     /// Test that an explicit sync() call bypasses the BackOff wait via the unbounded channel.
-    /// After a FailedInConnectivity error sets BackOff on the event loop, the next sync()
+    /// After a SyncFailed error sets BackOff on the event loop, the next sync()
     /// is still processed immediately (not after the 500ms delay).
     #[test]
     #[instrument]
@@ -312,11 +310,11 @@ mod tests_event_loop {
             .get_wired_interceptor(&resource_id, &client.get_cuid())
             .unwrap();
 
-        // inject FailedInConnectivity → maps to EventLoopAction::BackOff, DatatypeAction::Normal
+        // inject SyncFailed → maps to EventLoopAction::BackOff, DatatypeAction::Normal
         interceptor.set_after_pull(|_| Err(make_backoff_error()));
 
         let err = counter.sync().unwrap_err();
-        assert!(matches!(err, DatatypeError::FailedInConnectivity(_)));
+        assert!(matches!(err, DatatypeError::SyncFailed(_)));
         // DatatypeAction::Normal → no state change
         assert_eq!(counter.get_state(), DatatypeState::Creating);
 
@@ -410,7 +408,7 @@ mod tests_event_loop {
         assert_eq!(pull_count.load(Ordering::SeqCst), 2);
     }
 
-    /// Test that PauseSync + Disable transitions datatype to Disabled and
+    /// Test that StopSync + Disable transitions datatype to Disabled and
     /// does not keep retrying automatically afterward.
     #[test]
     #[instrument]

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -278,19 +278,19 @@ mod tests_event_loop {
         Client, ConnectivityError, DatatypeError, DatatypeState,
         connectivity::local_connectivity::LocalConnectivity,
         datatypes::datatype::Datatype,
-        errors::{datatypes::DatatypeErrorWithActions, push_pull::ClientPushPullError},
+        errors::datatypes::DatatypeErrorWithActions,
         utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
     };
 
     fn make_backoff_error() -> DatatypeErrorWithActions {
-        ClientPushPullError::FailedInConnectivity(ConnectivityError::ResourceNotFound(
+        DatatypeError::FailedInConnectivity(ConnectivityError::ResourceNotFound(
             "injected".to_string(),
         ))
         .mapping()
     }
 
     fn make_pause_sync_error() -> DatatypeErrorWithActions {
-        ClientPushPullError::FailedWithProtocolViolation("injected".to_string()).mapping()
+        DatatypeError::FailedByProtocolViolation("injected".to_string()).mapping()
     }
 
     /// Test that an explicit sync() call bypasses the BackOff wait via the unbounded channel.
@@ -316,7 +316,7 @@ mod tests_event_loop {
         interceptor.set_after_pull(|_| Err(make_backoff_error()));
 
         let err = counter.sync().unwrap_err();
-        assert!(matches!(err, DatatypeError::FailedByClientPushPullError(_)));
+        assert!(matches!(err, DatatypeError::FailedInConnectivity(_)));
         // DatatypeAction::Normal → no state change
         assert_eq!(counter.get_state(), DatatypeState::Creating);
 

--- a/src/datatypes/event_loop.rs
+++ b/src/datatypes/event_loop.rs
@@ -12,7 +12,7 @@ use crate::{
     datatypes::wired::WiredDatatype,
     defaults::DEFAULT_EVENT_LOOP_TIMEOUT_MS,
     errors::{
-        datatypes::{DatatypeAction, EventLoopAction, InternalReason},
+        datatypes::{InternalReason, RecoveryAction},
         with_err_out,
     },
     observability::{metrics, trace::add_span_event},
@@ -21,6 +21,38 @@ use crate::{
 
 const BACKOFF_MIN_DELAY: Duration = Duration::from_millis(500);
 const BACKOFF_MAX_DELAY: Duration = Duration::from_secs(30);
+
+/// Event-loop scheduling mode, derived from the routed [`RecoveryAction`].
+///
+/// This is loop-internal state: the routing decision lives in `RecoveryAction`, while
+/// `LoopMode` only tracks how the loop schedules the next sync attempt.
+#[derive(Debug)]
+enum LoopMode {
+    /// Process both channels and push when needed.
+    Normal,
+    /// Only the unbounded channel (manual sync/stop) is processed; a timed retry fires
+    /// when no event arrives within the backoff delay.
+    BackOff,
+    /// PushTransaction events are rejected without calling push_pull.
+    Stopped,
+}
+
+impl From<RecoveryAction> for LoopMode {
+    fn from(recovery: RecoveryAction) -> Self {
+        match recovery {
+            RecoveryAction::NotifyOnly | RecoveryAction::Resubscribe => LoopMode::Normal,
+            RecoveryAction::RetryWithBackOff | RecoveryAction::ResubscribeWithBackOff => {
+                LoopMode::BackOff
+            }
+            RecoveryAction::Disable => LoopMode::Stopped,
+            // Commit-path errors are consumed on the user thread and never reach the loop.
+            RecoveryAction::RollbackTransaction => {
+                debug_assert!(false, "RollbackTransaction must not reach the event loop");
+                LoopMode::Normal
+            }
+        }
+    }
+}
 
 #[derive(Display)]
 pub enum Event {
@@ -85,14 +117,14 @@ impl EventLoop {
         rt_handle.spawn_blocking(move || {
             span.in_scope(|| {
                 add_span_event!("start event_loop");
-                let mut event_loop_action = EventLoopAction::Normal;
+                let mut loop_mode = LoopMode::Normal;
                 let mut backoff = None;
                 loop {
                     match Self::receive_event(
                         &wired,
                         &bounded_rx,
                         &unbounded_rx,
-                        &mut event_loop_action,
+                        &mut loop_mode,
                         &mut backoff,
                     ) {
                         Ok(event) => match event {
@@ -104,29 +136,31 @@ impl EventLoop {
                                 break;
                             }
                             Event::PushTransaction(resp_tx) => {
-                                if matches!(event_loop_action, EventLoopAction::StopSync) {
+                                if matches!(loop_mode, LoopMode::Stopped) {
                                     Self::process_blocking_resp(
                                         resp_tx,
-                                        Some(InternalReason::EventLoop("event loop stopped".into()).into_error()),
+                                        Some(
+                                            InternalReason::EventLoop("event loop stopped".into())
+                                                .into_error(),
+                                        ),
                                     );
                                     continue;
                                 }
                                 let opt_datatype_error = match wired.push_pull() {
                                     Ok(_) => {
-                                        event_loop_action = EventLoopAction::Normal;
+                                        loop_mode = LoopMode::Normal;
                                         None
                                     }
                                     Err(dewa) => {
-                                        event_loop_action = dewa.event_loop_action;
-                                        if matches!(event_loop_action, EventLoopAction::BackOff) {
+                                        loop_mode = LoopMode::from(dewa.recovery);
+                                        if matches!(loop_mode, LoopMode::BackOff) {
                                             metrics::emit_backoff(&wired.attr);
                                         }
-                                        wired
-                                            .handle_error(dewa.error.clone(), dewa.datatype_action);
+                                        wired.handle_error(dewa.error.clone(), dewa.recovery);
                                         Some(dewa.error)
                                     }
                                 };
-                                if !matches!(event_loop_action, EventLoopAction::BackOff) {
+                                if !matches!(loop_mode, LoopMode::BackOff) {
                                     backoff = None;
                                 }
                                 Self::process_blocking_resp(resp_tx, opt_datatype_error);
@@ -140,7 +174,7 @@ impl EventLoop {
                             }
                         },
                         Err(err) => {
-                            wired.handle_error(err, DatatypeAction::Disable);
+                            wired.handle_error(err, RecoveryAction::Disable);
                         }
                     }
                 }
@@ -165,13 +199,13 @@ impl EventLoop {
         wired: &WiredDatatype,
         bounded_rx: &Receiver<Event>,
         unbounded_rx: &Receiver<Event>,
-        event_loop_action: &mut EventLoopAction,
+        loop_mode: &mut LoopMode,
         backoff: &mut Option<ExponentialBackoff>,
     ) -> Result<Event, DatatypeError> {
-        let (push_if_needed, backoff_duration) = match event_loop_action {
-            EventLoopAction::Normal => (true, None),
-            EventLoopAction::StopSync => (false, None),
-            EventLoopAction::BackOff => {
+        let (push_if_needed, backoff_duration) = match loop_mode {
+            LoopMode::Normal => (true, None),
+            LoopMode::Stopped => (false, None),
+            LoopMode::BackOff => {
                 let backoff_iter = backoff.get_or_insert_with(Self::build_backoff);
                 let d = backoff_iter.next().unwrap_or(BACKOFF_MAX_DELAY);
                 (false, Some(d))
@@ -193,7 +227,7 @@ impl EventLoop {
                 // only unbounded_rx is allowed to receive events during backoff for STOP or explicit sync event
                 recv(unbounded_rx) -> event => event.map_err(|e| map_err(e, "unbounded")),
                 default(duration) => {
-                    *event_loop_action = EventLoopAction::Normal;
+                    *loop_mode = LoopMode::Normal;
                     Ok(Event::BackOff)
                 }
             }
@@ -254,7 +288,8 @@ impl EventLoop {
                 Ok(None) => Ok(()),
                 Err(e) => Err(InternalReason::EventLoop(format!(
                     "failed to receive response of sync(): {e}"
-                )).into_error()),
+                ))
+                .into_error()),
             }
         })
     }
@@ -276,15 +311,15 @@ mod tests_event_loop {
         Client, DatatypeError, DatatypeState, ServerRejectReason,
         connectivity::local_connectivity::LocalConnectivity,
         datatypes::datatype::Datatype,
-        errors::datatypes::DatatypeErrorWithActions,
+        errors::datatypes::DatatypeErrorWithAction,
         utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
     };
 
-    fn make_backoff_error() -> DatatypeErrorWithActions {
+    fn make_backoff_error() -> DatatypeErrorWithAction {
         DatatypeError::SyncFailed("injected".to_string()).mapping()
     }
 
-    fn make_pause_sync_error() -> DatatypeErrorWithActions {
+    fn make_pause_sync_error() -> DatatypeErrorWithAction {
         DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(
             "injected".to_string(),
         ))
@@ -310,12 +345,12 @@ mod tests_event_loop {
             .get_wired_interceptor(&resource_id, &client.get_cuid())
             .unwrap();
 
-        // inject SyncFailed → maps to EventLoopAction::BackOff, DatatypeAction::Normal
+        // inject SyncFailed → maps to RecoveryAction::RetryWithBackOff
         interceptor.set_after_pull(|_| Err(make_backoff_error()));
 
         let err = counter.sync().unwrap_err();
         assert!(matches!(err, DatatypeError::SyncFailed(_)));
-        // DatatypeAction::Normal → no state change
+        // RetryWithBackOff leaves the datatype untouched → no state change
         assert_eq!(counter.get_state(), DatatypeState::Creating);
 
         // explicit sync() sends to unbounded channel → bypasses 500ms BackOff wait

--- a/src/datatypes/handler.rs
+++ b/src/datatypes/handler.rs
@@ -122,8 +122,9 @@ impl HandlersManager {
             rt_handle.spawn(async move {
                 for (priority, handler) in handlers {
                     span.in_scope(|| {
-                        add_span_event!(format!("{event_name} priority={priority}"));
+                        add_span_event!(format!("begin {event_name} priority={priority}"));
                         notify(&handler, ds.clone());
+                        add_span_event!(format!("end {event_name} priority={priority}"));
                     });
                 }
             });

--- a/src/datatypes/handler.rs
+++ b/src/datatypes/handler.rs
@@ -221,7 +221,7 @@ mod tests_handers_manager {
 
         let handler1 = DatatypeHandler::new().set_on_error(move |ds, err| {
             info!("error1: {:?}", err);
-            assert!(matches!(err, DatatypeError::FailedToSubscribe(_)));
+            assert!(matches!(err, DatatypeError::ServerRejected(_)));
             let a = count_for_h1.fetch_add(1, Ordering::Relaxed);
             assert_eq!(a, 1);
             assert_eq!(ds.get_state(), DatatypeState::Disabled);
@@ -229,7 +229,7 @@ mod tests_handers_manager {
 
         let handler2 = DatatypeHandler::new().set_on_error(move |ds, err| {
             info!("error2: {:?}", err);
-            assert!(matches!(err, DatatypeError::FailedToSubscribe(_)));
+            assert!(matches!(err, DatatypeError::ServerRejected(_)));
             let a = count_for_h2.fetch_add(1, Ordering::Relaxed);
             assert_eq!(a, 0);
             assert_eq!(ds.get_state(), DatatypeState::Disabled);
@@ -244,7 +244,7 @@ mod tests_handers_manager {
         assert_eq!(counter1.get_state(), DatatypeState::Subscribing);
         assert!(matches!(
             counter1.sync().unwrap_err(),
-            DatatypeError::FailedToSubscribe(_)
+            DatatypeError::ServerRejected(_)
         ));
         assert_eq!(counter1.get_state(), DatatypeState::Disabled);
         awaitility::at_most(Duration::from_secs(2))

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -11,13 +11,12 @@ use crate::{
         push_buffer::{MemoryPushBuffer, PushBuffer},
         tx_record::TxRecord,
     },
-    errors::{
-        push_pull::{CLIENT_PUSHPULL_ERR_MSG_NO_SNAPSHOT, ClientPushPullError},
-        with_err_out,
-    },
+    errors::with_err_out,
     operations::{Operation, body::OperationBody, transaction::Transaction},
     types::{checkpoint::CheckPoint, operation_id::OperationId},
 };
+
+pub(crate) const DATATYPE_ERR_MSG_NO_SNAPSHOT: &str = "no snapshot operation";
 
 #[derive(Debug)]
 pub struct MutableDatatype {
@@ -64,10 +63,10 @@ impl MutableDatatype {
     pub fn apply_snapshot_transaction(
         &mut self,
         tx: Arc<Transaction>,
-    ) -> Result<(), ClientPushPullError> {
+    ) -> Result<(), DatatypeError> {
         if tx.operations.is_empty() {
-            return Err(ClientPushPullError::FailedWithProtocolViolation(
-                CLIENT_PUSHPULL_ERR_MSG_NO_SNAPSHOT.to_owned(),
+            return Err(DatatypeError::FailedByProtocolViolation(
+                DATATYPE_ERR_MSG_NO_SNAPSHOT.to_owned(),
             ));
         }
         let snap_op = &tx.operations[0];
@@ -77,8 +76,8 @@ impl MutableDatatype {
             self.op_id.lamport = snap_op.lamport;
             self.reset();
         } else {
-            return Err(ClientPushPullError::FailedWithProtocolViolation(
-                CLIENT_PUSHPULL_ERR_MSG_NO_SNAPSHOT.to_owned(),
+            return Err(DatatypeError::FailedByProtocolViolation(
+                DATATYPE_ERR_MSG_NO_SNAPSHOT.to_owned(),
             ));
         }
         Ok(())
@@ -108,10 +107,10 @@ impl MutableDatatype {
             let tx = Arc::new(tx);
             if tx.cuid == self.op_id.cuid {
                 if let Err(err) = self.push_buffer.enqueue(tx.clone()) {
-                    if err == ClientPushPullError::ExceedMaxMemSize {
+                    if err == DatatypeError::PushBufferExceededMaxMemSize {
                         todo!("should reduce the push buffer size");
                     }
-                    if err == ClientPushPullError::NonSequentialCseq {
+                    if err == DatatypeError::NonSequentialCseq {
                         unreachable!("this should not happen");
                     }
                 }

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -11,7 +11,10 @@ use crate::{
         push_buffer::{MemoryPushBuffer, PushBuffer},
         tx_record::TxRecord,
     },
-    errors::with_err_out,
+    errors::{
+        datatypes::{DatatypeErrorWithAction, RecoveryAction},
+        with_err_out,
+    },
     operations::{Operation, body::OperationBody, transaction::Transaction},
     types::{checkpoint::CheckPoint, operation_id::OperationId},
 };
@@ -65,20 +68,20 @@ impl MutableDatatype {
         tx: Arc<Transaction>,
     ) -> Result<(), DatatypeError> {
         if tx.operations.is_empty() {
-            return Err(DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(
-                DATATYPE_ERR_MSG_NO_SNAPSHOT.to_owned(),
-            )));
+            return Err(DatatypeError::ServerRejected(
+                ServerRejectReason::ProtocolViolation(DATATYPE_ERR_MSG_NO_SNAPSHOT.to_owned()),
+            ));
         }
         let snap_op = &tx.operations[0];
         if let OperationBody::Snapshot(body) = &snap_op.body {
-            self.crdt.deserialize(&body.data);
+            self.crdt.deserialize(&body.data)?;
             self.op_id.cseq = 0;
             self.op_id.lamport = snap_op.lamport;
             self.reset();
         } else {
-            return Err(DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(
-                DATATYPE_ERR_MSG_NO_SNAPSHOT.to_owned(),
-            )));
+            return Err(DatatypeError::ServerRejected(
+                ServerRejectReason::ProtocolViolation(DATATYPE_ERR_MSG_NO_SNAPSHOT.to_owned()),
+            ));
         }
         Ok(())
     }
@@ -96,10 +99,20 @@ impl MutableDatatype {
         }
     }
 
-    pub fn end_transaction(&mut self, tag: Option<String>, committed: bool) -> bool {
+    /// Ends the in-progress transaction.
+    ///
+    /// Returns `Ok(true)` when a committed transaction was enqueued into the push buffer,
+    /// `Ok(false)` when the transaction was rolled back (`committed == false`).
+    /// On an enqueue failure, `pending` is restored so that the routed
+    /// `RecoveryAction::RollbackTransaction` can undo the transaction, and the error is returned.
+    pub fn end_transaction(
+        &mut self,
+        tag: Option<String>,
+        committed: bool,
+    ) -> Result<bool, DatatypeErrorWithAction> {
         if !committed {
             self.do_rollback();
-            return false;
+            return Ok(false);
         }
 
         if let Some(mut tx) = self.tx_record.pending.take() {
@@ -107,14 +120,31 @@ impl MutableDatatype {
             let tx = Arc::new(tx);
             if tx.cuid == self.op_id.cuid {
                 if let Err(err) = self.push_buffer.enqueue(tx.clone()) {
-                    if err == DatatypeError::PushBufferExceededMaxMemSize {
-                        todo!("should reduce the push buffer size");
-                    }
-                    unreachable!("unexpected enqueue error: {err:?}");
+                    // The clone passed to enqueue is dropped on failure, so this Arc is unique
+                    // again; restore pending so RecoveryAction::RollbackTransaction can undo it.
+                    self.tx_record.pending = Arc::try_unwrap(tx).ok();
+                    return Err(err);
                 }
             }
         }
-        true
+        Ok(true)
+    }
+
+    /// Applies the datatype-lifecycle side effect of a routed error.
+    ///
+    /// Single dispatch point for `RecoveryAction`, shared by the event-loop path
+    /// (`WiredDatatype::handle_error`) and the transaction-commit path
+    /// (`TransactionalDatatype::end_transaction`).
+    pub fn apply_action(&mut self, recovery: RecoveryAction) {
+        match recovery {
+            RecoveryAction::NotifyOnly | RecoveryAction::RetryWithBackOff => {}
+            RecoveryAction::RollbackTransaction => self.do_rollback(),
+            RecoveryAction::Resubscribe | RecoveryAction::ResubscribeWithBackOff => {
+                self.reset();
+                self.set_state(DatatypeState::SubscribingOrCreating);
+            }
+            RecoveryAction::Disable => self.disable(),
+        }
     }
 
     pub fn execute_remote_transaction(

--- a/src/datatypes/mutable.rs
+++ b/src/datatypes/mutable.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use tracing::instrument;
 
 use crate::{
-    DatatypeError, DatatypeHandler, DatatypeState,
+    DatatypeError, DatatypeHandler, DatatypeState, ServerRejectReason,
     datatypes::{
         common::{Attribute, ReturnType},
         crdts::Crdt,
@@ -65,9 +65,9 @@ impl MutableDatatype {
         tx: Arc<Transaction>,
     ) -> Result<(), DatatypeError> {
         if tx.operations.is_empty() {
-            return Err(DatatypeError::FailedByProtocolViolation(
+            return Err(DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(
                 DATATYPE_ERR_MSG_NO_SNAPSHOT.to_owned(),
-            ));
+            )));
         }
         let snap_op = &tx.operations[0];
         if let OperationBody::Snapshot(body) = &snap_op.body {
@@ -76,9 +76,9 @@ impl MutableDatatype {
             self.op_id.lamport = snap_op.lamport;
             self.reset();
         } else {
-            return Err(DatatypeError::FailedByProtocolViolation(
+            return Err(DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(
                 DATATYPE_ERR_MSG_NO_SNAPSHOT.to_owned(),
-            ));
+            )));
         }
         Ok(())
     }
@@ -110,9 +110,7 @@ impl MutableDatatype {
                     if err == DatatypeError::PushBufferExceededMaxMemSize {
                         todo!("should reduce the push buffer size");
                     }
-                    if err == DatatypeError::NonSequentialCseq {
-                        unreachable!("this should not happen");
-                    }
+                    unreachable!("unexpected enqueue error: {err:?}");
                 }
             }
         }

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -1,9 +1,9 @@
 use tracing::{debug, instrument};
 
 use crate::{
-    DatatypeError, DatatypeState,
+    DatatypeError, DatatypeState, ServerRejectReason,
     datatypes::mutable::MutableDatatype,
-    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
+    errors::datatypes::DatatypeErrorWithActions,
     observability::trace::add_span_event,
     types::{checkpoint::CheckPoint, push_pull_pack::PushPullPack},
 };
@@ -52,19 +52,16 @@ impl<'a> PullHandler<'a> {
         old: DatatypeState,
         new: DatatypeState,
     ) -> Result<(), DatatypeErrorWithActions> {
-        Err(DatatypeErrorWithActions::new(
-            DatatypeError::FailedByProtocolViolation(format!(
-                "illegal state from push-pull: received {new} for {old}"
-            )),
-            EventLoopAction::PauseSync,
-            DatatypeAction::Disable,
-        ))
+        Err(DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(format!(
+            "illegal state from push-pull: received {new} for {old}"
+        )))
+        .mapping())
     }
 
     fn handle_error_and_datatype_state(&mut self) -> Result<(), DatatypeErrorWithActions> {
         self.new_state = self.pulled_ppp.state;
         if let Some(sppe) = self.pulled_ppp.error.as_ref() {
-            return Err(sppe.mapping());
+            return Err(sppe.to_datatype_error().mapping());
         }
 
         match self.old_state {
@@ -151,9 +148,7 @@ impl<'a> PullHandler<'a> {
     fn execute_transactions(&mut self) -> Result<(), DatatypeErrorWithActions> {
         let transactions = self.pulled_ppp.transactions[self.skip..].to_vec();
         for tx in transactions {
-            self.mutable.execute_remote_transaction(tx).map_err(|e| {
-                DatatypeErrorWithActions::new(e, EventLoopAction::Normal, DatatypeAction::Restart)
-            })?;
+            self.mutable.execute_remote_transaction(tx).map_err(|e| e.mapping())?;
         }
         Ok(())
     }

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -64,7 +64,7 @@ impl<'a> PullHandler<'a> {
     fn handle_error_and_datatype_state(&mut self) -> Result<(), DatatypeErrorWithActions> {
         self.new_state = self.pulled_ppp.state;
         if let Some(sppe) = self.pulled_ppp.error.as_ref() {
-            return Err(sppe.mapping(self.old_state, self.pulled_ppp.state));
+            return Err(sppe.mapping());
         }
 
         match self.old_state {

--- a/src/datatypes/pull_handler.rs
+++ b/src/datatypes/pull_handler.rs
@@ -3,12 +3,12 @@ use tracing::{debug, instrument};
 use crate::{
     DatatypeError, DatatypeState, ServerRejectReason,
     datatypes::mutable::MutableDatatype,
-    errors::datatypes::DatatypeErrorWithActions,
+    errors::datatypes::DatatypeErrorWithAction,
     observability::trace::add_span_event,
     types::{checkpoint::CheckPoint, push_pull_pack::PushPullPack},
 };
 
-type PendingStep<'b> = fn(&mut PullHandler<'b>) -> Result<(), DatatypeErrorWithActions>;
+type PendingStep<'b> = fn(&mut PullHandler<'b>) -> Result<(), DatatypeErrorWithAction>;
 
 pub struct PullHandler<'a> {
     pulled_ppp: &'a mut PushPullPack,
@@ -35,8 +35,8 @@ impl<'a> PullHandler<'a> {
     }
 
     #[instrument(skip_all, name = "applyPull")]
-    pub fn apply(&mut self) -> Result<(), DatatypeErrorWithActions> {
-        let result = (|| -> Result<(), DatatypeErrorWithActions> {
+    pub fn apply(&mut self) -> Result<(), DatatypeErrorWithAction> {
+        let result = (|| -> Result<(), DatatypeErrorWithAction> {
             self.handle_error_and_datatype_state()?;
             self.enqueue_step(Self::skip_duplicated_transactions);
             self.enqueue_step(Self::execute_transactions);
@@ -51,14 +51,16 @@ impl<'a> PullHandler<'a> {
         &self,
         old: DatatypeState,
         new: DatatypeState,
-    ) -> Result<(), DatatypeErrorWithActions> {
-        Err(DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(format!(
-            "illegal state from push-pull: received {new} for {old}"
-        )))
-        .mapping())
+    ) -> Result<(), DatatypeErrorWithAction> {
+        Err(
+            DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(format!(
+                "illegal state from push-pull: received {new} for {old}"
+            )))
+            .mapping(),
+        )
     }
 
-    fn handle_error_and_datatype_state(&mut self) -> Result<(), DatatypeErrorWithActions> {
+    fn handle_error_and_datatype_state(&mut self) -> Result<(), DatatypeErrorWithAction> {
         self.new_state = self.pulled_ppp.state;
         if let Some(sppe) = self.pulled_ppp.error.as_ref() {
             return Err(sppe.to_datatype_error().mapping());
@@ -120,7 +122,7 @@ impl<'a> PullHandler<'a> {
         self.pending_steps.push(step);
     }
 
-    fn apply_subscribe_response(&mut self) -> Result<(), DatatypeErrorWithActions> {
+    fn apply_subscribe_response(&mut self) -> Result<(), DatatypeErrorWithAction> {
         if let Some(snapshot_tx) = self.pulled_ppp.snapshot_transaction.take() {
             self.mutable
                 .apply_snapshot_transaction(snapshot_tx)
@@ -130,7 +132,7 @@ impl<'a> PullHandler<'a> {
         Ok(())
     }
 
-    fn skip_duplicated_transactions(&mut self) -> Result<(), DatatypeErrorWithActions> {
+    fn skip_duplicated_transactions(&mut self) -> Result<(), DatatypeErrorWithAction> {
         let need_to_pull = self.calculate_pulling_transactions(&self.pulled_ppp.checkpoint);
         let len_pulled_txs = self.pulled_ppp.transactions.len();
         if len_pulled_txs > need_to_pull {
@@ -145,22 +147,24 @@ impl<'a> PullHandler<'a> {
         (new_cp.sseq - old_cp.sseq) as usize - (new_cp.cseq - old_cp.cseq) as usize
     }
 
-    fn execute_transactions(&mut self) -> Result<(), DatatypeErrorWithActions> {
+    fn execute_transactions(&mut self) -> Result<(), DatatypeErrorWithAction> {
         let transactions = self.pulled_ppp.transactions[self.skip..].to_vec();
         for tx in transactions {
-            self.mutable.execute_remote_transaction(tx).map_err(|e| e.mapping())?;
+            self.mutable
+                .execute_remote_transaction(tx)
+                .map_err(|e| e.mapping())?;
         }
         Ok(())
     }
 
-    fn sync_checkpoint(&mut self) -> Result<(), DatatypeErrorWithActions> {
+    fn sync_checkpoint(&mut self) -> Result<(), DatatypeErrorWithAction> {
         self.mutable
             .checkpoint
             .check_with(&self.pulled_ppp.checkpoint);
         Ok(())
     }
 
-    fn commit(&mut self) -> Result<(), DatatypeErrorWithActions> {
+    fn commit(&mut self) -> Result<(), DatatypeErrorWithAction> {
         let steps = std::mem::take(&mut self.pending_steps);
         for step in steps {
             step(self)?;

--- a/src/datatypes/push_buffer.rs
+++ b/src/datatypes/push_buffer.rs
@@ -3,6 +3,7 @@ use std::{collections::VecDeque, fmt::Display, sync::Arc};
 use crate::{
     DatatypeError,
     datatypes::option::DatatypeOption,
+    errors::datatypes::InternalReason,
     operations::{MemoryMeasurable, transaction::Transaction},
 };
 
@@ -56,7 +57,7 @@ impl MemoryPushBuffer {
 impl PushBuffer for MemoryPushBuffer {
     fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), DatatypeError> {
         if self.last_cseq != 0 && self.last_cseq + 1 != tx.cseq {
-            return Err(DatatypeError::NonSequentialCseq);
+            return Err(InternalReason::NonSequentialCseq.into_error());
         }
         if self.mem_size + tx.size() > self.option.max_mem_size_of_push_buffer {
             return Err(DatatypeError::PushBufferExceededMaxMemSize);
@@ -77,7 +78,7 @@ impl PushBuffer for MemoryPushBuffer {
     ) -> Result<(Vec<Arc<Transaction>>, u64), DatatypeError> {
         let mut popped = vec![];
         if cseq == 0 || cseq < self.first_cseq {
-            return Err(DatatypeError::FailedToGetPushingTransactions);
+            return Err(InternalReason::GetPushingTransactions.into_error());
         }
 
         let mut total_size: u64 = 0;
@@ -189,7 +190,7 @@ mod tests_push_buffer {
         let cseq2 = op_id2.next_cseq();
         let tx_not_sequential = Arc::new(Transaction::new(&op_id2.cuid, cseq2));
         let result = push_buffer.enqueue(tx_not_sequential);
-        assert_eq!(result.unwrap_err(), DatatypeError::NonSequentialCseq);
+        assert!(matches!(result.unwrap_err(), DatatypeError::Internal(_)));
 
         loop {
             let cseq = op_id.next_cseq();

--- a/src/datatypes/push_buffer.rs
+++ b/src/datatypes/push_buffer.rs
@@ -1,19 +1,19 @@
 use std::{collections::VecDeque, fmt::Display, sync::Arc};
 
 use crate::{
+    DatatypeError,
     datatypes::option::DatatypeOption,
-    errors::push_pull::ClientPushPullError,
     operations::{MemoryMeasurable, transaction::Transaction},
 };
 
 #[allow(dead_code)]
 pub trait PushBuffer {
-    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), ClientPushPullError>;
+    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), DatatypeError>;
     fn get_pushing_transactions(
         &mut self,
         cseq: u64,
         max_mem_size: u64,
-    ) -> Result<(Vec<Arc<Transaction>>, u64), ClientPushPullError>;
+    ) -> Result<(Vec<Arc<Transaction>>, u64), DatatypeError>;
     fn deque(&mut self, upto_cseq: u64) -> Vec<Arc<Transaction>>;
 }
 
@@ -54,12 +54,12 @@ impl MemoryPushBuffer {
 }
 
 impl PushBuffer for MemoryPushBuffer {
-    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), ClientPushPullError> {
+    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), DatatypeError> {
         if self.last_cseq != 0 && self.last_cseq + 1 != tx.cseq {
-            return Err(ClientPushPullError::NonSequentialCseq);
+            return Err(DatatypeError::NonSequentialCseq);
         }
         if self.mem_size + tx.size() > self.option.max_mem_size_of_push_buffer {
-            return Err(ClientPushPullError::ExceedMaxMemSize);
+            return Err(DatatypeError::PushBufferExceededMaxMemSize);
         }
         if self.first_cseq == 0 {
             self.first_cseq = tx.cseq;
@@ -74,10 +74,10 @@ impl PushBuffer for MemoryPushBuffer {
         &mut self,
         cseq: u64,
         max_mem_size: u64,
-    ) -> Result<(Vec<Arc<Transaction>>, u64), ClientPushPullError> {
+    ) -> Result<(Vec<Arc<Transaction>>, u64), DatatypeError> {
         let mut popped = vec![];
         if cseq == 0 || cseq < self.first_cseq {
-            return Err(ClientPushPullError::FailToGetPushingTransactions);
+            return Err(DatatypeError::FailedToGetPushingTransactions);
         }
 
         let mut total_size: u64 = 0;
@@ -148,9 +148,10 @@ mod tests_push_buffer {
     use tracing::{info, instrument};
 
     use crate::{
+        DatatypeError,
         datatypes::{
             option::DatatypeOption,
-            push_buffer::{ClientPushPullError, MemoryPushBuffer, PushBuffer},
+            push_buffer::{MemoryPushBuffer, PushBuffer},
         },
         operations::{MemoryMeasurable, transaction::Transaction},
         types::operation_id::OperationId,
@@ -188,7 +189,7 @@ mod tests_push_buffer {
         let cseq2 = op_id2.next_cseq();
         let tx_not_sequential = Arc::new(Transaction::new(&op_id2.cuid, cseq2));
         let result = push_buffer.enqueue(tx_not_sequential);
-        assert_eq!(result.unwrap_err(), ClientPushPullError::NonSequentialCseq);
+        assert_eq!(result.unwrap_err(), DatatypeError::NonSequentialCseq);
 
         loop {
             let cseq = op_id.next_cseq();
@@ -196,7 +197,7 @@ mod tests_push_buffer {
             if push_buffer.mem_size + tx.size() > MAX_SIZE {
                 assert_eq!(
                     push_buffer.enqueue(tx).unwrap_err(),
-                    ClientPushPullError::ExceedMaxMemSize
+                    DatatypeError::PushBufferExceededMaxMemSize
                 );
                 break;
             }

--- a/src/datatypes/push_buffer.rs
+++ b/src/datatypes/push_buffer.rs
@@ -3,13 +3,19 @@ use std::{collections::VecDeque, fmt::Display, sync::Arc};
 use crate::{
     DatatypeError,
     datatypes::option::DatatypeOption,
-    errors::datatypes::InternalReason,
+    errors::datatypes::{DatatypeErrorWithAction, InternalReason},
     operations::{MemoryMeasurable, transaction::Transaction},
 };
 
 #[allow(dead_code)]
 pub trait PushBuffer {
-    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), DatatypeError>;
+    /// Enqueues a committed transaction.
+    ///
+    /// Errors are returned with their routing actions already resolved, because the
+    /// `NonSequentialCseq` reason would lose its routing override once erased into
+    /// `DatatypeError::Internal`. The routing pairs themselves are still defined in the
+    /// errors module (`InternalReason::mapping` / `DatatypeError::mapping`).
+    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), DatatypeErrorWithAction>;
     fn get_pushing_transactions(
         &mut self,
         cseq: u64,
@@ -55,12 +61,12 @@ impl MemoryPushBuffer {
 }
 
 impl PushBuffer for MemoryPushBuffer {
-    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), DatatypeError> {
+    fn enqueue(&mut self, tx: Arc<Transaction>) -> Result<(), DatatypeErrorWithAction> {
         if self.last_cseq != 0 && self.last_cseq + 1 != tx.cseq {
-            return Err(InternalReason::NonSequentialCseq.into_error());
+            return Err(InternalReason::NonSequentialCseq.mapping());
         }
         if self.mem_size + tx.size() > self.option.max_mem_size_of_push_buffer {
-            return Err(DatatypeError::PushBufferExceededMaxMemSize);
+            return Err(DatatypeError::PushBufferExceededMaxMemSize.mapping());
         }
         if self.first_cseq == 0 {
             self.first_cseq = tx.cseq;
@@ -190,14 +196,17 @@ mod tests_push_buffer {
         let cseq2 = op_id2.next_cseq();
         let tx_not_sequential = Arc::new(Transaction::new(&op_id2.cuid, cseq2));
         let result = push_buffer.enqueue(tx_not_sequential);
-        assert!(matches!(result.unwrap_err(), DatatypeError::Internal(_)));
+        assert!(matches!(
+            result.unwrap_err().error,
+            DatatypeError::Internal(_)
+        ));
 
         loop {
             let cseq = op_id.next_cseq();
             let tx = Arc::new(Transaction::new(&op_id.cuid, cseq));
             if push_buffer.mem_size + tx.size() > MAX_SIZE {
                 assert_eq!(
-                    push_buffer.enqueue(tx).unwrap_err(),
+                    push_buffer.enqueue(tx).unwrap_err().error,
                     DatatypeError::PushBufferExceededMaxMemSize
                 );
                 break;

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -12,7 +12,10 @@ use crate::{
         mutable::MutableDatatype,
         wired::WiredDatatype,
     },
-    errors::{datatypes::DatatypeError, with_err_out},
+    errors::{
+        datatypes::{DatatypeError, RecoveryAction},
+        with_err_out,
+    },
     observability::trace::add_span_event,
     operations::Operation,
     utils::{defer_guard::DeferGuard, no_guard_mutex::NoGuardMutex},
@@ -250,9 +253,27 @@ impl TransactionalDatatype {
 
     #[instrument(skip_all)]
     fn end_transaction(&self, tag: Option<String>, committed: bool) {
-        let mut mutable = self.mutable.write();
-        if mutable.end_transaction(tag, committed) {
-            self.event_loop.send_push_transaction_with_best_effort();
+        let error = {
+            let mut mutable = self.mutable.write();
+            match mutable.end_transaction(tag, committed) {
+                Ok(true) => {
+                    self.event_loop.send_push_transaction_with_best_effort();
+                    None
+                }
+                Ok(false) => None,
+                Err(dewa) => {
+                    // This path runs in a defer guard, after the API call has returned, and
+                    // does not go through the event loop: only RollbackTransaction is expected
+                    // here, and the on_error handler is the only way to notify the user.
+                    debug_assert!(matches!(dewa.recovery, RecoveryAction::RollbackTransaction));
+                    mutable.apply_action(dewa.recovery);
+                    Some(dewa.error)
+                }
+            }
+        };
+        if let Some(err) = error {
+            // Notify after releasing the write lock; handlers may re-enter the datatype.
+            self.mutable.read().call_error_handler(err);
         }
         self.tx_ctx.write().take();
         self.tx_mutex.unlock();
@@ -362,14 +383,44 @@ mod tests_transactional {
     use tracing_opentelemetry::OpenTelemetrySpanExt;
 
     use crate::{
-        Client, DataType,
+        Client, DataType, DatatypeState,
         datatypes::{
             common::new_attribute,
+            crdts::Crdt,
             transactional::{TransactionContext, TransactionalDatatype},
         },
         operations::Operation,
         utils::test_utils::{get_test_collection_name, get_test_func_name},
     };
+
+    #[test]
+    #[instrument]
+    fn can_rollback_on_enqueue_failure() {
+        let attr = new_attribute!(DataType::Counter);
+        let tx_dt = TransactionalDatatype::new_arc(attr, Default::default(), Default::default());
+        let tx_ctx = Arc::new(TransactionContext::new("non_sequential_cseq"));
+
+        let tx_dt_in_tx = tx_dt.clone();
+        let tx_ctx_in_tx = tx_ctx.clone();
+        let result = tx_dt.do_transaction(tx_ctx, move || {
+            tx_dt_in_tx.execute_local_operation_as_tx(
+                tx_ctx_in_tx.clone(),
+                Operation::new_counter_increase(5),
+            )?;
+            // Corrupt the buffer sequence so the commit-time enqueue fails with
+            // InternalReason::NonSequentialCseq.
+            tx_dt_in_tx.mutable.write().push_buffer.last_cseq = 42;
+            Ok(())
+        });
+        // tx_func itself succeeded; the enqueue failure is routed to Normal + Rollback.
+        assert!(result.is_ok());
+
+        let mutable = tx_dt.mutable.read();
+        let Crdt::Counter(c) = &mutable.crdt;
+        assert_eq!(c.value(), 0);
+        assert_eq!(mutable.op_id.cseq, 0);
+        assert_ne!(mutable.get_state(), DatatypeState::Disabled);
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
     #[instrument]

--- a/src/datatypes/transactional.rs
+++ b/src/datatypes/transactional.rs
@@ -174,17 +174,14 @@ impl TransactionalDatatype {
 
         let state = self.get_state();
         if !state.is_read_writable() {
-            return Err(with_err_out!(DatatypeError::Disallowed(format!(
+            return Err(with_err_out!(DatatypeError::NotWritable(format!(
                 "Datatype '{}' cannot be modified for {:?} state",
                 self.attr.key, state
             ))));
         }
 
         if self.attr.is_readonly {
-            return Err(with_err_out!(DatatypeError::Disallowed(format!(
-                "Datatype '{}' is readonly",
-                self.attr.key
-            ))));
+            return Err(with_err_out!(DatatypeError::ReadonlyViolation));
         }
 
         Ok(())
@@ -192,7 +189,7 @@ impl TransactionalDatatype {
 
     fn check_disabled(&self, op: &str) -> Result<(), DatatypeError> {
         if self.mutable.read().get_state() == DatatypeState::Disabled {
-            return Err(DatatypeError::Disallowed(format!(
+            return Err(DatatypeError::NotWritable(format!(
                 "{} is not allowed in Disabled state",
                 op
             )));
@@ -203,7 +200,7 @@ impl TransactionalDatatype {
     fn check_subscribed(&self, op: &str) -> Result<(), DatatypeError> {
         let state = self.mutable.read().get_state();
         if state != DatatypeState::Subscribed {
-            return Err(with_err_out!(DatatypeError::Disallowed(format!(
+            return Err(with_err_out!(DatatypeError::NotWritable(format!(
                 "{} is only allowed in Subscribed state, current state is {:?}",
                 op, state
             ))));

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -12,10 +12,7 @@ use crate::{
         push_buffer::PushBuffer,
     },
     defaults,
-    errors::{
-        datatypes::{DatatypeAction, DatatypeErrorWithActions},
-        push_pull::ClientPushPullError,
-    },
+    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions},
     observability::{metrics, trace::add_span_event},
     operations::transaction::Transaction,
     types::{notification::Notification, push_pull_pack::PushPullPack, uid::Cuid},
@@ -163,7 +160,7 @@ impl WiredDatatype {
 
 impl MutableDatatype {
     #[instrument(skip_all)]
-    fn create_push_pull_pack(&mut self) -> Result<PushPullPack, ClientPushPullError> {
+    fn create_push_pull_pack(&mut self) -> Result<PushPullPack, DatatypeError> {
         let mut ppp = PushPullPack::new(&self.attr, self.get_state());
 
         let (transactions, _tx_size) = self.push_buffer.get_pushing_transactions(

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -73,7 +73,7 @@ impl WiredDatatype {
                 mutable.set_state(DatatypeState::SubscribingOrCreating);
             }
             DatatypeAction::Disable => self.mutable.write().disable(),
-            DatatypeAction::Reset => {
+            DatatypeAction::Rollback => {
                 self.mutable.write().do_rollback();
             }
         }
@@ -132,7 +132,7 @@ impl WiredDatatype {
         #[cfg_attr(not(test), allow(unused_mut))]
         let mut pulled_ppp = connectivity
             .push_pull(&pushing_ppp)
-            .map_err(|e| e.mapping())?;
+            .map_err(|e| e.to_datatype_error().mapping())?;
 
         #[cfg(test)]
         self.interceptor.after_pull(&mut pulled_ppp)?;

--- a/src/datatypes/wired.rs
+++ b/src/datatypes/wired.rs
@@ -12,7 +12,7 @@ use crate::{
         push_buffer::PushBuffer,
     },
     defaults,
-    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions},
+    errors::datatypes::{DatatypeErrorWithAction, RecoveryAction},
     observability::{metrics, trace::add_span_event},
     operations::transaction::Transaction,
     types::{notification::Notification, push_pull_pack::PushPullPack, uid::Cuid},
@@ -64,19 +64,8 @@ impl WiredDatatype {
         true
     }
 
-    pub fn handle_error(&self, err: DatatypeError, action: DatatypeAction) {
-        match action {
-            DatatypeAction::Normal => {}
-            DatatypeAction::Restart => {
-                let mut mutable = self.mutable.write();
-                mutable.reset();
-                mutable.set_state(DatatypeState::SubscribingOrCreating);
-            }
-            DatatypeAction::Disable => self.mutable.write().disable(),
-            DatatypeAction::Rollback => {
-                self.mutable.write().do_rollback();
-            }
-        }
+    pub fn handle_error(&self, err: DatatypeError, recovery: RecoveryAction) {
+        self.mutable.write().apply_action(recovery);
         self.mutable.read().call_error_handler(err);
     }
 
@@ -109,14 +98,14 @@ impl WiredDatatype {
     }
 
     #[instrument(skip_all)]
-    pub fn push_pull(&self) -> Result<(), DatatypeErrorWithActions> {
+    pub fn push_pull(&self) -> Result<(), DatatypeErrorWithAction> {
         let start = std::time::Instant::now();
         let result = self.do_push_pull();
         metrics::emit_sync(&self.attr, result.is_ok(), start.elapsed());
         result
     }
 
-    fn do_push_pull(&self) -> Result<(), DatatypeErrorWithActions> {
+    fn do_push_pull(&self) -> Result<(), DatatypeErrorWithAction> {
         let connectivity = &self.attr.client_common.connectivity;
 
         #[cfg_attr(not(test), allow(unused_mut))]

--- a/src/datatypes/wired_interceptor.rs
+++ b/src/datatypes/wired_interceptor.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-use crate::{errors::datatypes::DatatypeErrorWithActions, types::push_pull_pack::PushPullPack};
+use crate::{errors::datatypes::DatatypeErrorWithAction, types::push_pull_pack::PushPullPack};
 
 pub type BeforePushFn = dyn Fn(&mut PushPullPack) + Send + Sync + 'static;
 pub type AfterPullFn =
-    dyn Fn(&mut PushPullPack) -> Result<(), DatatypeErrorWithActions> + Send + Sync + 'static;
+    dyn Fn(&mut PushPullPack) -> Result<(), DatatypeErrorWithAction> + Send + Sync + 'static;
 
 pub struct WiredInterceptor {
     before_push: RwLock<Box<BeforePushFn>>,
@@ -28,7 +28,7 @@ impl WiredInterceptor {
 
     pub fn set_after_pull(
         &self,
-        f: impl Fn(&mut PushPullPack) -> Result<(), DatatypeErrorWithActions> + Send + Sync + 'static,
+        f: impl Fn(&mut PushPullPack) -> Result<(), DatatypeErrorWithAction> + Send + Sync + 'static,
     ) -> &Self {
         *self.after_pull.write() = Box::new(f);
         self
@@ -41,7 +41,7 @@ impl WiredInterceptor {
     pub(crate) fn after_pull(
         &self,
         pull: &mut PushPullPack,
-    ) -> Result<(), DatatypeErrorWithActions> {
+    ) -> Result<(), DatatypeErrorWithAction> {
         (self.after_pull.read())(pull)
     }
 }

--- a/src/errors/connectivity.rs
+++ b/src/errors/connectivity.rs
@@ -1,14 +1,8 @@
 use thiserror::Error;
 
-use crate::{
-    DatatypeError,
-    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
-};
+use crate::DatatypeError;
 
 /// Errors related to connectivity operations.
-///
-/// These errors occur when interacting with the underlying synchronization
-/// backend or when resources cannot be found.
 ///
 /// # Equality
 /// Two `ConnectivityError` values are considered equal if they have the same
@@ -16,22 +10,17 @@ use crate::{
 #[non_exhaustive]
 #[derive(Debug, Error, PartialEq, Eq, Clone)]
 pub enum ConnectivityError {
-    /// The requested resource was not found.
+    /// The connectivity backend did not respond within the expected time.
     ///
-    /// Returned when attempting to access a datatype or resource that
-    /// does not exist in the connectivity backend.
-    #[error("[ConnectivityError] the demanded resource is not found: {_0}")]
-    ResourceNotFound(String),
+    /// This is a transient error. The event loop will retry with exponential backoff.
+    #[error("[ConnectivityError] connection timed out: {_0}")]
+    TimedOut(String),
 }
 
 impl ConnectivityError {
-    pub(crate) fn mapping(self) -> DatatypeErrorWithActions {
+    pub(crate) fn to_datatype_error(self) -> DatatypeError {
         match self {
-            ConnectivityError::ResourceNotFound(_) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedInConnectivity(self),
-                EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
-            ),
+            ConnectivityError::TimedOut(_) => DatatypeError::SyncFailed(self.to_string()),
         }
     }
 }

--- a/src/errors/connectivity.rs
+++ b/src/errors/connectivity.rs
@@ -18,7 +18,7 @@ pub enum ConnectivityError {
 }
 
 impl ConnectivityError {
-    pub(crate) fn to_datatype_error(self) -> DatatypeError {
+    pub(crate) fn to_datatype_error(&self) -> DatatypeError {
         match self {
             ConnectivityError::TimedOut(_) => DatatypeError::SyncFailed(self.to_string()),
         }

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -1,22 +1,45 @@
 use thiserror::Error;
 
-
 /// Internal SDK error reason, used by the event loop for action routing.
 ///
 /// Not exposed to users. Internal callers use this to construct `DatatypeError::Internal`
 /// via `into_error()`.
 #[derive(Debug, Error)]
 pub(crate) enum InternalReason {
+    /// A server snapshot could not be deserialized into the CRDT.
+    ///
+    /// Route: `apply_snapshot_transaction()` → `pull_handler::apply_subscribe_response()`
+    /// → `mapping()` → `RecoveryAction::Disable`.
     #[error("deserialize: {0}")]
     Deserialize(String),
+    /// A CRDT operation failed to execute.
+    ///
+    /// Routes:
+    /// - remote: `execute_transactions()` → `mapping()` → `RecoveryAction::Disable`
+    /// - local: returned directly to the user API caller (does not reach the event loop)
     #[error("execute operation: {0}")]
     ExecuteOperation(String),
+    /// An event-loop channel operation failed.
+    ///
+    /// Routes:
+    /// - `receive_event()` Err → `handle_error(_, RecoveryAction::Disable)` directly,
+    ///   bypassing `mapping()` (the loop is stopping anyway)
+    /// - send/response failures and stopped-loop rejections: returned directly to the
+    ///   API caller (e.g., `sync()`), without event-loop routing
     #[error("event loop: {0}")]
     EventLoop(String),
     /// Cseq was non-sequential in the push buffer.
-    /// Requires `Normal + Rollback` instead of the default `StopSync + Disable`.
+    ///
+    /// Routed at the enqueue site via [`InternalReason::mapping`] before the reason is
+    /// erased into `DatatypeError::Internal`:
+    /// `enqueue()` → `end_transaction()` → `RecoveryAction::RollbackTransaction`
+    /// (the unbuffered transaction is rolled back and the datatype stays alive).
     #[error("non-sequential cseq in push buffer")]
     NonSequentialCseq,
+    /// The push buffer could not provide the transactions to push (cseq out of range).
+    ///
+    /// Route: `create_push_pull_pack()` → `do_push_pull()` → `mapping()`
+    /// → `RecoveryAction::Disable`.
     #[error("failed to get pushing transactions")]
     GetPushingTransactions,
 }
@@ -25,6 +48,24 @@ impl InternalReason {
     /// Converts to `DatatypeError::Internal` with the formatted reason message.
     pub(crate) fn into_error(self) -> DatatypeError {
         DatatypeError::Internal(self.to_string())
+    }
+
+    /// Converts this reason into its recovery action.
+    ///
+    /// `into_error()` erases the reason into `DatatypeError::Internal(String)`, so a variant
+    /// that needs a routing other than the `Internal` default (`RecoveryAction::Disable`) must
+    /// be mapped here, at its creation site, before the erasure. All other variants delegate to
+    /// [`DatatypeError::mapping`], which remains the single source of truth per error variant.
+    pub(crate) fn mapping(self) -> DatatypeErrorWithAction {
+        match self {
+            InternalReason::NonSequentialCseq => {
+                DatatypeErrorWithAction::new(self.into_error(), RecoveryAction::RollbackTransaction)
+            }
+            InternalReason::Deserialize(_)
+            | InternalReason::ExecuteOperation(_)
+            | InternalReason::EventLoop(_)
+            | InternalReason::GetPushingTransactions => self.into_error().mapping(),
+        }
     }
 }
 
@@ -96,32 +137,40 @@ pub enum DatatypeError {
 }
 
 impl DatatypeError {
-    /// Converts this error into event-loop routing actions.
+    /// Converts this error into its recovery action.
     ///
     /// This is the single source of truth for action routing. Variants handled here:
-    /// - `SyncFailed`       — transient connectivity failure → retry with backoff
-    /// - `Internal`         — fatal SDK-internal fault → stop sync, disable
-    /// - `ServerRejected`   — server permanently rejected the operation → stop sync, disable
-    /// - `ReadonlyViolation`— server rejected a write from a readonly client → stop sync, disable
+    /// - `SyncFailed`       — transient connectivity failure → `RetryWithBackOff`
+    /// - `Internal`         — fatal SDK-internal fault → `Disable`
+    ///   (reason-level overrides live in [`InternalReason::mapping`])
+    /// - `ServerRejected`   — server permanently rejected the operation → `Disable`
+    /// - `ReadonlyViolation`— server rejected a write from a readonly client → `Disable`
+    /// - `PushBufferExceededMaxMemSize` — the transaction cannot be buffered
+    ///   → `RollbackTransaction`
     ///
     /// Variants that are returned directly to API callers must never reach this method.
-    pub(crate) fn mapping(self) -> DatatypeErrorWithActions {
+    pub(crate) fn mapping(self) -> DatatypeErrorWithAction {
         match self {
             DatatypeError::SyncFailed(_) => {
-                DatatypeErrorWithActions::new(self, EventLoopAction::BackOff, DatatypeAction::Normal)
+                DatatypeErrorWithAction::new(self, RecoveryAction::RetryWithBackOff)
             }
             DatatypeError::Internal(_)
             | DatatypeError::ServerRejected(_)
             | DatatypeError::ReadonlyViolation => {
-                DatatypeErrorWithActions::new(self, EventLoopAction::StopSync, DatatypeAction::Disable)
+                DatatypeErrorWithAction::new(self, RecoveryAction::Disable)
+            }
+            DatatypeError::PushBufferExceededMaxMemSize => {
+                DatatypeErrorWithAction::new(self, RecoveryAction::RollbackTransaction)
             }
             // These variants are returned directly to API callers and are never routed through
             // the event loop. Reaching here indicates a misrouted error.
             DatatypeError::TransactionFailed(_)
             | DatatypeError::Disallowed(_)
-            | DatatypeError::NotWritable(_)
-            | DatatypeError::PushBufferExceededMaxMemSize => {
-                unreachable!("variant {:?} must not be routed through DatatypeError::mapping()", self)
+            | DatatypeError::NotWritable(_) => {
+                unreachable!(
+                    "variant {:?} must not be routed through DatatypeError::mapping()",
+                    self
+                )
             }
         }
     }
@@ -138,40 +187,52 @@ impl PartialEq for DatatypeError {
 // sound because the custom PartialEq above is discriminant-only, so reflexivity always holds.
 impl Eq for DatatypeError {}
 
-pub enum EventLoopAction {
-    Normal,
-    BackOff,
-    StopSync,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum DatatypeAction {
-    Normal,
-    // set the datatype state to 'SubscribingOrCreating' so that the datatype should restart sync.
-    Restart,
-    // set the datatype state to 'Disabled' so that the datatype should stop sync.
+/// How the SDK recovers from a routed datatype error.
+///
+/// Each variant is a self-consistent recovery policy: it bundles the event-loop scheduling
+/// effect and the datatype-lifecycle side effect that must occur together. Contradictory
+/// pairings of the two effects (e.g., disabling the datatype while keeping sync scheduled)
+/// are unrepresentable by construction.
+///
+/// Consumers dispatch exhaustively:
+/// - event-loop scheduling: `LoopMode` derivation in `event_loop.rs`
+/// - datatype side effect: `MutableDatatype::apply_action()`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryAction {
+    /// Notify the `on_error` handler only; no state change and no scheduling change.
+    ///
+    /// Reserved: no producer yet.
+    NotifyOnly,
+    /// Transient failure: retry sync with exponential backoff; the datatype is untouched.
+    RetryWithBackOff,
+    /// Commit-time failure: roll back the pending transaction; sync is unaffected.
+    ///
+    /// Consumed on the user thread by `TransactionalDatatype::end_transaction()`;
+    /// never routed through the event loop.
+    RollbackTransaction,
+    /// Rebuild the replica: reset local state and re-subscribe from a server snapshot
+    /// on the next sync.
+    ///
+    /// Reserved: no producer yet. WARNING: the reset discards unpushed transactions in the
+    /// push buffer — a local data-loss policy must be decided before wiring a producer.
+    Resubscribe,
+    /// Same as [`RecoveryAction::Resubscribe`], but waits with exponential backoff first
+    /// (e.g., the server is temporarily unavailable).
+    ///
+    /// Reserved: no producer yet. Carries the same data-loss warning as `Resubscribe`.
+    ResubscribeWithBackOff,
+    /// Permanent failure: stop syncing and disable the datatype; user intervention required.
     Disable,
-    // rolls back the in-progress transaction, leaving the datatype state unchanged.
-    Rollback,
 }
 
-pub struct DatatypeErrorWithActions {
+#[derive(Debug)]
+pub struct DatatypeErrorWithAction {
     pub error: DatatypeError,
-    pub event_loop_action: EventLoopAction,
-    pub datatype_action: DatatypeAction,
+    pub recovery: RecoveryAction,
 }
 
-impl DatatypeErrorWithActions {
-    pub(crate) fn new(
-        error: DatatypeError,
-        event_loop_action: EventLoopAction,
-        datatype_action: DatatypeAction,
-    ) -> Self {
-        DatatypeErrorWithActions {
-            error,
-            event_loop_action,
-            datatype_action,
-        }
+impl DatatypeErrorWithAction {
+    pub(crate) fn new(error: DatatypeError, recovery: RecoveryAction) -> Self {
+        DatatypeErrorWithAction { error, recovery }
     }
 }
-

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::{ConnectivityError, DatatypeState, errors::push_pull::ServerPushPullError};
+use crate::{ConnectivityError, DatatypeState};
 
 /// Errors that can occur while working with Qortoo datatypes.
 ///
@@ -46,8 +46,6 @@ pub enum DatatypeError {
     FailedInConnectivity(ConnectivityError) = 210,
     #[error("[DatatypeError] pushBuffer exceeded max size of memory")]
     PushBufferExceededMaxMemSize = 211,
-    #[error("[DatatypeError] failed by server push-pull error: {0}")]
-    FailedByServerPushPullError(ServerPushPullError) = 212,
     #[error("[DatatypeError] failed by protocol violation: {0}")]
     FailedByProtocolViolation(String) = 213,
     #[error("[DatatypeError] failed to create datatype: {0}")]
@@ -71,7 +69,6 @@ impl DatatypeError {
             | DatatypeError::FailedInEventLoop(_)
             | DatatypeError::Disallowed(_)
             | DatatypeError::PushBufferExceededMaxMemSize
-            | DatatypeError::FailedByServerPushPullError(_)
             | DatatypeError::FailedByProtocolViolation(_)
             | DatatypeError::FailedToCreate(_)
             | DatatypeError::FailedToSubscribe(_)
@@ -86,7 +83,6 @@ impl DatatypeError {
             | DatatypeError::FailedInEventLoop(_)
             | DatatypeError::Disallowed(_)
             | DatatypeError::PushBufferExceededMaxMemSize
-            | DatatypeError::FailedByServerPushPullError(_)
             | DatatypeError::FailedByProtocolViolation(_)
             | DatatypeError::FailedToCreate(_)
             | DatatypeError::FailedToSubscribe(_)

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -1,6 +1,49 @@
 use thiserror::Error;
 
-use crate::{ConnectivityError, DatatypeState};
+
+/// Internal SDK error reason, used by the event loop for action routing.
+///
+/// Not exposed to users. Internal callers use this to construct `DatatypeError::Internal`
+/// via `into_error()`.
+#[derive(Debug, Error)]
+pub(crate) enum InternalReason {
+    #[error("deserialize: {0}")]
+    Deserialize(String),
+    #[error("execute operation: {0}")]
+    ExecuteOperation(String),
+    #[error("event loop: {0}")]
+    EventLoop(String),
+    /// Cseq was non-sequential in the push buffer.
+    /// Requires `Normal + Rollback` instead of the default `StopSync + Disable`.
+    #[error("non-sequential cseq in push buffer")]
+    NonSequentialCseq,
+    #[error("failed to get pushing transactions")]
+    GetPushingTransactions,
+}
+
+impl InternalReason {
+    /// Converts to `DatatypeError::Internal` with the formatted reason message.
+    pub(crate) fn into_error(self) -> DatatypeError {
+        DatatypeError::Internal(self.to_string())
+    }
+}
+
+/// Reason a server permanently rejected a datatype operation.
+///
+/// Carried by [`DatatypeError::ServerRejected`]. New lifecycle operations
+/// (e.g., delete, merge) add variants here without touching `DatatypeError` itself.
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub enum ServerRejectReason {
+    /// The server refused to create the datatype (e.g., already exists).
+    CreateFailed(String),
+    /// The requested resource does not exist or has an incompatible type.
+    ResourceNotFound(String),
+    /// The server-side subscription entry is missing (e.g., server restarted and lost state).
+    MissingSubscription(String),
+    /// The push violated the wire protocol (e.g., unexpected state transition, type mismatch).
+    ProtocolViolation(String),
+}
 
 /// Errors that can occur while working with Qortoo datatypes.
 ///
@@ -14,120 +57,102 @@ use crate::{ConnectivityError, DatatypeState};
 ///
 #[non_exhaustive]
 #[repr(i32)]
-#[derive(Debug, Error, PartialEq, Eq, Clone)]
+#[derive(Debug, Error, Clone)]
 pub enum DatatypeError {
     /// Transaction execution failed.
     ///
     /// Returned when a closure passed to `transaction` returns an error or when the
     /// transactional context cannot be committed. The datatype state is left unchanged
     /// if a rollback succeeds.
-    #[error("[DatatypeError] failed to do transaction: {0}")]
-    FailedTransaction(String) = 201,
-    /// Deserialization from bytes failed.
+    #[error("[DatatypeError] transaction failed: {0}")]
+    TransactionFailed(String) = 201,
+    /// An internal SDK error that is not caused by user code.
     ///
-    /// Returned when decoding a datatype, operation, or internal state from a byte
-    /// sequence is not possible (e.g., invalid length, unexpected format, or version
-    /// mismatch).
-    #[error("[DatatypeError] failed to deserialize: {0}")]
-    FailedToDeserialize(String) = 202,
-    /// Applying a local operation failed.
-    ///
-    /// Returned when an operation cannot be executed in the current state (e.g.,
-    /// unsupported operation kind, precondition violations, or internal invariants
-    /// not satisfied).
-    #[error("[DatatypeError] failed to execute operation: {0}")]
-    FailedToExecuteOperation(String) = 203,
-    #[error("[DatatypeError] failure in EventLoop")]
-    FailedInEventLoop(String) = 204,
+    /// The message describes the internal failure. This error is not user-actionable;
+    /// please report it as a bug.
+    #[error("[DatatypeError] internal error: {0}")]
+    Internal(String) = 202,
+    /// Access denied for a reason other than state or readonly flag (e.g., key not managed by this client).
     #[error("[DatatypeError] disallowed to {0}")]
     Disallowed(String) = 205,
+    /// Write rejected because the datatype state does not allow writes.
+    #[error("[DatatypeError] not writable: {0}")]
+    NotWritable(String) = 206,
+    /// Write rejected because the datatype is configured as readonly.
+    #[error("[DatatypeError] readonly violation")]
+    ReadonlyViolation = 207,
 
-    #[error("[DatatypeError] failed in connectivity: {0}")]
-    FailedInConnectivity(ConnectivityError) = 210,
+    /// A transient sync failure that warrants a retry with backoff.
+    ///
+    /// The connectivity backend failed to complete the push-pull exchange.
+    /// The datatype state is not changed; the event loop will retry with exponential backoff.
+    #[error("[DatatypeError] sync failed: {0}")]
+    SyncFailed(String) = 210,
     #[error("[DatatypeError] pushBuffer exceeded max size of memory")]
     PushBufferExceededMaxMemSize = 211,
-    #[error("[DatatypeError] failed by protocol violation: {0}")]
-    FailedByProtocolViolation(String) = 213,
-    #[error("[DatatypeError] failed to create datatype: {0}")]
-    FailedToCreate(String) = 214,
-    #[error("[DatatypeError] failed to subscribe datatype: {0}")]
-    FailedToSubscribe(String) = 215,
-    #[error("[DatatypeError] an operation of nonsequential cseq is enqueued into PushBuffer")]
-    NonSequentialCseq = 216,
-    #[error("[DatatypeError] failed to get pushing transactions")]
-    FailedToGetPushingTransactions = 217,
+    /// The server permanently rejected the operation. The datatype transitions to `Disabled`.
+    #[error("[DatatypeError] server rejected: {0:?}")]
+    ServerRejected(ServerRejectReason) = 213,
 }
 
 impl DatatypeError {
+    /// Converts this error into event-loop routing actions.
+    ///
+    /// This is the single source of truth for action routing. Variants handled here:
+    /// - `SyncFailed`       — transient connectivity failure → retry with backoff
+    /// - `Internal`         — fatal SDK-internal fault → stop sync, disable
+    /// - `ServerRejected`   — server permanently rejected the operation → stop sync, disable
+    /// - `ReadonlyViolation`— server rejected a write from a readonly client → stop sync, disable
+    ///
+    /// Variants that are returned directly to API callers must never reach this method.
     pub(crate) fn mapping(self) -> DatatypeErrorWithActions {
-        let event_loop_action = match &self {
-            DatatypeError::FailedInConnectivity(_) => EventLoopAction::BackOff,
-            DatatypeError::NonSequentialCseq => EventLoopAction::Normal,
-            DatatypeError::FailedTransaction(_)
-            | DatatypeError::FailedToDeserialize(_)
-            | DatatypeError::FailedToExecuteOperation(_)
-            | DatatypeError::FailedInEventLoop(_)
+        match self {
+            DatatypeError::SyncFailed(_) => {
+                DatatypeErrorWithActions::new(self, EventLoopAction::BackOff, DatatypeAction::Normal)
+            }
+            DatatypeError::Internal(_)
+            | DatatypeError::ServerRejected(_)
+            | DatatypeError::ReadonlyViolation => {
+                DatatypeErrorWithActions::new(self, EventLoopAction::StopSync, DatatypeAction::Disable)
+            }
+            // These variants are returned directly to API callers and are never routed through
+            // the event loop. Reaching here indicates a misrouted error.
+            DatatypeError::TransactionFailed(_)
             | DatatypeError::Disallowed(_)
-            | DatatypeError::PushBufferExceededMaxMemSize
-            | DatatypeError::FailedByProtocolViolation(_)
-            | DatatypeError::FailedToCreate(_)
-            | DatatypeError::FailedToSubscribe(_)
-            | DatatypeError::FailedToGetPushingTransactions => EventLoopAction::PauseSync,
-        };
-        let datatype_action = match &self {
-            DatatypeError::FailedInConnectivity(_) => DatatypeAction::Normal,
-            DatatypeError::NonSequentialCseq => DatatypeAction::Reset,
-            DatatypeError::FailedTransaction(_)
-            | DatatypeError::FailedToDeserialize(_)
-            | DatatypeError::FailedToExecuteOperation(_)
-            | DatatypeError::FailedInEventLoop(_)
-            | DatatypeError::Disallowed(_)
-            | DatatypeError::PushBufferExceededMaxMemSize
-            | DatatypeError::FailedByProtocolViolation(_)
-            | DatatypeError::FailedToCreate(_)
-            | DatatypeError::FailedToSubscribe(_)
-            | DatatypeError::FailedToGetPushingTransactions => DatatypeAction::Disable,
-        };
-
-        DatatypeErrorWithActions::new(self, event_loop_action, datatype_action)
+            | DatatypeError::NotWritable(_)
+            | DatatypeError::PushBufferExceededMaxMemSize => {
+                unreachable!("variant {:?} must not be routed through DatatypeError::mapping()", self)
+            }
+        }
     }
 }
 
-// impl PartialEq for DatatypeError {
-//     fn eq(&self, other: &Self) -> bool {
-//         std::mem::discriminant(self) == std::mem::discriminant(other)
-//     }
-// }
+impl PartialEq for DatatypeError {
+    fn eq(&self, other: &Self) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
+}
+
+// Manual impl (not #[derive(Eq)]) because derive would add `ServerRejectReason: Eq` as a where
+// bound, which fails since ServerRejectReason does not implement Eq. The unconditional impl is
+// sound because the custom PartialEq above is discriminant-only, so reflexivity always holds.
+impl Eq for DatatypeError {}
 
 pub enum EventLoopAction {
     Normal,
     BackOff,
-    PauseSync,
+    StopSync,
 }
 
 #[derive(Debug, PartialEq)]
 pub enum DatatypeAction {
     Normal,
-    // set the datatype state to 'Due_To_SubscribeOrCreate' so that the datatype should restart sync.
+    // set the datatype state to 'SubscribingOrCreating' so that the datatype should restart sync.
     Restart,
     // set the datatype state to 'Disabled' so that the datatype should stop sync.
     Disable,
-    // set the datatype state to 'Subscribed' and reset the datatype with the snapshot sent by the server.
-    Reset,
-}
-
-impl From<DatatypeState> for DatatypeAction {
-    fn from(value: DatatypeState) -> Self {
-        match value {
-            DatatypeState::Creating => DatatypeAction::Restart,
-            DatatypeState::Subscribing => DatatypeAction::Restart,
-            DatatypeState::SubscribingOrCreating => DatatypeAction::Restart,
-            DatatypeState::Subscribed => DatatypeAction::Normal,
-            DatatypeState::Unsubscribing => DatatypeAction::Normal,
-            DatatypeState::Deleting => DatatypeAction::Normal,
-            DatatypeState::Disabled => DatatypeAction::Disable,
-        }
-    }
+    // rolls back the in-progress transaction, leaving the datatype state unchanged.
+    Rollback,
 }
 
 pub struct DatatypeErrorWithActions {
@@ -137,7 +162,7 @@ pub struct DatatypeErrorWithActions {
 }
 
 impl DatatypeErrorWithActions {
-    pub fn new(
+    pub(crate) fn new(
         error: DatatypeError,
         event_loop_action: EventLoopAction,
         datatype_action: DatatypeAction,
@@ -150,25 +175,3 @@ impl DatatypeErrorWithActions {
     }
 }
 
-#[cfg(test)]
-mod tests_datatypes {
-    use rstest::rstest;
-
-    use crate::{DatatypeState, errors::datatypes::DatatypeAction};
-
-    #[rstest]
-    #[case(DatatypeState::Creating, DatatypeAction::Restart)]
-    #[case(DatatypeState::Subscribing, DatatypeAction::Restart)]
-    #[case(DatatypeState::SubscribingOrCreating, DatatypeAction::Restart)]
-    #[case(DatatypeState::Subscribed, DatatypeAction::Normal)]
-    #[case(DatatypeState::Unsubscribing, DatatypeAction::Normal)]
-    #[case(DatatypeState::Deleting, DatatypeAction::Normal)]
-    #[case(DatatypeState::Disabled, DatatypeAction::Disable)]
-    fn can_convert_datatype_state_into_action(
-        #[case] state: DatatypeState,
-        #[case] expected_action: DatatypeAction,
-    ) {
-        let datatype_action: DatatypeAction = state.into();
-        assert_eq!(datatype_action, expected_action);
-    }
-}

--- a/src/errors/datatypes.rs
+++ b/src/errors/datatypes.rs
@@ -1,9 +1,6 @@
 use thiserror::Error;
 
-use crate::{
-    ConnectivityError, DatatypeState,
-    errors::push_pull::{ClientPushPullError, ServerPushPullError},
-};
+use crate::{ConnectivityError, DatatypeState, errors::push_pull::ServerPushPullError};
 
 /// Errors that can occur while working with Qortoo datatypes.
 ///
@@ -47,8 +44,8 @@ pub enum DatatypeError {
 
     #[error("[DatatypeError] failed in connectivity: {0}")]
     FailedInConnectivity(ConnectivityError) = 210,
-    #[error("[DatatypeError] failed by client push-pull error: {0}")]
-    FailedByClientPushPullError(ClientPushPullError) = 211,
+    #[error("[DatatypeError] pushBuffer exceeded max size of memory")]
+    PushBufferExceededMaxMemSize = 211,
     #[error("[DatatypeError] failed by server push-pull error: {0}")]
     FailedByServerPushPullError(ServerPushPullError) = 212,
     #[error("[DatatypeError] failed by protocol violation: {0}")]
@@ -57,6 +54,47 @@ pub enum DatatypeError {
     FailedToCreate(String) = 214,
     #[error("[DatatypeError] failed to subscribe datatype: {0}")]
     FailedToSubscribe(String) = 215,
+    #[error("[DatatypeError] an operation of nonsequential cseq is enqueued into PushBuffer")]
+    NonSequentialCseq = 216,
+    #[error("[DatatypeError] failed to get pushing transactions")]
+    FailedToGetPushingTransactions = 217,
+}
+
+impl DatatypeError {
+    pub(crate) fn mapping(self) -> DatatypeErrorWithActions {
+        let event_loop_action = match &self {
+            DatatypeError::FailedInConnectivity(_) => EventLoopAction::BackOff,
+            DatatypeError::NonSequentialCseq => EventLoopAction::Normal,
+            DatatypeError::FailedTransaction(_)
+            | DatatypeError::FailedToDeserialize(_)
+            | DatatypeError::FailedToExecuteOperation(_)
+            | DatatypeError::FailedInEventLoop(_)
+            | DatatypeError::Disallowed(_)
+            | DatatypeError::PushBufferExceededMaxMemSize
+            | DatatypeError::FailedByServerPushPullError(_)
+            | DatatypeError::FailedByProtocolViolation(_)
+            | DatatypeError::FailedToCreate(_)
+            | DatatypeError::FailedToSubscribe(_)
+            | DatatypeError::FailedToGetPushingTransactions => EventLoopAction::PauseSync,
+        };
+        let datatype_action = match &self {
+            DatatypeError::FailedInConnectivity(_) => DatatypeAction::Normal,
+            DatatypeError::NonSequentialCseq => DatatypeAction::Reset,
+            DatatypeError::FailedTransaction(_)
+            | DatatypeError::FailedToDeserialize(_)
+            | DatatypeError::FailedToExecuteOperation(_)
+            | DatatypeError::FailedInEventLoop(_)
+            | DatatypeError::Disallowed(_)
+            | DatatypeError::PushBufferExceededMaxMemSize
+            | DatatypeError::FailedByServerPushPullError(_)
+            | DatatypeError::FailedByProtocolViolation(_)
+            | DatatypeError::FailedToCreate(_)
+            | DatatypeError::FailedToSubscribe(_)
+            | DatatypeError::FailedToGetPushingTransactions => DatatypeAction::Disable,
+        };
+
+        DatatypeErrorWithActions::new(self, event_loop_action, datatype_action)
+    }
 }
 
 // impl PartialEq for DatatypeError {

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -89,10 +89,10 @@ mod tests_datatype_errors {
     fn can_compare_errors() {
         let source_err1 = Error::new(ErrorKind::InvalidData, "source err1");
         let source_err2 = Error::new(ErrorKind::InvalidInput, "source err2");
-        let e1 = DatatypeError::FailedTransaction(source_err1.to_string());
-        let e2 = DatatypeError::FailedTransaction(source_err2.to_string());
-        assert_ne!(e1, e2);
-        let e3 = DatatypeError::FailedToDeserialize("e2".to_string());
+        let e1 = DatatypeError::TransactionFailed(source_err1.to_string());
+        let e2 = DatatypeError::TransactionFailed(source_err2.to_string());
+        assert_eq!(e1, e2); // same variant — payload is ignored by PartialEq
+        let e3 = DatatypeError::Internal("e2".to_string());
         assert_ne!(e2, e3);
         assert!(equal_errors!(&e1, &e2));
         assert!(!equal_errors!(&e1, &e3));
@@ -102,11 +102,9 @@ mod tests_datatype_errors {
 
     #[test]
     fn can_use_err_macro() {
-        let d1 = with_err_out!(DatatypeError::FailedToDeserialize(
-            "datatype error".to_owned()
-        ));
+        let d1 = with_err_out!(DatatypeError::Internal("datatype error".to_owned()));
         let source_err1 = Error::new(ErrorKind::InvalidInput, "source err1");
-        let d2 = with_err_out!(DatatypeError::FailedTransaction(source_err1.to_string()));
+        let d2 = with_err_out!(DatatypeError::TransactionFailed(source_err1.to_string()));
         assert_ne!(d1, d2);
         let c1 = with_err_out!(ClientError::FailedToSubscribeOrCreateDatatype(
             "clients error".into()
@@ -118,6 +116,6 @@ mod tests_datatype_errors {
 
     fn into_next_stack() {
         let err = TrySendError::Full(Event::PushTransaction(None));
-        let _d3 = with_err_out!(DatatypeError::FailedInEventLoop(err.to_string()));
+        let _d3 = with_err_out!(DatatypeError::Internal(err.to_string()));
     }
 }

--- a/src/errors/push_pull.rs
+++ b/src/errors/push_pull.rs
@@ -1,50 +1,53 @@
 use thiserror::Error;
 
 use crate::{
-    DatatypeError, DatatypeState,
-    errors::datatypes::{DatatypeErrorWithActions, EventLoopAction},
+    DatatypeError,
+    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
 };
 
 #[non_exhaustive]
 #[repr(i32)]
 #[derive(Debug, Error, Eq, Clone)]
 pub enum ServerPushPullError {
-    #[error("[ServerPushPullError] illegal push request - {0}")]
-    IllegalPushRequest(String) = 301,
-    #[error("[ServerPushPull] fail to create - {0}")]
-    FailedToCreate(String) = 302,
-    #[error("[ServerPushPull] fail to subscribe - {0}")]
-    FailedToSubscribe(String) = 303,
+    #[error("[PushPullError] illegal push request - {0}")]
+    FailedByIllegalRequest(String) = 301,
+    #[error("[PushPullError] readonly client attempted write operation")]
+    FailedByReadonlyRestriction = 302,
+    #[error("[PushPullError] fail to create - {0}")]
+    FailedToCreate(String) = 303,
+    #[error("[PushPullError] fail to subscribe - {0}")]
+    FailedToSubscribe(String) = 304,
+    #[error("[PushPullError] client's datatype is not subscribed on this server - {0}")]
+    FailedByMissingSubscription(String) = 305,
 }
 
 impl ServerPushPullError {
-    pub fn mapping(
-        &self,
-        old_state: DatatypeState,
-        new_state: DatatypeState,
-    ) -> DatatypeErrorWithActions {
+    pub fn mapping(&self) -> DatatypeErrorWithActions {
         match self {
-            ServerPushPullError::IllegalPushRequest(msg) => {
-                let data_err = match old_state {
-                    DatatypeState::Creating => DatatypeError::FailedToCreate(msg.to_owned()),
-                    DatatypeState::Subscribing => DatatypeError::FailedToSubscribe(msg.to_owned()),
-                    _ => DatatypeError::FailedByServerPushPullError(self.clone()),
-                };
-                DatatypeErrorWithActions::new(
-                    data_err,
-                    EventLoopAction::PauseSync,
-                    new_state.into(),
-                )
-            }
+            ServerPushPullError::FailedByIllegalRequest(msg) => DatatypeErrorWithActions::new(
+                DatatypeError::FailedByProtocolViolation(msg.to_owned()),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Disable,
+            ),
+            ServerPushPullError::FailedByReadonlyRestriction => DatatypeErrorWithActions::new(
+                DatatypeError::Disallowed("readonly client attempted write operation".to_owned()),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Disable,
+            ),
             ServerPushPullError::FailedToCreate(msg) => DatatypeErrorWithActions::new(
                 DatatypeError::FailedToCreate(msg.to_owned()),
                 EventLoopAction::PauseSync,
-                new_state.into(),
+                DatatypeAction::Disable,
             ),
             ServerPushPullError::FailedToSubscribe(msg) => DatatypeErrorWithActions::new(
                 DatatypeError::FailedToSubscribe(msg.to_owned()),
                 EventLoopAction::PauseSync,
-                new_state.into(),
+                DatatypeAction::Disable,
+            ),
+            ServerPushPullError::FailedByMissingSubscription(msg) => DatatypeErrorWithActions::new(
+                DatatypeError::FailedToSubscribe(msg.to_owned()),
+                EventLoopAction::PauseSync,
+                DatatypeAction::Restart,
             ),
         }
     }

--- a/src/errors/push_pull.rs
+++ b/src/errors/push_pull.rs
@@ -1,9 +1,6 @@
 use thiserror::Error;
 
-use crate::{
-    DatatypeError,
-    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
-};
+use crate::{DatatypeError, ServerRejectReason};
 
 #[non_exhaustive]
 #[repr(i32)]
@@ -15,40 +12,38 @@ pub enum ServerPushPullError {
     FailedByReadonlyRestriction = 302,
     #[error("[PushPullError] fail to create - {0}")]
     FailedToCreate(String) = 303,
-    #[error("[PushPullError] fail to subscribe - {0}")]
-    FailedToSubscribe(String) = 304,
+    /// The requested resource does not exist or has an incompatible type.
+    #[error("[PushPullError] resource not found - {0}")]
+    FailedByResourceNotFound(String) = 304,
     #[error("[PushPullError] client's datatype is not subscribed on this server - {0}")]
     FailedByMissingSubscription(String) = 305,
+    /// The server encountered a temporary internal error and could not process the request.
+    ///
+    /// The client should retry with exponential backoff. This maps to
+    /// [`DatatypeError::SyncFailed`] so the event loop applies `BackOff + Normal`.
+    #[error("[PushPullError] server internal error - {0}")]
+    FailedByServerInternalError(String) = 306,
 }
 
 impl ServerPushPullError {
-    pub fn mapping(&self) -> DatatypeErrorWithActions {
+    pub fn to_datatype_error(&self) -> DatatypeError {
         match self {
-            ServerPushPullError::FailedByIllegalRequest(msg) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedByProtocolViolation(msg.to_owned()),
-                EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
-            ),
-            ServerPushPullError::FailedByReadonlyRestriction => DatatypeErrorWithActions::new(
-                DatatypeError::Disallowed("readonly client attempted write operation".to_owned()),
-                EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
-            ),
-            ServerPushPullError::FailedToCreate(msg) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedToCreate(msg.to_owned()),
-                EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
-            ),
-            ServerPushPullError::FailedToSubscribe(msg) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedToSubscribe(msg.to_owned()),
-                EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
-            ),
-            ServerPushPullError::FailedByMissingSubscription(msg) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedToSubscribe(msg.to_owned()),
-                EventLoopAction::PauseSync,
-                DatatypeAction::Restart,
-            ),
+            ServerPushPullError::FailedByIllegalRequest(msg) => {
+                DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(msg.to_owned()))
+            }
+            ServerPushPullError::FailedByReadonlyRestriction => DatatypeError::ReadonlyViolation,
+            ServerPushPullError::FailedToCreate(msg) => {
+                DatatypeError::ServerRejected(ServerRejectReason::CreateFailed(msg.to_owned()))
+            }
+            ServerPushPullError::FailedByResourceNotFound(msg) => {
+                DatatypeError::ServerRejected(ServerRejectReason::ResourceNotFound(msg.to_owned()))
+            }
+            ServerPushPullError::FailedByMissingSubscription(msg) => {
+                DatatypeError::ServerRejected(ServerRejectReason::MissingSubscription(msg.to_owned()))
+            }
+            ServerPushPullError::FailedByServerInternalError(msg) => {
+                DatatypeError::SyncFailed(msg.to_owned())
+            }
         }
     }
 }

--- a/src/errors/push_pull.rs
+++ b/src/errors/push_pull.rs
@@ -1,15 +1,13 @@
 use thiserror::Error;
 
 use crate::{
-    ConnectivityError, DatatypeError, DatatypeState,
-    errors::datatypes::{DatatypeAction, DatatypeErrorWithActions, EventLoopAction},
+    DatatypeError, DatatypeState,
+    errors::datatypes::{DatatypeErrorWithActions, EventLoopAction},
 };
-
-pub(crate) const CLIENT_PUSHPULL_ERR_MSG_NO_SNAPSHOT: &str = "no snapshot operation";
 
 #[non_exhaustive]
 #[repr(i32)]
-#[derive(Debug, Error /*PartialEq*/, Eq, Clone)]
+#[derive(Debug, Error, Eq, Clone)]
 pub enum ServerPushPullError {
     #[error("[ServerPushPullError] illegal push request - {0}")]
     IllegalPushRequest(String) = 301,
@@ -55,54 +53,5 @@ impl ServerPushPullError {
 impl PartialEq for ServerPushPullError {
     fn eq(&self, other: &Self) -> bool {
         std::mem::discriminant(self) == std::mem::discriminant(other)
-    }
-}
-
-#[non_exhaustive]
-#[derive(Debug, Error, PartialEq, Eq, Clone)]
-pub enum ClientPushPullError {
-    #[error("[ClientPushPullError] pushBuffer exceeded max size of memory")]
-    ExceedMaxMemSize,
-    #[error("[ClientPushPullError] an operation of nonsequential cseq is enqueued into PushBuffer")]
-    NonSequentialCseq,
-    #[error("[ClientPushPullError] failed to get after")]
-    FailToGetPushingTransactions,
-    #[error("[ClientPushPullError] failed in Connectivity: {0}")]
-    FailedInConnectivity(ConnectivityError),
-    #[error("[ClientPushPullError] failed with protocol violation: {0}")]
-    FailedWithProtocolViolation(String),
-}
-
-impl ClientPushPullError {
-    pub fn mapping(self) -> DatatypeErrorWithActions {
-        match self {
-            ClientPushPullError::ExceedMaxMemSize => todo!(),
-            ClientPushPullError::NonSequentialCseq => DatatypeErrorWithActions::new(
-                DatatypeError::FailedByClientPushPullError(self),
-                EventLoopAction::Normal,
-                DatatypeAction::Reset,
-            ),
-            ClientPushPullError::FailToGetPushingTransactions => DatatypeErrorWithActions::new(
-                DatatypeError::FailedByClientPushPullError(self),
-                EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
-            ),
-            ClientPushPullError::FailedInConnectivity(_) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedByClientPushPullError(self),
-                EventLoopAction::BackOff,
-                DatatypeAction::Normal,
-            ),
-            ClientPushPullError::FailedWithProtocolViolation(_) => DatatypeErrorWithActions::new(
-                DatatypeError::FailedByClientPushPullError(self),
-                EventLoopAction::PauseSync,
-                DatatypeAction::Disable,
-            ),
-        }
-    }
-}
-
-impl From<ConnectivityError> for ClientPushPullError {
-    fn from(ce: ConnectivityError) -> Self {
-        ClientPushPullError::FailedInConnectivity(ce)
     }
 }

--- a/src/errors/push_pull.rs
+++ b/src/errors/push_pull.rs
@@ -2,53 +2,57 @@ use thiserror::Error;
 
 use crate::{DatatypeError, ServerRejectReason};
 
+/// Wire-level error set by the responder in `PushPullPack.error`.
+///
+/// In the push-pull protocol the responder (the server side) fills this field when it
+/// rejects or fails to process a request. The client converts it into a [`DatatypeError`]
+/// via [`PushPullError::to_datatype_error`]; variant names mirror [`ServerRejectReason`]
+/// where a counterpart exists.
 #[non_exhaustive]
 #[repr(i32)]
 #[derive(Debug, Error, Eq, Clone)]
-pub enum ServerPushPullError {
-    #[error("[PushPullError] illegal push request - {0}")]
-    FailedByIllegalRequest(String) = 301,
+pub enum PushPullError {
+    #[error("[PushPullError] protocol violation - {0}")]
+    ProtocolViolation(String) = 301,
     #[error("[PushPullError] readonly client attempted write operation")]
-    FailedByReadonlyRestriction = 302,
+    ReadonlyViolation = 302,
     #[error("[PushPullError] fail to create - {0}")]
-    FailedToCreate(String) = 303,
+    CreateFailed(String) = 303,
     /// The requested resource does not exist or has an incompatible type.
     #[error("[PushPullError] resource not found - {0}")]
-    FailedByResourceNotFound(String) = 304,
+    ResourceNotFound(String) = 304,
     #[error("[PushPullError] client's datatype is not subscribed on this server - {0}")]
-    FailedByMissingSubscription(String) = 305,
+    MissingSubscription(String) = 305,
     /// The server encountered a temporary internal error and could not process the request.
     ///
     /// The client should retry with exponential backoff. This maps to
-    /// [`DatatypeError::SyncFailed`] so the event loop applies `BackOff + Normal`.
+    /// [`DatatypeError::SyncFailed`] → `RecoveryAction::RetryWithBackOff`.
     #[error("[PushPullError] server internal error - {0}")]
-    FailedByServerInternalError(String) = 306,
+    ServerInternalError(String) = 306,
 }
 
-impl ServerPushPullError {
+impl PushPullError {
     pub fn to_datatype_error(&self) -> DatatypeError {
         match self {
-            ServerPushPullError::FailedByIllegalRequest(msg) => {
+            PushPullError::ProtocolViolation(msg) => {
                 DatatypeError::ServerRejected(ServerRejectReason::ProtocolViolation(msg.to_owned()))
             }
-            ServerPushPullError::FailedByReadonlyRestriction => DatatypeError::ReadonlyViolation,
-            ServerPushPullError::FailedToCreate(msg) => {
+            PushPullError::ReadonlyViolation => DatatypeError::ReadonlyViolation,
+            PushPullError::CreateFailed(msg) => {
                 DatatypeError::ServerRejected(ServerRejectReason::CreateFailed(msg.to_owned()))
             }
-            ServerPushPullError::FailedByResourceNotFound(msg) => {
+            PushPullError::ResourceNotFound(msg) => {
                 DatatypeError::ServerRejected(ServerRejectReason::ResourceNotFound(msg.to_owned()))
             }
-            ServerPushPullError::FailedByMissingSubscription(msg) => {
-                DatatypeError::ServerRejected(ServerRejectReason::MissingSubscription(msg.to_owned()))
-            }
-            ServerPushPullError::FailedByServerInternalError(msg) => {
-                DatatypeError::SyncFailed(msg.to_owned())
-            }
+            PushPullError::MissingSubscription(msg) => DatatypeError::ServerRejected(
+                ServerRejectReason::MissingSubscription(msg.to_owned()),
+            ),
+            PushPullError::ServerInternalError(msg) => DatatypeError::SyncFailed(msg.to_owned()),
         }
     }
 }
 
-impl PartialEq for ServerPushPullError {
+impl PartialEq for PushPullError {
     fn eq(&self, other: &Self) -> bool {
         std::mem::discriminant(self) == std::mem::discriminant(other)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,10 @@ pub use crate::{
         handler::DatatypeHandler,
     },
     errors::{
-        BoxedError, clients::ClientError, connectivity::ConnectivityError, datatypes::DatatypeError,
+        BoxedError,
+        clients::ClientError,
+        connectivity::ConnectivityError,
+        datatypes::{DatatypeError, ServerRejectReason},
     },
     types::{
         common::IntoString,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@ pub use crate::{
     errors::{
         BoxedError,
         clients::ClientError,
-        connectivity::ConnectivityError,
         datatypes::{DatatypeError, ServerRejectReason},
     },
     types::{

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -64,10 +64,9 @@ mod tests_metrics {
     use tracing::instrument;
 
     use crate::{
-        Client, ConnectivityError,
+        Client, ConnectivityError, DatatypeError,
         connectivity::local_connectivity::LocalConnectivity,
         datatypes::datatype::Datatype,
-        errors::push_pull::ClientPushPullError,
         utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
     };
 
@@ -157,7 +156,7 @@ mod tests_metrics {
             .unwrap();
         interceptor.set_after_pull(|_| {
             Err(
-                ClientPushPullError::FailedInConnectivity(ConnectivityError::ResourceNotFound(
+                DatatypeError::FailedInConnectivity(ConnectivityError::ResourceNotFound(
                     "injected".into(),
                 ))
                 .mapping(),

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -64,7 +64,7 @@ mod tests_metrics {
     use tracing::instrument;
 
     use crate::{
-        Client, ConnectivityError, DatatypeError,
+        Client, DatatypeError,
         connectivity::local_connectivity::LocalConnectivity,
         datatypes::datatype::Datatype,
         utils::test_utils::{get_test_collection_name, get_test_func_name, get_test_ids},
@@ -155,12 +155,7 @@ mod tests_metrics {
             .get_wired_interceptor(&resource_id, &client.get_cuid())
             .unwrap();
         interceptor.set_after_pull(|_| {
-            Err(
-                DatatypeError::FailedInConnectivity(ConnectivityError::ResourceNotFound(
-                    "injected".into(),
-                ))
-                .mapping(),
-            )
+            Err(DatatypeError::SyncFailed("injected".into()).mapping())
         });
 
         let _ = counter.sync();

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -154,9 +154,7 @@ mod tests_metrics {
         let interceptor = connectivity
             .get_wired_interceptor(&resource_id, &client.get_cuid())
             .unwrap();
-        interceptor.set_after_pull(|_| {
-            Err(DatatypeError::SyncFailed("injected".into()).mapping())
-        });
+        interceptor.set_after_pull(|_| Err(DatatypeError::SyncFailed("injected".into()).mapping()));
 
         let _ = counter.sync();
 

--- a/src/types/push_pull_pack.rs
+++ b/src/types/push_pull_pack.rs
@@ -143,7 +143,7 @@ mod tests_push_pull_pack {
         );
         assert_eq!(format!("{ppp}"), format!("{ppp:?}"));
         info!("{ppp}");
-        ppp.error = Some(ServerPushPullError::IllegalPushRequest(
+        ppp.error = Some(ServerPushPullError::FailedByIllegalRequest(
             "some error".to_owned(),
         ));
         assert_eq!(format!("{ppp}"), format!("{ppp:?}"));

--- a/src/types/push_pull_pack.rs
+++ b/src/types/push_pull_pack.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
     DataType, DatatypeState,
     datatypes::common::Attribute,
-    errors::push_pull::ServerPushPullError,
+    errors::push_pull::PushPullError,
     operations::transaction::Transaction,
     types::{
         checkpoint::CheckPoint,
@@ -28,7 +28,7 @@ pub struct PushPullPack {
     pub transactions: Vec<Arc<Transaction>>,
     pub snapshot_transaction: Option<Arc<Transaction>>,
     pub is_readonly: bool,
-    pub error: Option<ServerPushPullError>,
+    pub error: Option<PushPullError>,
 }
 
 impl PushPullPack {
@@ -129,7 +129,7 @@ mod tests_push_pull_pack {
 
     use crate::{
         DataType, DatatypeState, datatypes::common::new_attribute,
-        errors::push_pull::ServerPushPullError, types::push_pull_pack::PushPullPack,
+        errors::push_pull::PushPullError, types::push_pull_pack::PushPullPack,
     };
 
     #[test]
@@ -143,9 +143,7 @@ mod tests_push_pull_pack {
         );
         assert_eq!(format!("{ppp}"), format!("{ppp:?}"));
         info!("{ppp}");
-        ppp.error = Some(ServerPushPullError::FailedByIllegalRequest(
-            "some error".to_owned(),
-        ));
+        ppp.error = Some(PushPullError::ProtocolViolation("some error".to_owned()));
         assert_eq!(format!("{ppp}"), format!("{ppp:?}"));
         info!("{ppp}");
         ppp.snapshot_transaction =


### PR DESCRIPTION
## Summary

Consolidates the error-handling layer around a single routed recovery policy. The old `ClientPushPullError`/`ServerPushPullError` split and the two-axis `EventLoopAction` × `DatatypeAction` pair are replaced by a flattened `DatatypeError` taxonomy and one `RecoveryAction` enum that only encodes valid recovery policies.

### Commits

- **remove `ClientPushPullError` and flatten into `DatatypeError`** — client-side push/pull failures become `DatatypeError` variants routed by `mapping()`.
- **strengthen `ServerPushPullError` structure and fill server validation gaps** — consistent variant scheme, new readonly/subscription-loss variants, stateless `mapping()`, and stricter `LocalDatatypeServer` validation (no more silent empty responses or infinite BackOff on missing creators).
- **consolidate `DatatypeError` variants and centralize action routing** — `ServerRejectReason` for permanent server rejections, `InternalReason` for crate-private causes, `DatatypeError::mapping()` as the single source of truth.
- **replace action pair with `RecoveryAction` and route `end_transaction` failures** — only 3 of the 12 old action combinations were ever produced and several were contradictory; `RecoveryAction` (6 variants incl. 3 reserved) makes invalid pairings unrepresentable. `ServerPushPullError` is renamed to `PushPullError` with cause-centric variant names mirroring `ServerRejectReason`. Commit-time enqueue failures (`PushBufferExceededMaxMemSize`, non-sequential cseq) now roll back the pending transaction on the user thread and notify `on_error`, instead of leaving the buffer inconsistent.
- **rewrite error-handling docs** — `docs/error-handling.md` rewritten for the new taxonomy and routing flow; `docs/event-loop.md` updated to `LoopMode`/`RecoveryAction`.

### Key design points

- `DatatypeErrorWithAction { error, recovery }` pairs a `DatatypeError` with exactly one `RecoveryAction`; consumers dispatch exhaustively (`LoopMode::from` for scheduling, `MutableDatatype::apply_action` for lifecycle side effects).
- `RollbackTransaction` is consumed on the user thread by `end_transaction()` and never reaches the event loop (guarded by `debug_assert`).
- `InternalReason::mapping()` overrides routing at the creation site before the reason is erased into `Internal(String)`.
- `ConnectivityError` is no longer re-exported at the crate root (crate-internal until custom backends become a public extension point).

## Test plan

- [x] `cargo test` — 164 unit + 3 integration + 23 doctests pass
- [x] `cargo test --all-features` — passes with the local observability stack running
- [x] `make lint` — nightly fmt check, cargo check, clippy `-D warnings` all pass
- [x] New tests: enqueue-failure rollback (`can_rollback_on_enqueue_failure`), on_error notification on commit-time failure (`can_notify_on_error_when_enqueue_fails`), BackOff retry/exit and Disable behavior in `event_loop.rs`