### PR TITLE
🧬feat(types): add timestamp and element identity primitives

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Each datatype is composed of five layers stacked vertically. A user operation pa
 | Document | Description |
 |----------|-------------|
 | [Architecture](architecture.md) | Layer stack, shared state model, operation flow, and concurrency model |
+| [Core Types](core-types.md) | UID roles, CRDT timestamps and element IDs, operation progress, and transaction sequence coordinates |
 | [Client and DatatypeBuilder](client-and-datatype-builder.md) | `Client` builder pattern, collection/key naming validation, and the `DatatypeBuilder` chain |
 | [Datatype State](datatype-state.md) | `DatatypeState` lifecycle, write access, sync intent states, and unsubscribe cleanup |
 | [Transaction and Rollback](transaction-and-rollback.md) | `TxRecord` structure, transaction lifecycle, and inverse-operation rollback |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,7 @@ flowchart TD
 > For datatype lifecycle states and write-access rules see [`docs/datatype-state.md`](datatype-state.md).
 > For event loop internals (channel architecture, BackOff, Notify flow) see [`docs/event-loop.md`](event-loop.md).
 > For error taxonomy and `RecoveryAction` routing see [`docs/error-handling.md`](error-handling.md).
+> For UID roles, CRDT ordering keys, and client/server transaction sequence types see [`docs/core-types.md`](core-types.md).
 
 ### Layer Responsibilities
 
@@ -100,7 +101,10 @@ flowchart TD
 
 | Type | Location | Purpose |
 |------|----------|---------|
-| `OperationId` | `src/types/operation_id.rs` | `(lamport, cuid, cseq)` — identifies an operation's position |
+| `Uid` / `Cuid` / `Duid` | `src/types/uid.rs` | Immutable identities for clients and logical datatypes; see [`docs/core-types.md`](core-types.md) |
+| `Timestamp` / `ElementId` | `src/types/timestamp.rs`, `src/types/element_id.rs` | CRDT precedence and exact element identity; see [`docs/core-types.md`](core-types.md) |
+| `OperationId` | `src/types/operation_id.rs` | Mutable local Lamport/cseq progress; see [`docs/core-types.md`](core-types.md) |
+| `CheckPoint` | `src/types/checkpoint.rs` | Carries server-side and client-side transaction sequences; see [`docs/core-types.md`](core-types.md) |
 | `Operation` | `src/operations/mod.rs` | Single CRDT operation with `OperationBody` and `lamport` |
 | `Transaction` | `src/operations/transaction.rs` | Ordered group of operations sharing `cuid`/`cseq` |
 | `TxRecord` | `src/datatypes/tx_record.rs` | Pending transaction buffer + rollback save point |

