### PR TITLE
🧬feat(observability): export otel spans in the loki test subscriber path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ coverage
 AGENTS.md
 GEMINI.md
 CLAUDE.md
+# Developer-local Prometheus scrape configs (keep .example files)
+qortoo-rs-docker/prometheus/conf.d/*.yml

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Qortoo-rs exposes instrumentation, but applications own exporter setup. The crate does not install a global `tracing` subscriber and no longer has a `tracing` feature.
+Qortoo-rs emits `tracing` spans and events and records metrics through the `metrics` facade. Applications configure the global tracing subscriber, metrics recorder, and exporters. The `log_layer` feature provides Qortoo's optional stdout formatting layer.
 
 | Surface | Mechanism | Code |
 |---------|-----------|------|
@@ -66,8 +66,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://my-collector:4317 cargo run --example trace
 | Span | Trigger |
 |------|---------|
 | `datatype_event_loop` | Event loop lifetime per datatype |
-| `push_pull` | Each push/pull sync cycle |
-| `execute_local_operation` | Each local write |
+| `push_pull` | Each datatype push/pull sync cycle |
+| `LocalConnectivity::push_pull` | Processing a push/pull pack through local connectivity |
 | `create_push_pull_pack` | Assembly of outgoing `PushPullPack` |
 
 Span events added with `add_span_event!` annotate moments such as event loop start, push pack send, pull pack receive, and event loop shutdown.
@@ -129,7 +129,7 @@ duid
 
 ### Shipping Test Logs to Loki
 
-The test subscriber (`src/observability/test_subscriber.rs`) is installed once per process via `#[ctor]`. By default it uses the OpenTelemetry subscriber. Setting `QORTOO_RS_LOKI_URL` switches it to ship logs to Loki instead:
+The test subscriber (`src/observability/test_subscriber.rs`) is installed once per test process via `#[ctor]`. It exports spans over OTLP using the agent string (for example, `qortoo-0.1.0-<git hash>`) as the Tempo service name. Setting `QORTOO_RS_LOKI_URL` adds Loki log shipping to the subscriber:
 
 ```shell
 make obs-up
@@ -144,7 +144,7 @@ Labels attached to every test log line:
 | `app` | `qortoo` |
 | `source` | `test` |
 
-If the URL is missing or invalid, the subscriber silently falls back to the OTel backend.
+Without `QORTOO_RS_LOKI_URL`, the test subscriber uses the OpenTelemetry and stdout formatting layers. If the URL is invalid or the Loki layer cannot be created, it reports the error to stderr and initializes those layers without Loki.
 
 ---
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -210,6 +210,14 @@ cargo run --example metrics
 
 Prometheus is provisioned by `qortoo-rs-docker/prometheus/prometheus.yml` to scrape `host.docker.internal:9000`. On Linux, replace that target with the Docker bridge gateway IP, usually `172.17.0.1:9000`.
 
+Developer-local scrape configs go in `qortoo-rs-docker/prometheus/conf.d/` — `*.yml` files there are gitignored and loaded through the `scrape_config_files` glob in `prometheus.yml`, so the base config stays untouched. For host-level metrics, run `node_exporter` on the host and enable the bundled example:
+
+```shell
+cd qortoo-rs-docker/prometheus/conf.d
+cp node_exporter.yml.example node_exporter.yml
+make obs-up   # or restart the prometheus container to pick it up
+```
+
 ### Testing Metrics
 
 Tests use `metrics-util`'s `DebuggingRecorder`.

--- a/qortoo-rs-docker/docker-compose.yml
+++ b/qortoo-rs-docker/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - --web.enable-remote-write-receiver
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/conf.d:/etc/prometheus/conf.d:ro
       - prometheus_data:/prometheus
     ports:
       - "9090:9090"

--- a/qortoo-rs-docker/prometheus/conf.d/node_exporter.yml.example
+++ b/qortoo-rs-docker/prometheus/conf.d/node_exporter.yml.example
@@ -1,0 +1,9 @@
+# Developer-local scrape config for host-level metrics.
+# Requires node_exporter running on the host (default port 9100).
+# Enable it with: cp node_exporter.yml.example node_exporter.yml
+# (*.yml files in this directory are gitignored and loaded by Prometheus
+# via the scrape_config_files glob in ../prometheus.yml)
+scrape_configs:
+  - job_name: node_exporter
+    static_configs:
+      - targets: [host.docker.internal:9100]

--- a/qortoo-rs-docker/prometheus/prometheus.yml
+++ b/qortoo-rs-docker/prometheus/prometheus.yml
@@ -2,6 +2,12 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+# Optional developer-local scrape configs (gitignored). A glob that matches
+# nothing is fine, so this activates only when a developer adds files there.
+# See conf.d/node_exporter.yml.example for how to enable one.
+scrape_config_files:
+  - conf.d/*.yml
+
 scrape_configs:
   - job_name: prometheus
     static_configs:

--- a/src/observability/test_subscriber.rs
+++ b/src/observability/test_subscriber.rs
@@ -3,8 +3,12 @@ use std::sync::OnceLock;
 use libc::atexit;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig};
-use opentelemetry_sdk::{Resource, trace::SdkTracerProvider};
+use opentelemetry_sdk::{
+    Resource,
+    trace::{SdkTracer, SdkTracerProvider},
+};
 use parking_lot::Mutex;
+use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
 
 #[cfg(feature = "log_layer")]
@@ -37,40 +41,60 @@ fn init_once() {
     let handle = get_or_init_runtime_handle("observability");
     // The tonic OTLP exporter requires an active Tokio runtime context.
     let _enter = handle.enter();
-
+    let env_filter = build_env_filter();
     let loki_url = std::env::var("QORTOO_RS_LOKI_URL").ok();
     if let Some(url) = loki_url {
-        init_subscriber_with_loki(url, &handle);
+        init_subscriber_with_loki(env_filter, url, &handle);
     } else {
-        init_otel_subscriber();
+        init_subscriber(env_filter);
     }
 }
 
-fn init_otel_subscriber() {
-    let level = build_env_filter();
-    println!(
-        "Initialize open-telemetry tracing with service '{}' for '{}' level",
-        constants::get_agent(),
-        level
-    );
-
-    let provider = init_provider();
-    let tracer = provider.tracer(constants::get_agent());
-    let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-
-    #[cfg(feature = "log_layer")]
-    let fmt = QortooLogLayer { level_filter: None };
-    #[cfg(not(feature = "log_layer"))]
-    let fmt = tracing_subscriber::fmt::layer();
-
-    let subscriber = Registry::default().with(telemetry).with(level).with(fmt);
-    let _ = tracing::subscriber::set_global_default(subscriber);
+fn init_subscriber(env_filter: EnvFilter) {
+    let env_filter_display = env_filter.to_string();
+    let subscriber = Registry::default()
+        .with(build_telemetry_layer())
+        .with(env_filter)
+        .with(build_fmt_layer());
+    if tracing::subscriber::set_global_default(subscriber).is_ok() {
+        println!(
+            "Initialized OpenTelemetry tracing with service '{}' and filter '{}'",
+            constants::get_agent(),
+            env_filter_display
+        );
+    }
 }
 
-fn init_subscriber_with_loki(loki_url: String, handle: &tokio::runtime::Handle) {
+fn build_telemetry_layer<S>() -> OpenTelemetryLayer<S, SdkTracer>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    let provider = init_provider();
+    let tracer = provider.tracer(constants::get_agent());
+    tracing_opentelemetry::layer().with_tracer(tracer)
+}
+
+#[cfg(feature = "log_layer")]
+fn build_fmt_layer() -> QortooLogLayer {
+    QortooLogLayer { level_filter: None }
+}
+
+#[cfg(not(feature = "log_layer"))]
+fn build_fmt_layer<S>() -> impl tracing_subscriber::Layer<S>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    tracing_subscriber::fmt::layer()
+}
+
+fn init_subscriber_with_loki(
+    env_filter: EnvFilter,
+    loki_url: String,
+    handle: &tokio::runtime::Handle,
+) {
     let Ok(parsed_url) = url::Url::parse(&loki_url) else {
         eprintln!("QORTOO_RS_LOKI_URL is not a valid URL: {loki_url}");
-        init_otel_subscriber();
+        init_subscriber(env_filter);
         return;
     };
 
@@ -83,20 +107,24 @@ fn init_subscriber_with_loki(loki_url: String, handle: &tokio::runtime::Handle) 
         Ok((loki_layer, loki_task)) => {
             handle.spawn(loki_task);
 
-            #[cfg(feature = "log_layer")]
-            let fmt = QortooLogLayer { level_filter: None };
-            #[cfg(not(feature = "log_layer"))]
-            let fmt = tracing_subscriber::fmt::layer();
-
+            let env_filter_display = env_filter.to_string();
             let subscriber = Registry::default()
-                .with(build_env_filter())
-                .with(fmt)
+                .with(build_telemetry_layer())
+                .with(env_filter)
+                .with(build_fmt_layer())
                 .with(loki_layer);
-            let _ = tracing::subscriber::set_global_default(subscriber);
+            if tracing::subscriber::set_global_default(subscriber).is_ok() {
+                println!(
+                    "Initialized OpenTelemetry tracing with service '{}', filter '{}', and Loki: {}",
+                    constants::get_agent(),
+                    env_filter_display,
+                    loki_url
+                );
+            }
         }
         Err(e) => {
             eprintln!("failed to build Loki layer: {e}");
-            init_otel_subscriber();
+            init_subscriber(env_filter);
         }
     }
 }
@@ -111,7 +139,7 @@ fn init_provider() -> SdkTracerProvider {
         .with_tonic()
         .with_protocol(Protocol::Grpc)
         .build()
-        .expect("failed to create otlp exporter");
+        .expect("failed to create OTLP exporter");
 
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)


### PR DESCRIPTION
- Attach the OpenTelemetry layer to the Loki path so spans reach Tempo in both modes.
- Extract build_telemetry_layer/build_fmt_layer helpers and announce init only on successful subscriber registration.
- Update docs/observability.md for the combined Loki+OTel stack and refresh the instrumented spans table.

## Commits included
- 🧬feat(observability): export otel spans in the loki test subscriber path
- 🧩chore(docker): load developer-local prometheus scrape configs from conf.d