### PR TITLE
🧪test(ffi): add C ABI boundary contract test suite

### DIFF
--- a/.github/workflows/build-test-coverage.yml
+++ b/.github/workflows/build-test-coverage.yml
@@ -40,6 +40,11 @@ jobs:
       - name: Build
         run: cargo build --verbose
 
+      - name: Check qortoo-ffi ABI contract
+        run: |
+          make ffi-header-check
+          make abi-symbols-check
+
       - name: Check observability feature boundaries
         run: |
           cargo check --no-default-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Shared across all qortoo-* repos (canonical text in [qortoo-harness `AGENTS.md`]
 - All code comments and documentation must be written in **English**.
 - Favor SOLID principles, especially Single Responsibility (SRP) and Open/Closed (OCP), where practical. Check for these during review.
 - Structure important concepts under `./docs/` so they're easy to follow from Markdown and diagrams grounded in the actual code. Use the `/qortoo-shared:doc-new` command to scaffold a new concept document.
-- Individual plans, task lists, and working notes belong in the gitignored `.local/` at the repo root — never commit them or propose committing them. Claude Code's project-scoped agent memory (`.claude/agent-memory/`) is likewise personal and gitignored, not shared team knowledge.
+- All individual plan documents, regardless of the repository they concern, belong in the qortoo-harness repository's gitignored `.local/plans/` directory. Task lists and working notes likewise belong under qortoo-harness's `.local/` — never commit them or propose committing them. Claude Code's project-scoped agent memory (`.claude/agent-memory/`) is likewise personal and gitignored, not shared team knowledge.
 
 ## Project Structure & Module Organization
 - `src/` holds the Rust crate, with modules like `clients/`, `connectivity/`, `datatypes/`, `errors/`, `observability/`, `operations/`, `types/`, and `utils/`, plus shared roots like `constants.rs` and `defaults.rs`.
@@ -91,11 +91,16 @@ When you change behavior described in one of these documents, update it in the s
 - Treat clippy warnings as errors (`make lint`).
 
 ## Testing Guidelines
+- Name test functions `can_<behavior>` (e.g. `can_reject_a_null_collection`), describing the
+  behavior being proven rather than the code path under test — consistent across unit and
+  integration tests in this repo.
 - Use `cargo test` for unit/integration tests; async tests use `#[tokio::test(flavor = "multi_thread", worker_threads = N)]`.
 - Test macros: `get_test_collection_name!()`, `get_test_func_name!()` for unique names; `new_attribute!(DataType::Counter)` and `new_client_common!()` for unit-level construction.
 - Parametric tests use `rstest`; polling assertions use `awaitility`.
 - Prefer `#[instrument]` on tests that need tracing.
 - **`LocalConnectivity` realtime pitfall**: call `connectivity.set_realtime(false)` before creating datatypes when you need deterministic test ordering (e.g., to register a handler before the first auto-sync fires).
+- **`qortoo-ffi` test scope**: before writing a test under `qortoo-ffi/tests/` or `qortoo-ffi/src/`, ask "if the C ABI were deleted and this called the safe Rust API directly, would it still make sense as a `qortoo-rs` test?" If yes, it belongs in `qortoo-rs`, not `qortoo-ffi` — CRDT correctness, state-machine transitions, and sync semantics are the core's responsibility to prove, not the boundary's. Keep `qortoo-ffi` tests scoped to what only exists at the boundary: null-pointer/invalid-UTF-8 handling, ownership (exactly-once free/userdata-drop), Rust-error-to-i32 code mapping, and callback-trampoline marshalling. When a test needs the counter in a particular state, treat that as minimal setup, not the thing under test — don't re-derive multi-client sync or CRDT value propagation to prove a pointer argument works. Also apply this within `qortoo-ffi` itself: if another test in the same crate already exercises a call as incidental setup, or already proves the same fact more strongly, a dedicated smoke test for it adds no signal.
+- **`qortoo-ffi` completeness signal**: don't use `make ffi-coverage`'s line-coverage percentage as a target to hit (it isn't a CI gate). Most of `qortoo-ffi` is thin pass-through wrappers, so a coverage percentage rewards filler tests over real boundary coverage. Judge completeness by the explicit contract checklist instead — every exported symbol exercised, every null/invalid-UTF-8/ownership/error-code case asserted — and treat an uncovered line as worth investigating only if it's a case that checklist actually calls for.
 
 ## Naming Validation
 Collection names and datatype keys must:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,6 +1977,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "qortoo",
+ "rstest",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,20 @@ lint:
 
 .PHONY: tarpaulin
 tarpaulin:
-	-cargo tarpaulin -o html -o xml -o Lcov --workspace --tests --all-features --engine Llvm --fail-under 90 --output-dir ./coverage --exclude-files 'benches/*'
+	cargo tarpaulin -o html -o xml -o Lcov --workspace --tests --all-features --engine Llvm --fail-under 90 --output-dir ./coverage --exclude-files 'benches/*'
 	open coverage/tarpaulin-report.html
+
+# Local, informational only — not run in CI. Line coverage is a poor completeness
+# signal for a C ABI boundary crate: most of qortoo-ffi is one-line pass-through
+# wrappers, and a hard percentage gate on it tends to reward filler tests (a null-check
+# nobody would otherwise write, a core algorithm re-verified through a pointer) instead
+# of real boundary contract coverage. The authoritative completeness bar is the
+# reviewable checklist in the FFI test-plan doc: every `qortoo_*` symbol exercised,
+# every null/invalid-UTF-8/ownership/error-code case asserted — not this number. Run it
+# yourself if you want a rough sanity check after touching qortoo-ffi/src.
+.PHONY: ffi-coverage
+ffi-coverage:
+	cargo tarpaulin -p qortoo-ffi --tests --all-features --engine Llvm --include-files 'qortoo-ffi/src/*' --fail-under 85
 
 .PHONY: doc
 doc:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![codecov](https://codecov.io/gh/qortoo/qortoo-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/qortoo/qortoo-rs)
 [![CI](https://github.com/qortoo/qortoo-rs/actions/workflows/build-test-coverage.yml/badge.svg)](https://github.com/qortoo/qortoo-rs/actions/workflows/build-test-coverage.yml)
-![GitHub commit activity](https://img.shields.io/github/commit-activity/w/qortoo/qortoo-rs)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/qortoo/qortoo-rs/build-test-coverage.yml)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/w/qortoo/qortoo-rs)](https://github.com/qortoo/qortoo-rs/graphs/commit-activity)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/qortoo/qortoo-rs/build-test-coverage.yml)](https://github.com/qortoo/qortoo-rs/actions/workflows/build-test-coverage.yml)
 
 Qortoo is a Rust SDK for conflict-free datatypes with distributed synchronization capabilities.
 

--- a/docs/go-binding.md
+++ b/docs/go-binding.md
@@ -81,7 +81,7 @@ must be rejected; minor additions remain compatible within the major version.
 `qortoo_sdk_version()` returns the native SDK package version. During the pre-1.0 period,
 native SDK and language-binding releases use lockstep versions.
 
-Two checks keep the ABI reviewable:
+Two checks keep the ABI reviewable, and both run in CI:
 
 ```shell
 make ffi-header-check   # generated qortoo.h must match the checked-in header
@@ -90,6 +90,12 @@ make abi-symbols-check  # exported qortoo_* symbols must match the allowlist
 
 Any public symbol or declaration change requires an ABI version decision and an update
 to `qortoo-ffi/abi-symbols.txt` when appropriate.
+
+`make ffi-coverage` is also available locally as a rough sanity check, but it is not a
+CI gate: line coverage isn't a good completeness signal for a boundary crate that's
+mostly thin pass-through wrappers, and gating on it tends to reward filler tests over
+real contract coverage. Treat the null-pointer/invalid-UTF-8/ownership/error-code test
+matrix itself — not a percentage — as the bar for "is this boundary tested."
 
 ## Native SDK Staging
 

--- a/qortoo-ffi/Cargo.toml
+++ b/qortoo-ffi/Cargo.toml
@@ -35,3 +35,4 @@ opentelemetry_sdk = { version = "^0.32", features = ["trace", "testing"] }
 tracing-subscriber = { version = "^0.3.23", features = ["env-filter"] }
 metrics-util = { version = "^0.20", features = ["debugging"] }
 awaitility = "^0.4"
+rstest = "^0.26"

--- a/qortoo-ffi/src/error.rs
+++ b/qortoo-ffi/src/error.rs
@@ -95,7 +95,7 @@ pub(crate) unsafe fn set_err(err_out: *mut QortooError, code: i32, msg: &str) {
 
 #[cfg(test)]
 mod tests_error {
-    use qortoo::ObservabilityError;
+    use qortoo::{ClientError, DatatypeError, ObservabilityError, ServerRejectReason};
 
     use super::*;
 
@@ -118,5 +118,100 @@ mod tests_error {
             codes.iter().all(|c| (900..=906).contains(c)),
             "observability codes stay in the 900 block the bindings mirror"
         );
+    }
+
+    #[test]
+    fn can_map_every_client_error_variant_to_its_exact_code() {
+        assert_eq!(
+            client_error_code(&ClientError::InvalidCollectionName(String::new())),
+            100
+        );
+        assert_eq!(
+            client_error_code(&ClientError::FailedToSubscribeOrCreateDatatype(
+                String::new()
+            )),
+            101
+        );
+    }
+
+    #[test]
+    fn can_map_every_datatype_error_variant_to_its_exact_code() {
+        assert_eq!(
+            datatype_error_code(&DatatypeError::TransactionFailed(String::new())),
+            201
+        );
+        assert_eq!(
+            datatype_error_code(&DatatypeError::Internal(String::new())),
+            202
+        );
+        assert_eq!(
+            datatype_error_code(&DatatypeError::Disallowed(String::new())),
+            205
+        );
+        assert_eq!(
+            datatype_error_code(&DatatypeError::NotWritable(String::new())),
+            206
+        );
+        assert_eq!(datatype_error_code(&DatatypeError::ReadonlyViolation), 207);
+        assert_eq!(
+            datatype_error_code(&DatatypeError::SyncFailed(String::new())),
+            210
+        );
+        assert_eq!(
+            datatype_error_code(&DatatypeError::PushBufferExceededMaxMemSize),
+            211
+        );
+        assert_eq!(
+            datatype_error_code(&DatatypeError::ServerRejected(
+                ServerRejectReason::CreateFailed(String::new())
+            )),
+            213
+        );
+    }
+
+    #[test]
+    fn can_accept_a_null_out_pointer_in_set_err_and_clear_err() {
+        unsafe {
+            set_err(ptr::null_mut(), 42, "ignored");
+            clear_err(ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn can_populate_a_non_null_out_pointer_via_set_err() {
+        let mut err = QortooError {
+            code: 0,
+            msg: ptr::null_mut(),
+        };
+        unsafe { set_err(&mut err, 42, "boom") };
+        assert_eq!(err.code, 42);
+        assert!(!err.msg.is_null());
+        let msg = unsafe { CString::from_raw(err.msg) };
+        assert_eq!(msg.to_str().unwrap(), "boom");
+    }
+
+    #[test]
+    fn can_reset_a_non_null_out_pointer_via_clear_err() {
+        let mut err = QortooError {
+            code: 7,
+            msg: crate::util::to_owned_c_string("stale"),
+        };
+        unsafe { clear_err(&mut err) };
+        assert_eq!(err.code, 0);
+        assert!(err.msg.is_null());
+    }
+
+    #[test]
+    fn can_fall_back_to_a_null_message_on_an_embedded_nul_without_losing_the_code() {
+        let mut err = QortooError {
+            code: 0,
+            msg: ptr::null_mut(),
+        };
+        unsafe { set_err(&mut err, 13, "bad\0message") };
+        assert_eq!(
+            err.code, 13,
+            "the code must survive even though the message could not"
+        );
+        assert!(err.msg.is_null());
     }
 }

--- a/qortoo-ffi/src/observability/trace_context.rs
+++ b/qortoo-ffi/src/observability/trace_context.rs
@@ -147,4 +147,23 @@ mod tests_trace_context {
         );
         assert_eq!(unsafe { optional_str(std::ptr::null()) }, None);
     }
+
+    #[test]
+    fn can_treat_invalid_utf8_c_strings_as_absent() {
+        // A stray UTF-8 continuation byte, NUL-terminated.
+        let bytes: [c_char; 3] = ['b' as c_char, 0x80u8 as c_char, 0];
+        assert_eq!(unsafe { optional_str(bytes.as_ptr()) }, None);
+    }
+
+    #[test]
+    fn can_expose_every_inserted_key_via_carrier_keys() {
+        let mut map = HashMap::new();
+        map.insert(TRACEPARENT.to_string(), valid_traceparent());
+        map.insert(TRACESTATE.to_string(), "vendor=value".to_string());
+        let carrier = Carrier(map);
+
+        let mut keys = carrier.keys();
+        keys.sort_unstable();
+        assert_eq!(keys, vec![TRACEPARENT, TRACESTATE]);
+    }
 }

--- a/qortoo-ffi/src/util.rs
+++ b/qortoo-ffi/src/util.rs
@@ -72,3 +72,83 @@ pub unsafe extern "C" fn qortoo_string_free(s: *mut c_char) {
         drop(unsafe { CString::from_raw(s) });
     }
 }
+
+#[cfg(test)]
+mod tests_util {
+    use super::*;
+
+    fn new_err() -> QortooError {
+        QortooError {
+            code: 0,
+            msg: ptr::null_mut(),
+        }
+    }
+
+    #[test]
+    fn can_accept_valid_utf8_in_cstr_arg() {
+        let mut err = new_err();
+        let s = CString::new("hello").unwrap();
+        let got = unsafe { cstr_arg(s.as_ptr(), "arg", &mut err) };
+        assert_eq!(got.as_deref(), Some("hello"));
+        assert_eq!(err.code, 0);
+    }
+
+    #[test]
+    fn can_reject_a_null_pointer_in_cstr_arg() {
+        let mut err = new_err();
+        let got = unsafe { cstr_arg(ptr::null(), "arg", &mut err) };
+        assert!(got.is_none());
+        assert_eq!(err.code, QORTOO_ERR_INVALID_ARGUMENT);
+    }
+
+    #[test]
+    fn can_reject_invalid_utf8_in_cstr_arg() {
+        let mut err = new_err();
+        // A stray UTF-8 continuation byte, NUL-terminated.
+        let bytes: Vec<c_char> = vec!['b' as c_char, 0x80u8 as c_char, 0];
+        let got = unsafe { cstr_arg(bytes.as_ptr(), "arg", &mut err) };
+        assert!(got.is_none());
+        assert_eq!(err.code, QORTOO_ERR_INVALID_ARGUMENT);
+    }
+
+    #[test]
+    fn can_round_trip_a_valid_string_via_to_owned_c_string() {
+        let ptr = to_owned_c_string("hello");
+        assert!(!ptr.is_null());
+        let s = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap();
+        assert_eq!(s, "hello");
+        unsafe { qortoo_string_free(ptr) };
+    }
+
+    #[test]
+    fn can_return_null_for_an_embedded_nul_via_to_owned_c_string() {
+        let ptr = to_owned_c_string("bad\0string");
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn can_return_the_closures_value_on_success_via_ffi_guard() {
+        let mut err = new_err();
+        let v = unsafe { ffi_guard(&mut err, 0, || 7) };
+        assert_eq!(v, 7);
+        assert_eq!(err.code, 0);
+    }
+
+    #[test]
+    fn can_convert_a_panic_into_the_default_value_and_code_999_via_ffi_guard() {
+        let mut err = new_err();
+        let v = unsafe { ffi_guard(&mut err, -1, || -> i32 { panic!("boundary panic") }) };
+        assert_eq!(v, -1, "the default value must be returned on panic");
+        assert_eq!(err.code, QORTOO_ERR_INTERNAL_FFI);
+        assert!(
+            !err.msg.is_null(),
+            "the panic must be reported with an owned message"
+        );
+        unsafe { qortoo_string_free(err.msg) };
+    }
+
+    #[test]
+    fn can_accept_a_null_pointer_in_qortoo_string_free() {
+        unsafe { qortoo_string_free(ptr::null_mut()) };
+    }
+}

--- a/qortoo-ffi/tests/client_counter.rs
+++ b/qortoo-ffi/tests/client_counter.rs
@@ -1,0 +1,616 @@
+//! `Client` and `Counter` lifecycle contracts exercised through the C ABI: construction,
+//! pointer/UTF-8 validation, ownership, and the exact error-code mapping a binding
+//! relies on.
+//!
+//! Deliberate use-after-free, double-free, and non-NUL-terminated input are out of
+//! scope: those invoke undefined behavior rather than a supported contract.
+
+mod support;
+
+use std::ptr;
+
+use qortoo_ffi::{
+    QORTOO_ERR_INVALID_ARGUMENT, QortooDatatypeOptions, qortoo_client_get_alias,
+    qortoo_client_get_collection, qortoo_client_new, qortoo_client_unsubscribe_datatype,
+    qortoo_counter_create, qortoo_counter_free, qortoo_counter_get_client_version,
+    qortoo_counter_get_key, qortoo_counter_get_server_version, qortoo_counter_get_state,
+    qortoo_counter_get_synced_client_version, qortoo_counter_get_type, qortoo_counter_get_value,
+    qortoo_counter_increase, qortoo_counter_increase_by, qortoo_counter_subscribe,
+    qortoo_counter_subscribe_or_create, qortoo_counter_sync, qortoo_counter_sync_with_context,
+    qortoo_counter_unset_handler, qortoo_counter_unsubscribe, qortoo_local_connectivity_new,
+    qortoo_local_connectivity_set_realtime,
+};
+use rstest::rstest;
+use support::*;
+
+/// A pointer-argument corruption shared by several `#[rstest]` groups below: every
+/// string argument across this crate's FFI surface goes through the same `cstr_arg`
+/// gate, so "null" and "invalid UTF-8" are the two cases worth repeating per argument.
+#[derive(Clone, Copy)]
+enum BadArg {
+    Null,
+    InvalidUtf8,
+}
+
+fn null_options() -> *const QortooDatatypeOptions {
+    ptr::null()
+}
+
+fn empty_options() -> QortooDatatypeOptions {
+    QortooDatatypeOptions {
+        readonly: false,
+        max_push_buffer_size: 0,
+        handler_priority: 0,
+        on_state_change: None,
+        on_error: None,
+        handler_userdata: 0,
+        handler_userdata_drop: None,
+    }
+}
+
+/// A manual-mode connectivity backend, guarded for release.
+fn manual_conn() -> ConnGuard {
+    let conn = qortoo_local_connectivity_new();
+    unsafe { qortoo_local_connectivity_set_realtime(conn, false) };
+    ConnGuard(conn)
+}
+
+/// Builds a client on the given connectivity (null selects the no-op backend), with a
+/// unique collection and alias so parallel tests never collide.
+fn new_client(conn: *const qortoo_ffi::QortooLocalConnectivity) -> ClientGuard {
+    let collection = unique_cstring("collection");
+    let alias = unique_cstring("alias");
+    let mut err = new_err();
+    let client = unsafe { qortoo_client_new(collection.as_ptr(), alias.as_ptr(), conn, &mut err) };
+    assert_ok(&mut err, "client creation");
+    assert!(!client.is_null());
+    ClientGuard(client)
+}
+
+// ---------------------------------------------------------------------------
+// Client construction
+// ---------------------------------------------------------------------------
+
+// Client construction with both null and real connectivity is already exercised as
+// setup by most other tests in this file (`new_client`/`manual_conn`); a dedicated
+// smoke test would only re-prove what a failure there would already surface loudly
+// elsewhere. `can_read_back_the_collection_and_alias` below is the one dedicated
+// construction test worth keeping, since it makes an assertion nothing else does.
+
+#[test]
+fn can_read_back_the_collection_and_alias() {
+    let collection = unique_cstring("collection");
+    let alias = unique_cstring("alias");
+    let mut err = new_err();
+    let client =
+        unsafe { qortoo_client_new(collection.as_ptr(), alias.as_ptr(), ptr::null(), &mut err) };
+    assert_ok(&mut err, "client creation");
+    let client = ClientGuard(client);
+
+    let got_collection = read_and_free_string(unsafe { qortoo_client_get_collection(client.0) });
+    let got_alias = read_and_free_string(unsafe { qortoo_client_get_alias(client.0) });
+
+    assert_eq!(got_collection.as_deref(), collection.to_str().ok());
+    assert_eq!(got_alias.as_deref(), alias.to_str().ok());
+}
+
+/// Which of `qortoo_client_new`'s two string arguments a case corrupts.
+#[derive(Clone, Copy)]
+enum ClientNewField {
+    Collection,
+    Alias,
+}
+
+#[rstest]
+#[case::null_collection(ClientNewField::Collection, BadArg::Null)]
+#[case::null_alias(ClientNewField::Alias, BadArg::Null)]
+#[case::invalid_utf8_collection(ClientNewField::Collection, BadArg::InvalidUtf8)]
+#[case::invalid_utf8_alias(ClientNewField::Alias, BadArg::InvalidUtf8)]
+fn can_reject_a_bad_client_new_argument(#[case] field: ClientNewField, #[case] bad: BadArg) {
+    let good_collection = unique_cstring("collection");
+    let good_alias = unique_cstring("alias");
+    let invalid = InvalidUtf8CString::new();
+    let bad_ptr = match bad {
+        BadArg::Null => ptr::null(),
+        BadArg::InvalidUtf8 => invalid.as_ptr(),
+    };
+    let (collection_ptr, alias_ptr) = match field {
+        ClientNewField::Collection => (bad_ptr, good_alias.as_ptr()),
+        ClientNewField::Alias => (good_collection.as_ptr(), bad_ptr),
+    };
+
+    let mut err = new_err();
+    let client = unsafe { qortoo_client_new(collection_ptr, alias_ptr, ptr::null(), &mut err) };
+    assert!(client.is_null());
+    assert_err(
+        &mut err,
+        QORTOO_ERR_INVALID_ARGUMENT,
+        "bad client_new argument",
+    );
+}
+
+#[test]
+fn can_map_an_invalid_collection_name_to_code_100() {
+    // Collection names cannot be empty (see `is_valid_collection_name`).
+    let collection = std::ffi::CString::new("").unwrap();
+    let alias = unique_cstring("alias");
+    let mut err = new_err();
+    let client =
+        unsafe { qortoo_client_new(collection.as_ptr(), alias.as_ptr(), ptr::null(), &mut err) };
+    assert!(client.is_null());
+    assert_err(&mut err, 100, "empty collection name");
+}
+
+#[test]
+fn can_free_a_null_client_safely() {
+    unsafe { qortoo_ffi::qortoo_client_free(ptr::null_mut()) };
+}
+
+#[test]
+fn can_use_null_safe_client_getters() {
+    assert!(unsafe { qortoo_client_get_collection(ptr::null()) }.is_null());
+    assert!(unsafe { qortoo_client_get_alias(ptr::null()) }.is_null());
+}
+
+#[derive(Clone, Copy)]
+enum BadUnsubscribeArg {
+    NullClient,
+    InvalidUtf8Key,
+}
+
+#[rstest]
+#[case::null_client(BadUnsubscribeArg::NullClient)]
+#[case::invalid_utf8_key(BadUnsubscribeArg::InvalidUtf8Key)]
+fn can_reject_a_bad_unsubscribe_datatype_argument(#[case] bad: BadUnsubscribeArg) {
+    let client = new_client(ptr::null());
+    let good_key = unique_cstring("key");
+    let invalid = InvalidUtf8CString::new();
+    let (client_ptr, key_ptr) = match bad {
+        BadUnsubscribeArg::NullClient => (ptr::null(), good_key.as_ptr()),
+        BadUnsubscribeArg::InvalidUtf8Key => (client.0 as *const _, invalid.as_ptr()),
+    };
+
+    let mut err = new_err();
+    unsafe { qortoo_client_unsubscribe_datatype(client_ptr, key_ptr, &mut err) };
+    assert_err(
+        &mut err,
+        QORTOO_ERR_INVALID_ARGUMENT,
+        "bad unsubscribe_datatype argument",
+    );
+}
+
+// The client-driven unsubscribe path (and its `Unsubscribing` transition) is covered
+// by `can_transition_state_through_both_unsubscribe_paths` below, alongside the
+// counter-driven path — a standalone test here would only repeat half of it.
+
+// ---------------------------------------------------------------------------
+// Counter construction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn can_construct_counters_with_the_expected_initial_state_per_mode() {
+    let client = new_client(ptr::null());
+    let mut err = new_err();
+
+    let created = unsafe {
+        qortoo_counter_create(
+            client.0,
+            unique_cstring("create").as_ptr(),
+            null_options(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "create");
+    let created = CounterGuard(created);
+    assert_eq!(
+        unsafe { qortoo_counter_get_state(created.0) },
+        0 /* Creating */
+    );
+
+    let subscribed = unsafe {
+        qortoo_counter_subscribe(
+            client.0,
+            unique_cstring("subscribe").as_ptr(),
+            null_options(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "subscribe");
+    let subscribed = CounterGuard(subscribed);
+    assert_eq!(
+        unsafe { qortoo_counter_get_state(subscribed.0) },
+        1 /* Subscribing */
+    );
+
+    let sub_or_create = unsafe {
+        qortoo_counter_subscribe_or_create(
+            client.0,
+            unique_cstring("subscribe-or-create").as_ptr(),
+            null_options(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "subscribe_or_create");
+    let sub_or_create = CounterGuard(sub_or_create);
+    assert_eq!(
+        unsafe { qortoo_counter_get_state(sub_or_create.0) },
+        2 /* SubscribingOrCreating */
+    );
+}
+
+// `qortoo_counter_create` with null options is exercised as setup by nearly every
+// other test in this file. A populated-but-callback-less `QortooDatatypeOptions` is
+// exercised more rigorously by `handler.rs`'s
+// `can_release_userdata_immediately_when_no_callback_is_supplied`, which proves
+// construction succeeds *and* that the userdata drop fires — a strictly stronger
+// version of what a standalone construction-only test here would show.
+
+#[test]
+fn can_reject_a_write_on_a_readonly_counter_with_code_207() {
+    let client = new_client(ptr::null());
+    let mut options = empty_options();
+    options.readonly = true;
+    let mut err = new_err();
+    // `Creating` is a writable state, so this isolates the readonly flag rather than
+    // the state-based `NotWritable` gate a `Subscribing`/`SubscribingOrCreating`
+    // counter would also hit before ever consulting the readonly flag.
+    let counter = unsafe {
+        qortoo_counter_create(client.0, unique_cstring("key").as_ptr(), &options, &mut err)
+    };
+    assert_ok(&mut err, "create readonly counter");
+    let counter = CounterGuard(counter);
+
+    let value = unsafe { qortoo_counter_increase(counter.0, &mut err) };
+    assert_eq!(value, 0);
+    assert_err(
+        &mut err,
+        207, /* ReadonlyViolation */
+        "write to readonly counter",
+    );
+}
+
+// `max_push_buffer_size`'s wiring to `PushBufferExceededMaxMemSize` (code 211),
+// delivered asynchronously through `on_error`, is covered once in `handler.rs`'s
+// `can_forward_a_datatype_error_with_its_mapped_code_and_message` — the same trigger
+// re-run here would only re-verify core push-buffer accounting, not anything specific
+// to this file's client/counter construction contracts.
+
+#[test]
+fn can_map_duplicate_construction_to_client_error_code_101() {
+    let client = new_client(ptr::null());
+    let key = unique_cstring("key");
+    let mut err = new_err();
+    let first = unsafe { qortoo_counter_create(client.0, key.as_ptr(), null_options(), &mut err) };
+    assert_ok(&mut err, "first construction");
+    let _first = CounterGuard(first);
+
+    let second = unsafe { qortoo_counter_create(client.0, key.as_ptr(), null_options(), &mut err) };
+    assert!(second.is_null());
+    assert_err(&mut err, 101, "duplicate key construction");
+}
+
+#[derive(Clone, Copy)]
+enum BadCreateArg {
+    NullClient,
+    NullKey,
+    InvalidUtf8Key,
+    /// Keys starting with `$` are rejected by `is_valid_datatype_key` — a synchronous
+    /// core validation error, not a boundary `cstr_arg` rejection, hence its own code.
+    InvalidKeySyntax,
+}
+
+#[rstest]
+#[case::null_client(BadCreateArg::NullClient, QORTOO_ERR_INVALID_ARGUMENT)]
+#[case::null_key(BadCreateArg::NullKey, QORTOO_ERR_INVALID_ARGUMENT)]
+#[case::invalid_utf8_key(BadCreateArg::InvalidUtf8Key, QORTOO_ERR_INVALID_ARGUMENT)]
+#[case::invalid_key_syntax(BadCreateArg::InvalidKeySyntax, 101)]
+fn can_reject_a_bad_counter_create_argument(#[case] bad: BadCreateArg, #[case] expected_code: i32) {
+    let client = new_client(ptr::null());
+    let good_key = unique_cstring("key");
+    let invalid = InvalidUtf8CString::new();
+    let reserved_key = std::ffi::CString::new("$reserved").unwrap();
+    let (client_ptr, key_ptr) = match bad {
+        BadCreateArg::NullClient => (ptr::null(), good_key.as_ptr()),
+        BadCreateArg::NullKey => (client.0 as *const _, ptr::null()),
+        BadCreateArg::InvalidUtf8Key => (client.0 as *const _, invalid.as_ptr()),
+        BadCreateArg::InvalidKeySyntax => (client.0 as *const _, reserved_key.as_ptr()),
+    };
+
+    let mut err = new_err();
+    let counter = unsafe { qortoo_counter_create(client_ptr, key_ptr, null_options(), &mut err) };
+    assert!(counter.is_null());
+    assert_err(&mut err, expected_code, "bad counter_create argument");
+}
+
+static USERDATA_DROP_COUNT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+extern "C" fn count_userdata_drop(_userdata: usize) {
+    USERDATA_DROP_COUNT.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+}
+
+extern "C" fn noop_on_state_change(_userdata: usize, _old: i32, _new: i32) {}
+
+#[test]
+fn can_release_handler_userdata_exactly_once_on_construction_failure() {
+    // Detailed callback-forwarding assertions live in `handler.rs`; this test only
+    // proves the exactly-once release on a *construction* failure path.
+    let client = new_client(ptr::null());
+    let key = unique_cstring("key");
+    let mut err = new_err();
+    let first = unsafe { qortoo_counter_create(client.0, key.as_ptr(), null_options(), &mut err) };
+    assert_ok(&mut err, "first construction");
+    let _first = CounterGuard(first);
+
+    let before = USERDATA_DROP_COUNT.load(std::sync::atomic::Ordering::SeqCst);
+    let mut options = empty_options();
+    options.on_state_change = Some(noop_on_state_change);
+    options.handler_userdata_drop = Some(count_userdata_drop);
+
+    let second = unsafe { qortoo_counter_create(client.0, key.as_ptr(), &options, &mut err) };
+    assert!(second.is_null());
+    assert_err(&mut err, 101, "duplicate key construction");
+
+    assert_eq!(
+        USERDATA_DROP_COUNT.load(std::sync::atomic::Ordering::SeqCst) - before,
+        1,
+        "userdata must be released exactly once on a construction failure"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Counter operations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn can_increase_and_read_back_the_counter_value() {
+    let client = new_client(ptr::null());
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(
+            client.0,
+            unique_cstring("key").as_ptr(),
+            null_options(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "create");
+    let counter = CounterGuard(counter);
+
+    assert_eq!(unsafe { qortoo_counter_increase(counter.0, &mut err) }, 1);
+    assert_ok(&mut err, "increase");
+    assert_eq!(
+        unsafe { qortoo_counter_increase_by(counter.0, 5, &mut err) },
+        6
+    );
+    assert_ok(&mut err, "increase_by positive");
+    assert_eq!(
+        unsafe { qortoo_counter_increase_by(counter.0, -2, &mut err) },
+        4
+    );
+    assert_ok(&mut err, "increase_by negative");
+    assert_eq!(unsafe { qortoo_counter_get_value(counter.0) }, 4);
+}
+
+#[test]
+fn can_report_key_type_and_versions_via_the_getters() {
+    let client = new_client(ptr::null());
+    let key = unique_cstring("key");
+    let mut err = new_err();
+    let counter =
+        unsafe { qortoo_counter_create(client.0, key.as_ptr(), null_options(), &mut err) };
+    assert_ok(&mut err, "create");
+    let counter = CounterGuard(counter);
+
+    let got_key = read_and_free_string(unsafe { qortoo_counter_get_key(counter.0) });
+    assert_eq!(got_key.as_deref(), key.to_str().ok());
+    assert_eq!(
+        unsafe { qortoo_counter_get_type(counter.0) },
+        0 /* Counter */
+    );
+    assert_eq!(unsafe { qortoo_counter_get_client_version(counter.0) }, 0);
+    assert_eq!(unsafe { qortoo_counter_get_server_version(counter.0) }, 0);
+    assert_eq!(
+        unsafe { qortoo_counter_get_synced_client_version(counter.0) },
+        0
+    );
+
+    unsafe { qortoo_counter_increase(counter.0, &mut err) };
+    assert_ok(&mut err, "increase");
+    assert_eq!(unsafe { qortoo_counter_get_client_version(counter.0) }, 1);
+}
+
+// Two-client push/pull value transfer over `LocalConnectivity` is core CRDT/sync
+// behavior, already proven directly in qortoo-rs (e.g.
+// `datatypes::datatype::tests::can_unsubscribe_with_pending_transactions`). Re-running
+// that scenario through the FFI wouldn't test anything specific to the C ABI beyond
+// what the single-client tests in this file already cover (pointer marshalling,
+// `qortoo_counter_sync`'s error-free path), so it isn't repeated here.
+
+#[test]
+fn can_transition_state_through_both_unsubscribe_paths() {
+    let conn = manual_conn();
+    let client = new_client(conn.0);
+    let mut err = new_err();
+
+    let counter_side = unsafe {
+        qortoo_counter_create(
+            client.0,
+            unique_cstring("counter-side").as_ptr(),
+            null_options(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "create (counter-driven)");
+    let counter_side = CounterGuard(counter_side);
+    unsafe { qortoo_counter_sync(counter_side.0, &mut err) };
+    assert_ok(&mut err, "sync before counter.unsubscribe");
+    unsafe { qortoo_counter_unsubscribe(counter_side.0, &mut err) };
+    assert_ok(&mut err, "counter.unsubscribe");
+    assert_eq!(
+        unsafe { qortoo_counter_get_state(counter_side.0) },
+        4 /* Unsubscribing */
+    );
+
+    let key_client_side = unique_cstring("client-side");
+    let counter_client_side = unsafe {
+        qortoo_counter_create(client.0, key_client_side.as_ptr(), null_options(), &mut err)
+    };
+    assert_ok(&mut err, "create (client-driven)");
+    let counter_client_side = CounterGuard(counter_client_side);
+    unsafe { qortoo_counter_sync(counter_client_side.0, &mut err) };
+    assert_ok(&mut err, "sync before client.unsubscribe_datatype");
+    unsafe { qortoo_client_unsubscribe_datatype(client.0, key_client_side.as_ptr(), &mut err) };
+    assert_ok(&mut err, "client.unsubscribe_datatype");
+    assert_eq!(
+        unsafe { qortoo_counter_get_state(counter_client_side.0) },
+        4 /* Unsubscribing */
+    );
+}
+
+#[test]
+fn can_reject_a_write_on_a_subscribing_counter_with_code_206() {
+    // A `Subscribing` counter is not yet writable: `NotWritable`, not `ReadonlyViolation`
+    // (see `can_reject_a_write_on_a_readonly_counter_with_code_207` for that split).
+    let client = new_client(ptr::null());
+    let mut err = new_err();
+    let subscribing = unsafe {
+        qortoo_counter_subscribe(
+            client.0,
+            unique_cstring("subscribing").as_ptr(),
+            null_options(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "subscribe");
+    let subscribing = CounterGuard(subscribing);
+    unsafe { qortoo_counter_increase(subscribing.0, &mut err) };
+    assert_err(
+        &mut err,
+        206, /* NotWritable */
+        "write to subscribing counter",
+    );
+}
+
+/// Every `qortoo_counter_*` call with no `err_out` parameter must return its
+/// documented default on a null counter rather than crash — the getters below, plus
+/// `unset_handler`'s `false` (a null counter never had anything registered to remove).
+#[test]
+fn can_return_documented_defaults_for_null_counter_calls() {
+    assert_eq!(unsafe { qortoo_counter_get_value(ptr::null()) }, 0);
+    assert_eq!(unsafe { qortoo_counter_get_state(ptr::null()) }, -1);
+    assert_eq!(unsafe { qortoo_counter_get_type(ptr::null()) }, -1);
+    assert!(unsafe { qortoo_counter_get_key(ptr::null()) }.is_null());
+    assert_eq!(unsafe { qortoo_counter_get_server_version(ptr::null()) }, 0);
+    assert_eq!(unsafe { qortoo_counter_get_client_version(ptr::null()) }, 0);
+    assert_eq!(
+        unsafe { qortoo_counter_get_synced_client_version(ptr::null()) },
+        0
+    );
+    assert!(!unsafe { qortoo_counter_unset_handler(ptr::null(), 0) });
+}
+
+#[test]
+fn can_reject_null_counter_fallible_operations_with_invalid_argument() {
+    let mut err = new_err();
+
+    let value = unsafe { qortoo_counter_increase(ptr::null(), &mut err) };
+    assert_eq!(value, 0);
+    assert_err(
+        &mut err,
+        QORTOO_ERR_INVALID_ARGUMENT,
+        "increase on null counter",
+    );
+
+    let value = unsafe { qortoo_counter_increase_by(ptr::null(), 3, &mut err) };
+    assert_eq!(value, 0);
+    assert_err(
+        &mut err,
+        QORTOO_ERR_INVALID_ARGUMENT,
+        "increase_by on null counter",
+    );
+
+    unsafe { qortoo_counter_sync(ptr::null(), &mut err) };
+    assert_err(
+        &mut err,
+        QORTOO_ERR_INVALID_ARGUMENT,
+        "sync on null counter",
+    );
+
+    unsafe { qortoo_counter_sync_with_context(ptr::null(), ptr::null(), ptr::null(), &mut err) };
+    assert_err(
+        &mut err,
+        QORTOO_ERR_INVALID_ARGUMENT,
+        "sync_with_context on null counter",
+    );
+
+    unsafe { qortoo_counter_unsubscribe(ptr::null(), &mut err) };
+    assert_err(
+        &mut err,
+        QORTOO_ERR_INVALID_ARGUMENT,
+        "unsubscribe on null counter",
+    );
+}
+
+#[test]
+fn can_free_a_null_counter_safely() {
+    unsafe { qortoo_counter_free(ptr::null_mut()) };
+}
+
+#[test]
+fn can_accept_a_null_err_out_on_counter_operations() {
+    let client = new_client(ptr::null());
+    let counter = unsafe {
+        qortoo_counter_create(
+            client.0,
+            unique_cstring("key").as_ptr(),
+            null_options(),
+            ptr::null_mut(),
+        )
+    };
+    assert!(!counter.is_null());
+    let counter = CounterGuard(counter);
+
+    // Success path with a null `err_out`.
+    let value = unsafe { qortoo_counter_increase(counter.0, ptr::null_mut()) };
+    assert_eq!(value, 1);
+
+    // Failure path with a null `err_out` (null counter): must not crash.
+    let value = unsafe { qortoo_counter_increase(ptr::null(), ptr::null_mut()) };
+    assert_eq!(value, 0);
+}
+
+#[test]
+fn can_report_the_exact_error_from_both_unsubscribe_paths_once_disabled() {
+    let conn = manual_conn();
+    let client = new_client(conn.0);
+    let key = unique_cstring("key");
+    let mut err = new_err();
+    let counter =
+        unsafe { qortoo_counter_create(client.0, key.as_ptr(), null_options(), &mut err) };
+    assert_ok(&mut err, "create");
+    let counter = CounterGuard(counter);
+    unsafe { qortoo_counter_sync(counter.0, &mut err) };
+    assert_ok(&mut err, "sync (Creating -> Subscribed)");
+    unsafe { qortoo_counter_unsubscribe(counter.0, &mut err) };
+    assert_ok(&mut err, "unsubscribe (Subscribed -> Unsubscribing)");
+    unsafe { qortoo_counter_sync(counter.0, &mut err) };
+    assert_ok(&mut err, "sync (Unsubscribing -> Disabled)");
+
+    // The datatype is now Disabled and detached from the client's manager: the
+    // counter-driven path still sees the state directly (`NotWritable`), while the
+    // client-driven path can no longer find the key at all (`Disallowed`) — both must
+    // report their exact code rather than silently no-op.
+    unsafe { qortoo_counter_unsubscribe(counter.0, &mut err) };
+    assert_err(
+        &mut err,
+        206, /* NotWritable */
+        "counter.unsubscribe once Disabled",
+    );
+
+    unsafe { qortoo_client_unsubscribe_datatype(client.0, key.as_ptr(), &mut err) };
+    assert_err(
+        &mut err,
+        205, /* Disallowed: no longer managed by this client */
+        "client.unsubscribe_datatype once Disabled",
+    );
+}

--- a/qortoo-ffi/tests/handler.rs
+++ b/qortoo-ffi/tests/handler.rs
@@ -1,0 +1,451 @@
+//! Handler callback forwarding and userdata-ownership contracts, exercised through the
+//! C ABI (`QortooDatatypeOptions`, `qortoo_counter_set_handler`,
+//! `qortoo_counter_unset_handler`).
+//!
+//! Every scenario records into a registry keyed by a unique `userdata` value (from
+//! `support::unique_userdata`), so parallel tests sharing this binary never observe
+//! each other's callbacks.
+
+mod support;
+
+use std::{
+    collections::HashMap,
+    ffi::{CStr, c_char},
+    ptr,
+    sync::{Mutex, OnceLock},
+    time::Duration,
+};
+
+use qortoo_ffi::{
+    QortooDatatypeOptions, qortoo_client_new, qortoo_counter_create, qortoo_counter_increase,
+    qortoo_counter_set_handler, qortoo_counter_sync, qortoo_counter_unset_handler,
+    qortoo_local_connectivity_new, qortoo_local_connectivity_set_realtime,
+};
+use support::*;
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+enum Event {
+    StateChange { old: i32, new: i32 },
+    Error { code: i32, msg: String },
+    Drop,
+}
+
+fn registry() -> &'static Mutex<HashMap<usize, Vec<Event>>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<usize, Vec<Event>>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn record(userdata: usize, event: Event) {
+    registry()
+        .lock()
+        .unwrap()
+        .entry(userdata)
+        .or_default()
+        .push(event);
+}
+
+fn events_for(userdata: usize) -> Vec<Event> {
+    registry()
+        .lock()
+        .unwrap()
+        .get(&userdata)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn await_event(userdata: usize, matches: impl Fn(&Event) -> bool + 'static) {
+    awaitility::at_most(Duration::from_secs(5))
+        .poll_interval(Duration::from_millis(10))
+        .until(|| events_for(userdata).iter().any(&matches));
+}
+
+extern "C" fn on_state_change_cb(userdata: usize, old_state: i32, new_state: i32) {
+    record(
+        userdata,
+        Event::StateChange {
+            old: old_state,
+            new: new_state,
+        },
+    );
+}
+
+extern "C" fn on_error_cb(userdata: usize, code: i32, msg: *const c_char) {
+    let msg = if msg.is_null() {
+        String::new()
+    } else {
+        unsafe { CStr::from_ptr(msg) }
+            .to_string_lossy()
+            .into_owned()
+    };
+    record(userdata, Event::Error { code, msg });
+}
+
+extern "C" fn on_drop_cb(userdata: usize) {
+    record(userdata, Event::Drop);
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+fn new_client(conn: *const qortoo_ffi::QortooLocalConnectivity) -> ClientGuard {
+    let collection = unique_cstring("collection");
+    let alias = unique_cstring("alias");
+    let mut err = new_err();
+    let client = unsafe { qortoo_client_new(collection.as_ptr(), alias.as_ptr(), conn, &mut err) };
+    assert_ok(&mut err, "client creation");
+    ClientGuard(client)
+}
+
+fn manual_conn() -> ConnGuard {
+    let conn = qortoo_local_connectivity_new();
+    unsafe { qortoo_local_connectivity_set_realtime(conn, false) };
+    ConnGuard(conn)
+}
+
+fn empty_options() -> QortooDatatypeOptions {
+    QortooDatatypeOptions {
+        readonly: false,
+        max_push_buffer_size: 0,
+        handler_priority: 0,
+        on_state_change: None,
+        on_error: None,
+        handler_userdata: 0,
+        handler_userdata_drop: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State-change forwarding
+// ---------------------------------------------------------------------------
+
+#[test]
+fn can_receive_a_state_transition_via_an_options_registered_handler() {
+    let conn = manual_conn();
+    let client = new_client(conn.0);
+    let userdata = unique_userdata();
+    let mut options = empty_options();
+    options.on_state_change = Some(on_state_change_cb);
+    options.handler_userdata = userdata;
+
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(client.0, unique_cstring("key").as_ptr(), &options, &mut err)
+    };
+    assert_ok(&mut err, "create with a state-change handler");
+    let counter = CounterGuard(counter);
+
+    unsafe { qortoo_counter_sync(counter.0, &mut err) };
+    assert_ok(&mut err, "sync (Creating -> Subscribed)");
+
+    await_event(userdata, |e| {
+        *e == Event::StateChange { old: 0, new: 3 } // Creating -> Subscribed
+    });
+}
+
+#[test]
+fn can_receive_a_state_transition_via_set_handler() {
+    let conn = manual_conn();
+    let client = new_client(conn.0);
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(
+            client.0,
+            unique_cstring("key").as_ptr(),
+            ptr::null(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "create without a handler");
+    let counter = CounterGuard(counter);
+
+    let userdata = unique_userdata();
+    unsafe {
+        qortoo_counter_set_handler(counter.0, 0, Some(on_state_change_cb), None, userdata, None)
+    };
+
+    unsafe { qortoo_counter_sync(counter.0, &mut err) };
+    assert_ok(&mut err, "sync (Creating -> Subscribed)");
+
+    await_event(userdata, |e| *e == Event::StateChange { old: 0, new: 3 });
+}
+
+// ---------------------------------------------------------------------------
+// Error forwarding
+// ---------------------------------------------------------------------------
+
+#[test]
+fn can_forward_a_datatype_error_with_its_mapped_code_and_message() {
+    // Same buffer-exceeded trigger as `client_counter.rs`'s push-buffer test: the
+    // error only ever reaches the caller through the registered `on_error` handler,
+    // never through `qortoo_counter_increase`'s synchronous `err_out`.
+    let conn = manual_conn();
+    let client = new_client(conn.0);
+    let userdata = unique_userdata();
+    let mut options = empty_options();
+    options.max_push_buffer_size = 1; // clamped up to the SDK's 1MB floor
+    options.on_error = Some(on_error_cb);
+    options.handler_userdata = userdata;
+
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(client.0, unique_cstring("key").as_ptr(), &options, &mut err)
+    };
+    assert_ok(
+        &mut err,
+        "create with a bounded push buffer and an error handler",
+    );
+    let counter = CounterGuard(counter);
+
+    const SAFETY_BOUND: u32 = 50_000;
+    for _ in 0..SAFETY_BOUND {
+        unsafe { qortoo_counter_increase(counter.0, &mut err) };
+        take_code(&mut err);
+        if events_for(userdata)
+            .iter()
+            .any(|e| matches!(e, Event::Error { .. }))
+        {
+            break;
+        }
+    }
+
+    await_event(userdata, |e| matches!(e, Event::Error { .. }));
+    let events = events_for(userdata);
+    let Event::Error { code, msg } = events
+        .iter()
+        .find(|e| matches!(e, Event::Error { .. }))
+        .unwrap()
+    else {
+        unreachable!()
+    };
+    assert_eq!(*code, 211 /* PushBufferExceededMaxMemSize */);
+    assert!(
+        !msg.is_empty(),
+        "the callback-scoped message must be non-empty"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Replace / unset
+// ---------------------------------------------------------------------------
+
+#[test]
+fn can_release_the_old_userdata_exactly_once_when_replacing_a_handler() {
+    let client = new_client(ptr::null());
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(
+            client.0,
+            unique_cstring("key").as_ptr(),
+            ptr::null(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "create");
+    let counter = CounterGuard(counter);
+
+    // `on_state_change` must be non-null here: `make_foreign_handler` only captures
+    // the userdata context inside a closure it actually registers, so a handler with
+    // both callbacks null releases its userdata immediately (see
+    // `can_release_userdata_immediately_when_no_callback_is_supplied`) rather than staying
+    // alive until it is replaced — which would make this test observe the release for
+    // the wrong reason.
+    let old_userdata = unique_userdata();
+    let new_userdata = unique_userdata();
+    unsafe {
+        qortoo_counter_set_handler(
+            counter.0,
+            0,
+            Some(on_state_change_cb),
+            None,
+            old_userdata,
+            Some(on_drop_cb),
+        )
+    };
+    unsafe {
+        qortoo_counter_set_handler(
+            counter.0,
+            0,
+            Some(on_state_change_cb),
+            None,
+            new_userdata,
+            Some(on_drop_cb),
+        )
+    };
+
+    await_event(old_userdata, |e| *e == Event::Drop);
+    assert_eq!(
+        events_for(old_userdata)
+            .iter()
+            .filter(|e| **e == Event::Drop)
+            .count(),
+        1,
+        "the replaced handler's userdata must be released exactly once"
+    );
+    assert!(
+        events_for(new_userdata).is_empty(),
+        "the replacing handler's userdata must still be live"
+    );
+}
+
+#[test]
+fn can_unset_a_handler_and_release_its_userdata_exactly_once() {
+    let client = new_client(ptr::null());
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(
+            client.0,
+            unique_cstring("key").as_ptr(),
+            ptr::null(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "create");
+    let counter = CounterGuard(counter);
+
+    // See the comment in `can_release_the_old_userdata_exactly_once_when_replacing_a_handler`:
+    // a non-null callback is required so the userdata survives until this `unset` call.
+    let userdata = unique_userdata();
+    unsafe {
+        qortoo_counter_set_handler(
+            counter.0,
+            3,
+            Some(on_state_change_cb),
+            None,
+            userdata,
+            Some(on_drop_cb),
+        )
+    };
+
+    let removed = unsafe { qortoo_counter_unset_handler(counter.0, 3) };
+    assert!(removed, "unsetting a registered priority must return true");
+    await_event(userdata, |e| *e == Event::Drop);
+    assert_eq!(
+        events_for(userdata)
+            .iter()
+            .filter(|e| **e == Event::Drop)
+            .count(),
+        1
+    );
+
+    let removed_again = unsafe { qortoo_counter_unset_handler(counter.0, 3) };
+    assert!(
+        !removed_again,
+        "unsetting an already-removed priority must return false"
+    );
+    assert_eq!(
+        events_for(userdata)
+            .iter()
+            .filter(|e| **e == Event::Drop)
+            .count(),
+        1,
+        "unsetting a missing handler must not trigger an extra destruction"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Userdata ownership at construction time
+// ---------------------------------------------------------------------------
+
+#[test]
+fn can_release_userdata_immediately_when_no_callback_is_supplied() {
+    let client = new_client(ptr::null());
+    let userdata = unique_userdata();
+    let mut options = empty_options();
+    // Both callbacks absent: Rust retains no handler, so the FFI layer must release
+    // the userdata immediately rather than leak it silently.
+    options.handler_userdata = userdata;
+    options.handler_userdata_drop = Some(on_drop_cb);
+
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(client.0, unique_cstring("key").as_ptr(), &options, &mut err)
+    };
+    assert_ok(&mut err, "create with a callback-less handler option");
+    let _counter = CounterGuard(counter);
+
+    assert_eq!(events_for(userdata), vec![Event::Drop]);
+}
+
+#[test]
+fn can_release_userdata_after_an_early_null_client_construction_failure() {
+    let userdata = unique_userdata();
+    let mut options = empty_options();
+    options.on_state_change = Some(on_state_change_cb);
+    options.handler_userdata = userdata;
+    options.handler_userdata_drop = Some(on_drop_cb);
+
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(
+            ptr::null(),
+            unique_cstring("key").as_ptr(),
+            &options,
+            &mut err,
+        )
+    };
+    assert!(counter.is_null());
+    assert_err(
+        &mut err,
+        qortoo_ffi::QORTOO_ERR_INVALID_ARGUMENT,
+        "null client",
+    );
+    assert_eq!(events_for(userdata), vec![Event::Drop]);
+}
+
+#[test]
+fn can_release_userdata_after_a_late_duplicate_key_construction_failure() {
+    let client = new_client(ptr::null());
+    let key = unique_cstring("key");
+    let mut err = new_err();
+    let first = unsafe { qortoo_counter_create(client.0, key.as_ptr(), ptr::null(), &mut err) };
+    assert_ok(&mut err, "first construction");
+    let _first = CounterGuard(first);
+
+    let userdata = unique_userdata();
+    let mut options = empty_options();
+    options.on_state_change = Some(on_state_change_cb);
+    options.handler_userdata = userdata;
+    options.handler_userdata_drop = Some(on_drop_cb);
+
+    let second = unsafe { qortoo_counter_create(client.0, key.as_ptr(), &options, &mut err) };
+    assert!(second.is_null());
+    assert_err(&mut err, 101, "duplicate key construction");
+    assert_eq!(events_for(userdata), vec![Event::Drop]);
+}
+
+#[test]
+fn can_release_userdata_immediately_when_setting_a_handler_on_a_null_counter() {
+    let userdata = unique_userdata();
+    unsafe { qortoo_counter_set_handler(ptr::null(), 0, None, None, userdata, Some(on_drop_cb)) };
+    assert_eq!(events_for(userdata), vec![Event::Drop]);
+}
+
+// ---------------------------------------------------------------------------
+// Null safety
+// ---------------------------------------------------------------------------
+
+#[test]
+fn can_accept_null_callbacks_and_userdata_drop_safely() {
+    let client = new_client(ptr::null());
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(
+            client.0,
+            unique_cstring("key").as_ptr(),
+            ptr::null(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "create");
+    let counter = CounterGuard(counter);
+
+    // Fully null handler on a live counter: must not crash.
+    unsafe { qortoo_counter_set_handler(counter.0, 0, None, None, 0, None) };
+    // Fully null handler on a null counter: must not crash.
+    unsafe { qortoo_counter_set_handler(ptr::null(), 0, None, None, 0, None) };
+}

--- a/qortoo-ffi/tests/support/mod.rs
+++ b/qortoo-ffi/tests/support/mod.rs
@@ -1,0 +1,149 @@
+//! Test-only helpers shared by the qortoo-ffi integration-test binaries.
+//!
+//! Kept deliberately small and explicit: a test asserting an FFI ownership contract
+//! must not lose track of which allocation it owns behind a helper. Each helper does
+//! exactly one thing and leaves ownership visible at the call site.
+//!
+//! Not every binary that includes this module (via `mod support;`) uses every helper,
+//! since each `tests/*.rs` file is compiled as its own crate.
+#![allow(dead_code)]
+
+use std::{
+    ffi::{CStr, CString, c_char},
+    ptr,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use qortoo_ffi::{
+    QortooClient, QortooCounter, QortooError, QortooLocalConnectivity, qortoo_client_free,
+    qortoo_counter_free, qortoo_local_connectivity_free, qortoo_string_free,
+};
+
+/// A fresh, zeroed `QortooError` ready to be passed as an out-parameter.
+pub fn new_err() -> QortooError {
+    QortooError {
+        code: 0,
+        msg: ptr::null_mut(),
+    }
+}
+
+/// Releases any message and returns the code, leaving `err` cleared. Mirrors what a
+/// binding does with every out-parameter after a call.
+pub fn take_code(err: &mut QortooError) -> i32 {
+    if !err.msg.is_null() {
+        unsafe { qortoo_string_free(err.msg) };
+        err.msg = ptr::null_mut();
+    }
+    let code = err.code;
+    err.code = 0;
+    code
+}
+
+/// Releases the message and returns `(code, owned message text)`.
+pub fn take_code_and_message(err: &mut QortooError) -> (i32, Option<String>) {
+    let msg = if err.msg.is_null() {
+        None
+    } else {
+        let owned = unsafe { CStr::from_ptr(err.msg) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { qortoo_string_free(err.msg) };
+        err.msg = ptr::null_mut();
+        Some(owned)
+    };
+    let code = err.code;
+    err.code = 0;
+    (code, msg)
+}
+
+/// Asserts success and releases any (unexpected) message.
+pub fn assert_ok(err: &mut QortooError, what: &str) {
+    let code = take_code(err);
+    assert_eq!(code, 0, "{what} unexpectedly failed with code {code}");
+}
+
+/// Asserts failure with the exact expected code and releases the message.
+pub fn assert_err(err: &mut QortooError, expected_code: i32, what: &str) {
+    let code = take_code(err);
+    assert_eq!(
+        code, expected_code,
+        "{what}: expected code {expected_code}, got {code}"
+    );
+}
+
+/// Reads and frees a string returned by this library, or `None` for a null pointer.
+pub fn read_and_free_string(ptr: *mut c_char) -> Option<String> {
+    if ptr.is_null() {
+        return None;
+    }
+    let owned = unsafe { CStr::from_ptr(ptr) }
+        .to_string_lossy()
+        .into_owned();
+    unsafe { qortoo_string_free(ptr) };
+    Some(owned)
+}
+
+/// A byte buffer that is NUL-terminated but not valid UTF-8, kept alive for the
+/// duration of an FFI call that borrows its pointer.
+pub struct InvalidUtf8CString(Vec<u8>);
+
+impl InvalidUtf8CString {
+    /// `0x80` alone is a stray UTF-8 continuation byte: never valid on its own,
+    /// regardless of what surrounds it.
+    pub fn new() -> Self {
+        Self(vec![b'b', b'a', 0x80, b'd', 0])
+    }
+
+    pub fn as_ptr(&self) -> *const c_char {
+        self.0.as_ptr() as *const c_char
+    }
+}
+
+static UNIQUE_COUNTER: AtomicUsize = AtomicUsize::new(1);
+
+/// Returns a name unique across the whole test run (process-wide), so parallel tests
+/// sharing a connectivity backend or collection never collide on collection, alias,
+/// or key.
+pub fn unique_name(prefix: &str) -> String {
+    let n = UNIQUE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{prefix}-{}-{n}", std::process::id())
+}
+
+pub fn unique_cstring(prefix: &str) -> CString {
+    CString::new(unique_name(prefix)).expect("generated name never contains a NUL")
+}
+
+/// A unique, non-zero userdata value. Non-zero because `0` means "no userdata" at the
+/// ABI boundary (see `handlerFromUserdata`/`goQortooOnStateChange` on the Go side).
+pub fn unique_userdata() -> usize {
+    UNIQUE_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+// ---------------------------------------------------------------------------
+// RAII guards. Each wraps exactly one `*_free` call so a test cannot forget which
+// function owns the release, even if it panics before reaching the end of the test.
+// ---------------------------------------------------------------------------
+
+pub struct ConnGuard(pub *mut QortooLocalConnectivity);
+
+impl Drop for ConnGuard {
+    fn drop(&mut self) {
+        unsafe { qortoo_local_connectivity_free(self.0) };
+    }
+}
+
+pub struct ClientGuard(pub *mut QortooClient);
+
+impl Drop for ClientGuard {
+    fn drop(&mut self) {
+        unsafe { qortoo_client_free(self.0) };
+    }
+}
+
+pub struct CounterGuard(pub *mut QortooCounter);
+
+impl Drop for CounterGuard {
+    fn drop(&mut self) {
+        unsafe { qortoo_counter_free(self.0) };
+    }
+}

--- a/qortoo-ffi/tests/trace_context_e2e.rs
+++ b/qortoo-ffi/tests/trace_context_e2e.rs
@@ -1,22 +1,34 @@
 //! End-to-end check that a foreign caller's W3C trace context reaches the core spans.
 //!
 //! A language binding is responsible for turning its context into the two headers; this
-//! file covers everything after the headers arrive: the FFI span, the sync that runs on
-//! the event-loop thread, and the push/pull spans the core emits there.
+//! file covers everything after the headers arrive: the FFI span, the sync (resp.
+//! transaction) that runs on the event-loop (resp. caller) thread, and the push/pull
+//! spans the core emits there.
+//!
+//! `tracing`'s global subscriber can only be installed once per process, and the two
+//! scenarios below both drive process-global tracing plus the shared background
+//! event-loop runtime. Running them in the same process lets one scenario's spans
+//! interleave with the other's ambient context, so — mirroring `observability.rs` —
+//! each scenario runs in its own fresh copy of this test binary.
 
-use std::{ffi::CString, ptr, time::Duration};
+use std::{env, ffi::CString, process::Command, ptr, time::Duration};
 
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
 use qortoo_ffi::{
-    QortooError, qortoo_client_free, qortoo_client_new, qortoo_counter_create, qortoo_counter_free,
-    qortoo_counter_increase_by, qortoo_counter_sync_with_context, qortoo_local_connectivity_free,
+    QortooCounter, QortooError, qortoo_client_free, qortoo_client_new, qortoo_counter_create,
+    qortoo_counter_free, qortoo_counter_increase_by, qortoo_counter_sync_with_context,
+    qortoo_counter_transaction_with_context, qortoo_local_connectivity_free,
     qortoo_local_connectivity_new, qortoo_local_connectivity_set_realtime,
 };
 use tracing_subscriber::{EnvFilter, Registry, layer::SubscriberExt};
 
 const TRACE_ID: &str = "4bf92f3577b34da6a3ce929d0e0e4736";
 const TRACEPARENT: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+const SUBPROCESS_ENV: &str = "QORTOO_FFI_TRACE_CONTEXT_TEST_SCENARIO";
+const SYNC_SCENARIO: &str = "sync";
+const TRANSACTION_SCENARIO: &str = "transaction";
 
 fn new_err() -> QortooError {
     QortooError {
@@ -43,8 +55,47 @@ fn install_recording_subscriber() -> InMemorySpanExporter {
     exporter
 }
 
+fn run_isolated(scenario: &str) {
+    let output = Command::new(env::current_exe().expect("resolve the current test binary"))
+        .args(["--exact", "trace_context_subprocess", "--nocapture"])
+        .env(SUBPROCESS_ENV, scenario)
+        .output()
+        .expect("run the trace-context test subprocess");
+
+    assert!(
+        output.status.success(),
+        "trace-context scenario {scenario:?} failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 #[test]
 fn can_continue_the_callers_trace_through_sync() {
+    run_isolated(SYNC_SCENARIO);
+}
+
+#[test]
+fn can_continue_the_callers_trace_through_transaction() {
+    run_isolated(TRANSACTION_SCENARIO);
+}
+
+/// Entry point selected by `run_isolated`; a normal test run leaves it as a no-op.
+#[test]
+fn trace_context_subprocess() {
+    let scenario = match env::var(SUBPROCESS_ENV) {
+        Ok(scenario) => scenario,
+        Err(env::VarError::NotPresent) => return,
+        Err(error) => panic!("read {SUBPROCESS_ENV}: {error}"),
+    };
+    match scenario.as_str() {
+        SYNC_SCENARIO => exercise_sync(),
+        TRANSACTION_SCENARIO => exercise_transaction(),
+        scenario => panic!("unknown trace-context subprocess scenario {scenario:?}"),
+    }
+}
+
+fn exercise_sync() {
     let exporter = install_recording_subscriber();
 
     let collection = CString::new("trace-context-e2e").unwrap();
@@ -75,16 +126,17 @@ fn can_continue_the_callers_trace_through_sync() {
         qortoo_local_connectivity_free(connectivity);
     }
 
-    // The sync span closes on the caller thread, but push_pull closes on the event-loop
-    // thread just before it answers, so give the exporter a moment on a slow machine.
+    // `qortoo.sync` is the parent of `push_pull`, and a span's export via
+    // `SimpleSpanProcessor` cannot complete until every child span it's tracking has
+    // itself closed — so `push_pull` (which closes on the event-loop thread) can
+    // appear in the exporter a moment before `qortoo.sync` does. Wait for both, not
+    // just the child, or this poll can race the parent's own export.
     awaitility::at_most(Duration::from_secs(5))
         .poll_interval(Duration::from_millis(50))
         .until(|| {
-            exporter
-                .get_finished_spans()
-                .unwrap_or_default()
-                .iter()
-                .any(|s| s.name == "push_pull")
+            let spans = exporter.get_finished_spans().unwrap_or_default();
+            spans.iter().any(|s| s.name == "push_pull")
+                && spans.iter().any(|s| s.name == "qortoo.sync")
         });
 
     let spans = exporter.get_finished_spans().unwrap();
@@ -107,5 +159,71 @@ fn can_continue_the_callers_trace_through_sync() {
         push_pull.span_context.trace_id().to_string(),
         TRACE_ID,
         "the sync that runs on the event-loop thread must stay in the caller's trace"
+    );
+}
+
+extern "C" fn commit_one_increase(tx_counter: *mut QortooCounter, _userdata: usize) -> i32 {
+    let mut err = new_err();
+    unsafe { qortoo_counter_increase_by(tx_counter, 1, &mut err) };
+    assert_ok(&err, "increase_by inside transaction");
+    0
+}
+
+fn exercise_transaction() {
+    let exporter = install_recording_subscriber();
+
+    let collection = CString::new("trace-context-e2e").unwrap();
+    let alias = CString::new("client-b").unwrap();
+    let key = CString::new("transaction-counter").unwrap();
+    let tag = CString::new("trace-context-e2e-tx").unwrap();
+    let traceparent = CString::new(TRACEPARENT).unwrap();
+    let mut err = new_err();
+
+    unsafe {
+        let client = qortoo_client_new(collection.as_ptr(), alias.as_ptr(), ptr::null(), &mut err);
+        assert_ok(&err, "client creation");
+
+        let counter = qortoo_counter_create(client, key.as_ptr(), ptr::null(), &mut err);
+        assert_ok(&err, "counter creation");
+
+        qortoo_counter_transaction_with_context(
+            counter,
+            tag.as_ptr(),
+            traceparent.as_ptr(),
+            ptr::null(),
+            commit_one_increase,
+            0,
+            &mut err,
+        );
+        assert_ok(&err, "transaction with context");
+
+        qortoo_counter_free(counter);
+        qortoo_client_free(client);
+    }
+
+    awaitility::at_most(Duration::from_secs(5))
+        .poll_interval(Duration::from_millis(50))
+        .until(|| {
+            exporter
+                .get_finished_spans()
+                .unwrap_or_default()
+                .iter()
+                .any(|s| s.name == "qortoo.transaction")
+        });
+
+    let spans = exporter.get_finished_spans().unwrap();
+    let tx_span = spans
+        .iter()
+        .find(|s| s.name == "qortoo.transaction")
+        .expect("checked by the poll above");
+    assert_eq!(
+        tx_span.span_context.trace_id().to_string(),
+        TRACE_ID,
+        "the FFI transaction span must join the caller's trace"
+    );
+    assert!(
+        tx_span.parent_span_id.to_string() == "00f067aa0ba902b7",
+        "the FFI transaction span must hang off the caller's span, got {}",
+        tx_span.parent_span_id
     );
 }

--- a/qortoo-ffi/tests/transaction.rs
+++ b/qortoo-ffi/tests/transaction.rs
@@ -1,0 +1,230 @@
+//! Transaction commit/rollback and trace-context propagation, exercised through the C
+//! ABI callback bridge (`qortoo_counter_transaction[_with_context]`).
+
+mod support;
+
+use std::ptr;
+
+use qortoo_ffi::{
+    QortooCounter, qortoo_client_new, qortoo_counter_create, qortoo_counter_get_value,
+    qortoo_counter_increase_by, qortoo_counter_transaction,
+    qortoo_counter_transaction_with_context,
+};
+use rstest::rstest;
+use support::*;
+
+fn new_client() -> ClientGuard {
+    let collection = unique_cstring("collection");
+    let alias = unique_cstring("alias");
+    let mut err = new_err();
+    let client =
+        unsafe { qortoo_client_new(collection.as_ptr(), alias.as_ptr(), ptr::null(), &mut err) };
+    assert_ok(&mut err, "client creation");
+    ClientGuard(client)
+}
+
+fn new_counter(client: &ClientGuard) -> CounterGuard {
+    let mut err = new_err();
+    let counter = unsafe {
+        qortoo_counter_create(
+            client.0,
+            unique_cstring("key").as_ptr(),
+            ptr::null(),
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "counter creation");
+    CounterGuard(counter)
+}
+
+// ---------------------------------------------------------------------------
+// Commit
+// ---------------------------------------------------------------------------
+
+extern "C" fn commit_two_increases(tx_counter: *mut QortooCounter, _userdata: usize) -> i32 {
+    let mut err = new_err();
+    unsafe { qortoo_counter_increase_by(tx_counter, 4, &mut err) };
+    assert_ok(&mut err, "increase_by inside transaction (1)");
+    unsafe { qortoo_counter_increase_by(tx_counter, 6, &mut err) };
+    assert_ok(&mut err, "increase_by inside transaction (2)");
+    0
+}
+
+#[test]
+fn can_commit_multiple_operations_in_a_transaction() {
+    let client = new_client();
+    let counter = new_counter(&client);
+    let tag = unique_cstring("tag");
+    let mut err = new_err();
+
+    unsafe {
+        qortoo_counter_transaction(counter.0, tag.as_ptr(), commit_two_increases, 0, &mut err)
+    };
+    assert_ok(&mut err, "transaction commit");
+    assert_eq!(unsafe { qortoo_counter_get_value(counter.0) }, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Rollback
+// ---------------------------------------------------------------------------
+
+extern "C" fn abort_after_write(tx_counter: *mut QortooCounter, _userdata: usize) -> i32 {
+    let mut err = new_err();
+    unsafe { qortoo_counter_increase_by(tx_counter, 100, &mut err) };
+    assert_ok(&mut err, "increase_by before abort");
+    7 // any non-zero code rolls back
+}
+
+#[test]
+fn can_roll_back_on_a_non_zero_callback_result() {
+    let client = new_client();
+    let counter = new_counter(&client);
+    let tag = unique_cstring("tag");
+    let mut err = new_err();
+
+    unsafe { qortoo_counter_increase_by(counter.0, 1, &mut err) };
+    assert_ok(&mut err, "seed value");
+
+    unsafe { qortoo_counter_transaction(counter.0, tag.as_ptr(), abort_after_write, 0, &mut err) };
+    assert_err(
+        &mut err,
+        201, /* TransactionFailed */
+        "aborted transaction",
+    );
+    assert_eq!(
+        unsafe { qortoo_counter_get_value(counter.0) },
+        1,
+        "the write inside the aborted transaction must be rolled back"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Userdata
+// ---------------------------------------------------------------------------
+
+extern "C" fn record_userdata(_tx_counter: *mut QortooCounter, userdata: usize) -> i32 {
+    let slot = userdata as *const std::sync::atomic::AtomicUsize;
+    unsafe { &*slot }.store(userdata, std::sync::atomic::Ordering::SeqCst);
+    0
+}
+
+#[test]
+fn can_forward_userdata_unchanged_to_the_transaction_callback() {
+    let client = new_client();
+    let counter = new_counter(&client);
+    let tag = unique_cstring("tag");
+    let mut err = new_err();
+
+    let slot: &'static std::sync::atomic::AtomicUsize =
+        Box::leak(Box::new(std::sync::atomic::AtomicUsize::new(0)));
+    let userdata = slot as *const _ as usize;
+
+    unsafe {
+        qortoo_counter_transaction(counter.0, tag.as_ptr(), record_userdata, userdata, &mut err)
+    };
+    assert_ok(&mut err, "transaction with userdata");
+    assert_eq!(slot.load(std::sync::atomic::Ordering::SeqCst), userdata);
+}
+
+// ---------------------------------------------------------------------------
+// Argument validation
+// ---------------------------------------------------------------------------
+
+extern "C" fn unreachable_callback(_tx_counter: *mut QortooCounter, _userdata: usize) -> i32 {
+    panic!("callback must not run when argument validation rejects the call first");
+}
+
+/// Which transaction entry point a `can_reject_a_bad_transaction_argument` case calls.
+#[derive(Clone, Copy)]
+enum Entry {
+    Plain,
+    WithContext,
+}
+
+#[derive(Clone, Copy)]
+enum BadTxArg {
+    NullCounter,
+    NullTag,
+    InvalidUtf8Tag,
+}
+
+#[rstest]
+#[case::plain_null_counter(Entry::Plain, BadTxArg::NullCounter)]
+#[case::plain_null_tag(Entry::Plain, BadTxArg::NullTag)]
+#[case::plain_invalid_utf8_tag(Entry::Plain, BadTxArg::InvalidUtf8Tag)]
+#[case::with_context_null_counter(Entry::WithContext, BadTxArg::NullCounter)]
+#[case::with_context_null_tag(Entry::WithContext, BadTxArg::NullTag)]
+#[case::with_context_invalid_utf8_tag(Entry::WithContext, BadTxArg::InvalidUtf8Tag)]
+fn can_reject_a_bad_transaction_argument(#[case] entry: Entry, #[case] bad: BadTxArg) {
+    let client = new_client();
+    let counter = new_counter(&client);
+    let good_tag = unique_cstring("tag");
+    let invalid = InvalidUtf8CString::new();
+    let (counter_ptr, tag_ptr) = match bad {
+        BadTxArg::NullCounter => (ptr::null(), good_tag.as_ptr()),
+        BadTxArg::NullTag => (counter.0 as *const _, ptr::null()),
+        BadTxArg::InvalidUtf8Tag => (counter.0 as *const _, invalid.as_ptr()),
+    };
+
+    let mut err = new_err();
+    match entry {
+        Entry::Plain => unsafe {
+            qortoo_counter_transaction(counter_ptr, tag_ptr, unreachable_callback, 0, &mut err)
+        },
+        Entry::WithContext => unsafe {
+            qortoo_counter_transaction_with_context(
+                counter_ptr,
+                tag_ptr,
+                ptr::null(),
+                ptr::null(),
+                unreachable_callback,
+                0,
+                &mut err,
+            )
+        },
+    };
+    assert_err(
+        &mut err,
+        qortoo_ffi::QORTOO_ERR_INVALID_ARGUMENT,
+        "bad transaction argument",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Trace-context variant
+// ---------------------------------------------------------------------------
+
+const TRACEPARENT: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+#[rstest]
+#[case::absent_headers(None)]
+#[case::malformed_headers(Some("garbage"))]
+#[case::valid_headers(Some(TRACEPARENT))]
+fn can_accept_trace_headers_in_a_transaction(#[case] traceparent: Option<&str>) {
+    let client = new_client();
+    let counter = new_counter(&client);
+    let tag = unique_cstring("tag");
+    let traceparent_c = traceparent.map(|s| std::ffi::CString::new(s).unwrap());
+    let traceparent_ptr = traceparent_c.as_ref().map_or(ptr::null(), |c| c.as_ptr());
+    let mut err = new_err();
+
+    unsafe {
+        qortoo_counter_transaction_with_context(
+            counter.0,
+            tag.as_ptr(),
+            traceparent_ptr,
+            ptr::null(),
+            commit_two_increases,
+            0,
+            &mut err,
+        )
+    };
+    assert_ok(&mut err, "transaction with trace headers");
+    assert_eq!(unsafe { qortoo_counter_get_value(counter.0) }, 10);
+}
+
+// A dedicated "the tx-scoped handle is usable during the callback" test was removed:
+// every commit/rollback test above already writes through that same handle, which is a
+// strictly stronger proof of liveness than a read-only variant would add. Exercising
+// "only during" (i.e. retaining or using it after the callback returns) would be a
+// use-after-free, which is deliberately out of scope for this crate's tests.


### PR DESCRIPTION
- Add integration tests for client/counter lifecycle, transaction
  commit/rollback, and handler callback ownership across the C ABI
  (qortoo-ffi/tests/client_counter.rs, transaction.rs, handler.rs,
  support/mod.rs).
- Extend unit tests in error.rs, util.rs, and observability/trace_context.rs
  to cover boundary-only concerns: embedded-NUL message fallback, panic
  containment across the FFI boundary, invalid-UTF-8 handling.
- Add a transaction trace-context test and isolate trace_context_e2e.rs's
  scenarios into subprocesses to remove a span-export race.
- Raise qortoo-ffi/src line coverage from 47.51% to 97.95%, with every
  symbol in abi-symbols.txt exercised by at least one test.
- Add rstest as a dev-dependency to consolidate repetitive
  null/invalid-UTF-8 argument checks into parametric test tables.
- Wire make ffi-header-check and make abi-symbols-check into CI, and add
  make ffi-coverage as a local-only informational check (not a CI gate,
  since line coverage rewards filler tests on a boundary crate that is
  mostly thin wrappers).
- Document the qortoo-ffi test-naming (can_<behavior>) and test-scope
  (boundary-only, not core-logic duplication) conventions in AGENTS.md.

## Commits included
- 📜docs(readme): make the commit-activity and CI-status badges clickable