--- a/docs/core-types.md
+++ b/docs/core-types.md
@@ -1,0 +1,225 @@
+# Core Types
+
+Qortoo separates identity, logical order, element identity, local progress, and
+transaction sequencing into distinct concepts. Each type answers one question and
+therefore carries one comparison meaning.
+
+## Overview
+
+The core types describe two dimensions of a replicated datatype: what a change belongs
+to, and how that change progresses through the distributed system.
+
+```mermaid
+flowchart LR
+    UID["Uid<br/>stable opaque identity"]
+    CUID["Cuid<br/>Client Unique ID"]
+    DUID["Duid<br/>Datatype Unique ID"]
+    RA["Datatype replica<br/>on client A"]
+    RB["Datatype replica<br/>on client B"]
+    OID["OperationId<br/>local logical progress"]
+    TS["Timestamp<br/>which change wins?"]
+    EID["ElementId<br/>which exact element?"]
+    CP["CheckPoint<br/>sseq + cseq"]
+
+    UID --> CUID
+    UID --> DUID
+    DUID -->|same identity| RA
+    DUID -->|same identity| RB
+    CUID --> OID
+    OID -->|logical time| TS
+    TS --> EID
+    OID -->|client progress| CP
+```
+
+These concepts answer different questions:
+
+| Question | Concept |
+|----------|---------|
+| Which client produced a change? | `Cuid` |
+| Which logical datatype do its replicas represent? | `Duid` |
+| Which concurrent change has precedence? | `Timestamp` |
+| Which exact element does an operation reference? | `ElementId` |
+| What logical time and local transaction comes next? | `OperationId` |
+| Which server-side and client-side transaction sequences are being carried? | `CheckPoint` |
+
+## Core Types
+
+### Identity: Uid, Cuid, and Duid
+
+`Uid` is Qortoo's common representation of stable identity. The identifier is opaque:
+its value distinguishes one client or datatype from another, but does not encode
+business meaning.
+
+Two semantic roles are built on that representation:
+
+- `Cuid` means **Client Unique ID**. It identifies a client and remains stable while
+  that client produces local operations and transactions.
+- `Duid` means **Datatype Unique ID**. It identifies one logical datatype, independent
+  of where that datatype is replicated.
+
+A datatype can have replicas on multiple clients. Every replica of the same datatype
+has the same DUID; replicas do not receive separate DUIDs. The DUID is therefore the
+shared identity that says those replicas represent the same logical datatype.
+
+The nil UID represents an identity that has not been assigned. It is a sentinel, not a
+generated client or datatype identity.
+
+`Cuid` and `Duid` share the same representation but have different conceptual roles.
+Code that moves an identifier across a boundary must preserve that role explicitly.
+
+### Precedence: Timestamp
+
+A `Timestamp` is the deterministic precedence key for a change:
+
+```text
+Timestamp = (Lamport time, client identity)
+```
+
+Lamport time establishes logical order. A higher Lamport value has precedence over a
+lower value. Two clients can independently produce the same Lamport value, so CUID
+provides a deterministic tie-breaker.
+
+```text
+compare Lamport time
+    └── if equal, compare CUID
+```
+
+This creates one stable ordering on every replica of the datatype. It does not claim
+that the winning change occurred later in wall-clock time; it only guarantees that all
+replicas of the datatype resolve the same competing changes in the same way.
+
+Equality, ordering, and hashing all describe this same `(Lamport, CUID)` identity.
+That consistency allows a CRDT rule to read naturally as “the greater timestamp wins.”
+
+### Exact element identity: ElementId
+
+One logical operation can create more than one element. Those elements share a
+timestamp, so timestamp equality alone cannot identify a particular element.
+
+`ElementId` adds a delimiter within the operation:
+
+```text
+ElementId = (Timestamp, delimiter)
+```
+
+The two parts have separate meanings:
+
+- `Timestamp` identifies the producing change and its precedence.
+- `delimiter` identifies one element produced by that change.
+
+Different delimiters therefore produce different element identities even when their
+timestamps are equal. Conflict resolution compares timestamps; exact lookup and
+reference compare element IDs. Keeping these concepts separate prevents element
+identity from silently changing a conflict rule.
+
+### Local logical progress: OperationId
+
+`OperationId` is the evolving local position of a client's replica of a datatype:
+
+```text
+OperationId = (Lamport time, client identity, client transaction sequence)
+```
+
+It combines two forms of progress:
+
+- Lamport time advances for successful local operations and absorbs logical time seen
+  from remote operations.
+- client sequence (`cseq`) advances for new local transactions.
+
+These counters serve different purposes. Lamport time orders changes, while `cseq`
+groups and tracks transactions produced by one client. A transaction containing
+multiple operations therefore consumes one client sequence but multiple Lamport
+positions.
+
+The operation ID is mutable clock state. A `Timestamp` is an immutable value taken from
+that logical-time domain and retained in CRDT state. Failed or rolled-back work must
+not permanently advance the local position.
+
+### Transaction sequences: CheckPoint
+
+A `CheckPoint` carries two transaction sequence values used during push-pull:
+
+```text
+CheckPoint = (server sequence, client sequence)
+```
+
+- server sequence (`sseq`) represents the order of transactions received by the server.
+- client sequence (`cseq`) represents the transaction sequence from the perspective of
+  one client.
+
+Their role at a particular point in push-pull is determined by that protocol context.
+This overview defines only the two sequence domains.
+
+### Code map
+
+The concept definitions are kept together under `src/types/`:
+
+| Concept | Definition |
+|---------|------------|
+| `Uid`, `Cuid`, `Duid` | `src/types/uid.rs` |
+| `Timestamp` | `src/types/timestamp.rs` |
+| `ElementId` | `src/types/element_id.rs` |
+| `OperationId` | `src/types/operation_id.rs` |
+| `CheckPoint` | `src/types/checkpoint.rs` |
+
+## How It Works
+
+The concepts participate in a change from creation to synchronization as follows:
+
+1. A client has a stable `Cuid`. A datatype has a stable `Duid`, and every replica of
+   that datatype carries the same DUID.
+2. A successful local operation receives the next Lamport time. The first operation in
+   a local transaction also advances that client's transaction sequence.
+3. A non-commutative CRDT records a `Timestamp` so every replica of the datatype can
+   select the same winner when changes compete.
+4. If one operation creates multiple addressable elements, each receives an
+   `ElementId` with the same timestamp and a distinct delimiter.
+5. A transaction carries its client-side `cseq`, and the server places received
+   transactions in its server-side `sseq` order. Push-pull exchanges carry both values
+   in a `CheckPoint`.
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant D as Local datatype replica
+    participant S as Synchronization service
+
+    C->>C: Advance OperationId
+    C->>D: Apply change with Timestamp
+    opt Multiple elements
+        C->>D: Distinguish each ElementId
+    end
+    C->>S: Send transaction with CUID/cseq
+    S->>S: Assign sseq
+    S-->>C: Return CheckPoint(sseq, cseq)
+```
+
+The separation remains important throughout the flow: identity selects the client or
+logical datatype, logical time resolves competition, element identity selects an exact
+node, and sequence numbers locate transactions in client-side and server-side orders.
+
+## Key Design Decisions
+
+- **One type carries one comparison meaning.** `Timestamp` represents precedence;
+  `ElementId` represents exact identity. A delimiter never changes which operation
+  wins a conflict.
+- **Logical time is not wall-clock time.** Lamport time provides deterministic causal
+  progress without depending on synchronized physical clocks.
+- **Client identity completes the order.** CUID tie-breaking turns equal Lamport values
+  into a stable order shared by every replica of the datatype.
+- **Clock state and retained values are distinct.** `OperationId` evolves as work is
+  produced, while timestamps and element IDs remain immutable inside CRDT state.
+- **Transaction ordering has two reference points.** `cseq` follows one client's
+  transaction sequence; `sseq` follows the order of transactions received by the
+  server. `CheckPoint` carries both sequence values through push-pull.
+
+## Related Concepts
+
+- [Architecture](architecture.md) — where identity and progress live in the datatype
+  layer stack
+- [Transaction and Rollback](transaction-and-rollback.md) — how local logical progress
+  participates in atomic transactions
+- [Connectivity](connectivity.md) — how client and server transaction progress is
+  exchanged
+- [Event Loop](event-loop.md) — how server progress notifications trigger
+  synchronization

--- a/src/types/element_id.rs
+++ b/src/types/element_id.rs
@@ -1,0 +1,101 @@
+use std::fmt::{Debug, Display, Formatter};
+
+use crate::types::timestamp::Timestamp;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub(crate) struct ElementId {
+    timestamp: Timestamp,
+    delimiter: u32,
+}
+
+impl ElementId {
+    pub(crate) fn new(timestamp: &Timestamp, delimiter: u32) -> Self {
+        Self {
+            timestamp: timestamp.clone(),
+            delimiter,
+        }
+    }
+
+    pub(crate) fn timestamp(&self) -> &Timestamp {
+        &self.timestamp
+    }
+
+    pub(crate) fn delimiter(&self) -> u32 {
+        self.delimiter
+    }
+}
+
+impl Debug for ElementId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for ElementId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[{}:{}:{}]",
+            self.timestamp.lamport(),
+            self.timestamp.cuid(),
+            self.delimiter
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests_element_id {
+    use std::collections::HashSet;
+
+    use super::*;
+    use crate::types::uid::Cuid;
+
+    fn new_timestamp(lamport: u64, cuid: &str) -> Timestamp {
+        Timestamp::new(lamport, &Cuid::try_from(cuid).unwrap())
+    }
+
+    #[test]
+    fn can_create_an_element_id() {
+        let timestamp = new_timestamp(1, "0000000000000001");
+        let element_id = ElementId::new(&timestamp, 2);
+
+        assert_eq!(element_id.timestamp(), &timestamp);
+        assert_eq!(element_id.delimiter(), 2);
+    }
+
+    #[test]
+    fn can_compare_exact_element_identity() {
+        let timestamp = new_timestamp(1, "0000000000000001");
+        let first = ElementId::new(&timestamp, 1);
+        let second = ElementId::new(&timestamp, 2);
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn can_hash_exact_element_identity() {
+        let timestamp = new_timestamp(1, "0000000000000001");
+        let first = ElementId::new(&timestamp, 1);
+        let second = ElementId::new(&timestamp, 2);
+        let element_ids = HashSet::from([first, second]);
+
+        assert_eq!(element_ids.len(), 2);
+    }
+
+    #[test]
+    fn can_order_element_ids_by_timestamp_then_delimiter() {
+        let earlier = new_timestamp(1, "0000000000000001");
+        let later = new_timestamp(2, "0000000000000001");
+
+        assert!(ElementId::new(&earlier, u32::MAX) < ElementId::new(&later, 0));
+        assert!(ElementId::new(&earlier, 1) < ElementId::new(&earlier, 2));
+    }
+
+    #[test]
+    fn can_display_an_element_id() {
+        let element_id = ElementId::new(&new_timestamp(1, "0000000000000001"), 2);
+
+        assert_eq!(element_id.to_string(), "[1:0000000000000001:2]");
+        assert_eq!(format!("{element_id:?}"), element_id.to_string());
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,7 +1,17 @@
 pub mod checkpoint;
 pub mod common;
 pub mod datatype;
+#[allow(
+    dead_code,
+    reason = "ElementId is consumed by upcoming ordered CRDT implementations"
+)]
+pub mod element_id;
 pub mod notification;
 pub mod operation_id;
 pub mod push_pull_pack;
+#[allow(
+    dead_code,
+    reason = "Timestamp is consumed by upcoming non-commutative CRDT implementations"
+)]
+pub mod timestamp;
 pub mod uid;

--- a/src/types/timestamp.rs
+++ b/src/types/timestamp.rs
@@ -1,0 +1,113 @@
+use std::fmt::{Debug, Display, Formatter};
+
+use crate::types::uid::Cuid;
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub(crate) struct Timestamp {
+    lamport: u64,
+    cuid: Cuid,
+}
+
+impl Timestamp {
+    pub(crate) fn new(lamport: u64, cuid: &Cuid) -> Self {
+        Self {
+            lamport,
+            cuid: cuid.clone(),
+        }
+    }
+
+    pub(crate) fn lamport(&self) -> u64 {
+        self.lamport
+    }
+
+    pub(crate) fn cuid(&self) -> &Cuid {
+        &self.cuid
+    }
+}
+
+impl Debug for Timestamp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Display for Timestamp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}:{}]", self.lamport, self.cuid)
+    }
+}
+
+#[cfg(test)]
+mod tests_timestamp {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    fn new_cuid(value: &str) -> Cuid {
+        Cuid::try_from(value).unwrap()
+    }
+
+    #[test]
+    fn can_create_a_timestamp() {
+        let cuid = new_cuid("0000000000000001");
+        let timestamp = Timestamp::new(1, &cuid);
+
+        assert_eq!(timestamp.lamport(), 1);
+        assert_eq!(timestamp.cuid(), &cuid);
+    }
+
+    #[test]
+    fn can_compare_timestamp_identity() {
+        let cuid = new_cuid("0000000000000001");
+        let timestamp = Timestamp::new(1, &cuid);
+
+        assert_eq!(timestamp, timestamp.clone());
+        assert_ne!(timestamp, Timestamp::new(2, &cuid));
+    }
+
+    #[test]
+    fn can_hash_timestamp_identity() {
+        let cuid = new_cuid("0000000000000001");
+        let timestamp = Timestamp::new(1, &cuid);
+        let timestamps = HashSet::from([timestamp.clone(), timestamp]);
+
+        assert_eq!(timestamps.len(), 1);
+    }
+
+    #[test]
+    fn can_order_timestamps_by_lamport() {
+        let cuid = new_cuid("0000000000000001");
+        let earlier = Timestamp::new(1, &cuid);
+        let later = Timestamp::new(2, &cuid);
+
+        assert!(earlier < later);
+        assert!(later > earlier);
+    }
+
+    #[test]
+    fn can_break_timestamp_ordering_ties_by_cuid() {
+        let lower = Timestamp::new(1, &new_cuid("0000000000000001"));
+        let higher = Timestamp::new(1, &new_cuid("0000000000000002"));
+
+        assert!(lower < higher);
+        assert!(higher > lower);
+    }
+
+    #[test]
+    fn can_compare_lamport_boundaries_without_overflow() {
+        let cuid = new_cuid("0000000000000001");
+        let oldest = Timestamp::new(0, &cuid);
+        let newest = Timestamp::new(u64::MAX, &cuid);
+
+        assert!(oldest < newest);
+        assert!(newest > oldest);
+    }
+
+    #[test]
+    fn can_display_a_timestamp() {
+        let timestamp = Timestamp::new(1, &new_cuid("0000000000000001"));
+
+        assert_eq!(timestamp.to_string(), "[1:0000000000000001]");
+        assert_eq!(format!("{timestamp:?}"), timestamp.to_string());
+    }
+}


### PR DESCRIPTION
- Add `Timestamp` and `ElementId` with separate precedence and exact-identity contracts.
- Document CUID as the client unique ID and DUID as the shared unique ID of all replicas of a logical datatype.
- Define sseq and cseq as server-side and client-side transaction sequence domains.

## Testing
- `cargo test --lib` — 176 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo +nightly-2026-08-02 fmt --check`