### PR TITLE
🪲fix(errors): preserve typed errors when stack traces fail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Qortoo is a Rust SDK for conflict-free replicated data types (CRDTs) with distri
 ## Critical guidelines
 
 Shared across all qortoo-* repos (canonical text in [qortoo-harness `AGENTS.md`](https://github.com/qortoo/qortoo-harness)):
-- All code comments and documentation must be written in **English**.
+- All code comments and shared, tracked documentation must be written in **English**. Personal plan documents under `qortoo-harness/.local/plans/` are the exception: they must use the language of the current user session.
 - Favor SOLID principles, especially Single Responsibility (SRP) and Open/Closed (OCP), where practical. Check for these during review.
 - Structure important concepts under `./docs/` so they're easy to follow from Markdown and diagrams grounded in the actual code. Use the `/qortoo-shared:doc-new` command to scaffold a new concept document.
 - All individual plan documents, regardless of the repository they concern, belong in the qortoo-harness repository's gitignored `.local/plans/` directory. Task lists and working notes likewise belong under qortoo-harness's `.local/` — never commit them or propose committing them. Claude Code's project-scoped agent memory (`.claude/agent-memory/`) is likewise personal and gitignored, not shared team knowledge.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -238,6 +238,10 @@ let err = with_err_out!(InternalReason::EventLoop(err_msg).into_error());
 
 The macro captures `Backtrace::force_capture()` and `Location::caller()`, then calls
 `with_stack_trace` which filters frames by `SDK_NAME` and formats them with `↘︎` arrows.
+Stack traces are diagnostic only: when a platform returns an unavailable, empty, or
+otherwise unparsable backtrace, the log omits the filtered trace and preserves the
+original typed error. Stack-trace formatting must never replace an application error or
+surface as a panic across an FFI boundary.
 
 ---
 

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -26,7 +26,11 @@ pub fn with_stack_trace(
     trace: &std::backtrace::Backtrace,
     caller: &std::panic::Location,
 ) -> String {
-    let bt_parsed = btparse::deserialize(trace).unwrap();
+    // Stack traces are diagnostic only. Preserve the original error when a
+    // platform produces an empty or otherwise unparsable backtrace.
+    let Ok(bt_parsed) = btparse::deserialize(trace) else {
+        return String::new();
+    };
     let mut s = String::new();
     let mut stack_count = 0;
     for frame in bt_parsed.frames {
@@ -74,7 +78,11 @@ pub(crate) use with_err_out;
 
 #[cfg(test)]
 mod tests_datatype_errors {
-    use std::io::{Error, ErrorKind};
+    use std::{
+        backtrace::Backtrace,
+        io::{Error, ErrorKind},
+        panic::Location,
+    };
 
     use crossbeam_channel::TrySendError;
 
@@ -100,6 +108,13 @@ mod tests_datatype_errors {
         assert!(!equal_errors!(&e1, &e3));
         let e4 = e3.clone();
         assert_eq!(e3, e4);
+    }
+
+    #[test]
+    fn can_omit_an_unavailable_stack_trace() {
+        let stack_trace = super::with_stack_trace(&Backtrace::disabled(), Location::caller());
+
+        assert!(stack_trace.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Treat unavailable or unparsable backtraces as missing diagnostic data instead of panicking.
- Preserve the original typed error and FFI error code when stack-trace formatting is unavailable.
- Add regression coverage and document the error-preservation invariant.

## Testing

- `make lint`
- `cargo test --workspace --all-features`
- `cargo test -p qortoo-ffi can_report_the_exact_error_from_both_unsubscribe_paths_once_disabled`
- Linux Docker: `go test -race -run "^TestCounterAndClientUnsubscribeLifecycle$" .`

## Commits included

- 📜docs(workflow): clarify personal plan language